### PR TITLE
Code fails with error message if a fieldlist file repeats an existing convention

### DIFF
--- a/src/util_mdtf.py
+++ b/src/util_mdtf.py
@@ -172,6 +172,8 @@ class TempDirManager(util.Singleton):
         for d in self._dirs:
             self.rm_tempdir(d)
 
+class ConventionError(Exception):
+    pass
 
 class VariableTranslator(util.Singleton):
     def __init__(self, unittest_flag=False, verbose=0):
@@ -200,9 +202,15 @@ class VariableTranslator(util.Singleton):
             for conv in util.coerce_to_iter(d['convention_name']):
                 if verbose > 0: 
                     print('XXX found ', conv)
+                if self.variables.has_key(conv):
+                    print("ERROR: convention "+conv+" defined in "+filename+" already exists")
+                    raise ConventionError
+
                 self.axes[conv] = d.get('axes', dict())
                 self.variables[conv] = util.MultiMap(d.get('var_names', dict()))
                 self.units[conv] = util.MultiMap(d.get('units', dict()))
+
+
 
     def toCF(self, convention, varname_in):
         if convention == 'CF': 


### PR DESCRIPTION
Hi Tom, this is my first time using git to commit/push/pull request so please educate me if I'm not doing it right. 

This is a simple change to src/util_mdtf.py to quit on error if a fieldlist file has the same convention as one that was already read. (This was my stupid errror in trying to write a new convention but failing to change the name of the convetion, only the file... however I think it will be a frequently-made stupid error so it deserves an error message). 

Also I'm new to writing Exceptions so I won't be insulted if you don't think it should be done the way I've done it.