### PR TITLE
Update reference on POD settings and env vars

### DIFF
--- a/doc/sphinx/ref_envvars.rst
+++ b/doc/sphinx/ref_envvars.rst
@@ -11,7 +11,7 @@ The MDTF framework can be viewed as a "wrapper" for your code that handles data 
 - The :doc:`settings file <./dev_settings_quick>` is where your code talks to the framework: when you write your code, you document what model data your code uses (not covered on this page, follow the link for details). 
 - When your code is run, the framework talks to it by setting shell `environment variables <https://en.wikipedia.org/wiki/Environment_variable>`__ containing paths to the data files and other information specific to the run. The framework communicates **all** runtime information this way: this is in order to 1) pass information in a language-independent way, and 2) to make writing diagnostics easier (you don't need to parse command-line settings). 
 
-**Note** that environment variables are always strings. Your script will need to cast non-text data to the appropriate type (eg. the bounds of the analysis time period, ``FIRSTYR``, ``LASTYR``, will need to be converted to integers.)
+**Note** that environment variables are always strings. Your script will need to cast non-text data to the appropriate type (e.g. the bounds of the analysis time period, ``FIRSTYR``, ``LASTYR``, will need to be converted to integers.)
 
 Also note that names of environment variables are case-sensitive.
 
@@ -19,7 +19,7 @@ Paths
 -----
 
 ``OBS_DATA``: 
-  Path to the top-level directory containing any observational or reference data you've provided as the author of your diagnostic. Any data your diagnostic uses that doesn't come from the model being analyzed should go here (ie, you supply it to the framework maintainers, they host it, and the user downloads it when they install the framework). The framework will ensure this is copied to a local filesystem when your diagnostic is run, but this directory should be treated as **read-only**.
+  Path to the top-level directory containing any observational or reference data you've provided as the author of your diagnostic. Any data your diagnostic uses that doesn't come from the model being analyzed should go here (i.e., you supply it to the framework maintainers, they host it, and the user downloads it when they install the framework). The framework will ensure this is copied to a local filesystem when your diagnostic is run, but this directory should be treated as **read-only**.
 
 ``POD_HOME``: 
   Path to the top-level directory containing your diagnostic's source code. This will be of the form ``.../MDTF-diagnostics/diagnostics/<your POD's name>``. This can be used to call sub-scripts from your diagnostic's driver script. This directory should be treated as **read-only**.
@@ -62,14 +62,14 @@ These are set depending on the data your diagnostic requests in its :doc:`settin
 *For each dimension:*
   If <key> is the name of the key labeling the key:value entry for this dimension, the framework will set an environment variable named ``<key>_coord`` equal to the name that dimension has in the data files it's providing.
   
-    - If ``rename_dimensions`` is set to ``true`` in the settings file, this will always be equal to <key>. If If ``rename_dimensions`` is ``false``, this will be whatever the model or data source's native name for this dimension is, and your diagnostic should read the name from this variable. Your diagnostic should **only** use hard-coded names for dimensions if ``rename_dimensions`` is set to ``true`` in its :doc:`settings file <ref_settings>`.
+    - If ``rename_dimensions`` is set to ``true`` in the settings file, this will always be equal to <key>. If ``rename_dimensions`` is ``false``, this will be whatever the model or data source's native name for this dimension is, and your diagnostic should read the name from this variable. Your diagnostic should **only** use hard-coded names for dimensions if ``rename_dimensions`` is set to ``true`` in its :doc:`settings file <ref_settings>`.
 
-  If the data source has provided (one-dimensional) bounds for this dimension, the name of the netCDF variable containing those bounds will be set in an environment variable named ``<key>_bnds``. If bounds are not provided, this will be set to the empty string. **Note** that multidimensional boundaries (eg for horizontal cells) should be listed as separate entries in the varlist section.
+  If the data source has provided (one-dimensional) bounds for this dimension, the name of the netCDF variable containing those bounds will be set in an environment variable named ``<key>_bnds``. If bounds are not provided, this will be set to the empty string. **Note** that multidimensional boundaries (e.g. for horizontal cells) should be listed as separate entries in the varlist section.
 
 *For each variable:*
   If <key> be the name of the key labeling the key:value entry for this variable in the varlist section, the framework will set an environment variable named ``<key>_var`` equal to the name that variable has in the data files it's providing.
   
-    - If ``rename_variables`` is set to ``true`` in the settings file, this will always be equal to <key>. If If ``rename_variables`` is ``false``, this will be whatever the model or data source's native name for this variable is, and your diagnostic should read the name from this variable. Your diagnostic should **only** use hard-coded names for dimensions if ``rename_variables`` is set to ``true`` in its :doc:`settings file <ref_settings>`.
+    - If ``rename_variables`` is set to ``true`` in the settings file, this will always be equal to <key>. If ``rename_variables`` is ``false``, this will be whatever the model or data source's native name for this variable is, and your diagnostic should read the name from this variable. Your diagnostic should **only** use hard-coded names for variables if ``rename_variables`` is set to ``true`` in its :doc:`settings file <ref_settings>`.
 
 
 Simple example
@@ -113,7 +113,7 @@ The framework will set the following environment variables:
 #. ``lon_dim``: Name of the longitude dimension in the model's native format (because ``rename_dimensions`` is false).
 #. ``time_dim``: Name of the time dimension in the model's native format (because ``rename_dimensions`` is false).
 #. ``pr_var``: Name of the precipitation variable in the model's native format (because ``rename_variables`` is false).
-#. ``PR_FILE``: Absolute path to the file containing ``pr`` data, eg. ``/dir/precip.nc``.
+#. ``PR_FILE``: Absolute path to the file containing ``pr`` data, e.g. ``/dir/precip.nc``.
 
 
 More complex example

--- a/doc/sphinx/ref_envvars.rst
+++ b/doc/sphinx/ref_envvars.rst
@@ -109,9 +109,9 @@ We only give the relevant parts of the :doc:`settings file <ref_settings>` below
 
 The framework will set the following environment variables:
 
-#. ``lat_dim``: Name of the latitude dimension in the model's native format (because ``rename_dimensions`` is false).
-#. ``lon_dim``: Name of the longitude dimension in the model's native format (because ``rename_dimensions`` is false).
-#. ``time_dim``: Name of the time dimension in the model's native format (because ``rename_dimensions`` is false).
+#. ``lat_coord``: Name of the latitude dimension in the model's native format (because ``rename_dimensions`` is false).
+#. ``lon_coord``: Name of the longitude dimension in the model's native format (because ``rename_dimensions`` is false).
+#. ``time_coord``: Name of the time dimension in the model's native format (because ``rename_dimensions`` is false).
 #. ``pr_var``: Name of the precipitation variable in the model's native format (because ``rename_variables`` is false).
 #. ``PR_FILE``: Absolute path to the file containing ``pr`` data, e.g. ``/dir/precip.nc``.
 

--- a/doc/sphinx/ref_envvars.rst
+++ b/doc/sphinx/ref_envvars.rst
@@ -59,15 +59,17 @@ Names of variables and dimensions
 
 These are set depending on the data your diagnostic requests in its :doc:`settings file <./dev_settings_quick>`. Refer to the examples below if you're unfamiliar with how that file is organized.
 
-For each dimension:
-  If <key> is the name of the key labeling the key:value entry for this dimension, the framework will set an environment variable named ``<key>_dim`` equal to the name that dimension has in the data files it's providing.
+*For each dimension:*
+  If <key> is the name of the key labeling the key:value entry for this dimension, the framework will set an environment variable named ``<key>_coord`` equal to the name that dimension has in the data files it's providing.
   
     - If ``rename_dimensions`` is set to ``true`` in the settings file, this will always be equal to <key>. If If ``rename_dimensions`` is ``false``, this will be whatever the model or data source's native name for this dimension is, and your diagnostic should read the name from this variable. Your diagnostic should **only** use hard-coded names for dimensions if ``rename_dimensions`` is set to ``true`` in its :doc:`settings file <ref_settings>`.
 
-For each variable:
+  If the data source has provided (one-dimensional) bounds for this dimension, the name of the netCDF variable containing those bounds will be set in an environment variable named ``<key>_bnds``. If bounds are not provided, this will be set to the empty string. **Note** that multidimensional boundaries (eg for horizontal cells) should be listed as separate entries in the varlist section.
+
+*For each variable:*
   If <key> be the name of the key labeling the key:value entry for this variable in the varlist section, the framework will set an environment variable named ``<key>_var`` equal to the name that variable has in the data files it's providing.
   
-    - If ``rename_variables`` is set to ``true`` in the settings file, this will always be equal to <key>. If If ``rename_variables`` is ``false``, this will be whatever the model or data source's native name for this variable is, and your diagnostic should read the name from this variable. Your diagnostic should **only** use hard-coded names for dimensions if ``rename_dimensions`` is set to ``true`` in its :doc:`settings file <ref_settings>`.
+    - If ``rename_variables`` is set to ``true`` in the settings file, this will always be equal to <key>. If If ``rename_variables`` is ``false``, this will be whatever the model or data source's native name for this variable is, and your diagnostic should read the name from this variable. Your diagnostic should **only** use hard-coded names for dimensions if ``rename_variables`` is set to ``true`` in its :doc:`settings file <ref_settings>`.
 
 
 Simple example
@@ -156,7 +158,7 @@ Let's elaborate on the previous example, and assume that the diagnostic is being
 
 Comparing this with the previous example:
 
-- ``lat_dim``, ``lon_dim`` and ``time_dim`` will be set to "lat", "lon" and "time", respectively, because ``rename_dimensions`` is true. The framework will have renamed these dimensions to have these names in all data files provided to the diagnostic.
+- ``lat_coord``, ``lon_coord`` and ``time_coord`` will be set to "lat", "lon" and "time", respectively, because ``rename_dimensions`` is true. The framework will have renamed these dimensions to have these names in all data files provided to the diagnostic.
 - ``prc_var`` and ``pr_var`` will be set to the model's native names for these variables. Names for all variables are always set, regardless of which variables are available from the data source.
 - In this example, ``PRC_FILE`` will be set to ``''``, the empty string, because it wasn't found. 
 - ``PR_FILE`` will be set to ``/dir/precip_1980_1989.nc:/dir/precip_1990_1999.nc:/dir/precip_2000_2009.nc``, because ``multi_file_ok`` was set to ``true``.

--- a/doc/sphinx/ref_settings.rst
+++ b/doc/sphinx/ref_settings.rst
@@ -18,7 +18,7 @@ In addition, for the purposes of the configuration file we define
 
 .. _time_duration:
 
-4. a "time duration": this is a string specifying a time span, used eg. to describe how frequently data is sampled. It consists of an optional integer (if omitted, the integer is assumed to be 1) and a units string which is one of ``hr``, ``day``, ``mon``, ``yr`` or ``fx``. ``fx`` is used where appropriate to denote time-independent data. Common synonyms for these units are also recognized (eg ``monthly``, ``month``, ``months``, ``mo`` for ``mon``, ``static`` for ``fx``, etc.)
+4. a "time duration": this is a string specifying a time span, used e.g. to describe how frequently data is sampled. It consists of an optional integer (if omitted, the integer is assumed to be 1) and a units string which is one of ``hr``, ``day``, ``mon``, ``yr`` or ``fx``. ``fx`` is used where appropriate to denote time-independent data. Common synonyms for these units are also recognized (e.g. ``monthly``, ``month``, ``months``, ``mo`` for ``mon``, ``static`` for ``fx``, etc.)
 
    **In addition**, the string ``"any"`` may be used to signify that any value is acceptable.
 
@@ -30,11 +30,11 @@ Items are combined in compound expressions of two types:
 
 .. _array:
 
-6. *arrays*, which are one-dimensional ordered lists delimited with square brackets. Entries can be of any type, eg ``[true, 1, "two"]``.
+6. *arrays*, which are one-dimensional ordered lists delimited with square brackets. Entries can be of any type, e.g. ``[true, 1, "two"]``.
 
 .. _object:
 
-7. *objects*, which are *un*-ordered lists of key:value pairs separated by colons and delimited with curly brackets. Keys must be strings and must all be unique within the object, while values may be any expression, eg. ``{"red": 0, "green": false, "blue": "bagels"}``.
+7. *objects*, which are *un*-ordered lists of key:value pairs separated by colons and delimited with curly brackets. Keys must be strings and must all be unique within the object, while values may be any expression, e.g. ``{"red": 0, "green": false, "blue": "bagels"}``.
 
 Compound expressions may be nested within each other to an arbitrary depth.
 
@@ -116,7 +116,7 @@ Diagnostic description
   String, **required**. Filename of the top-level driver script the framework should call to run your diagnostic's analysis.
 
 ``realm``: 
-  String or :ref:`array<array>` (list) of strings, **required**. One of the eight CMIP6 modeling realms (aerosol, atmos, atmosChem, land, landIce, ocean, ocnBgchem, seaIce) describing what data your diagnostic uses. If your diagnostic uses data from multiple realms, list them in an array (eg. ``["atmos", "ocean"]``). This information doesn't affect how the framework fetches model data for your diagnostic: it's provided to give the user a shortcut to say, eg., "run all the atmos diagnostics on this output."
+  String or :ref:`array<array>` (list) of strings, **required**. One of the eight CMIP6 modeling realms (aerosol, atmos, atmosChem, land, landIce, ocean, ocnBgchem, seaIce) describing what data your diagnostic uses. If your diagnostic uses data from multiple realms, list them in an array (e.g. ``["atmos", "ocean"]``). This information doesn't affect how the framework fetches model data for your diagnostic: it's provided to give the user a shortcut to say, e.g., "run all the atmos diagnostics on this output."
 
 Diagnostic runtime
 ^^^^^^^^^^^^^^^^^^
@@ -124,7 +124,7 @@ Diagnostic runtime
 ``runtime_requirements``: 
   :ref:`object<object>`, **required**. Programs your diagnostic needs to run (for example, scripting language interpreters) and any third-party libraries needed in those languages. Each executable should be listed in a separate key-value pair:
 
-  - The *key* is the name of the required executable, eg. languages such as "`python <https://www.python.org/>`__" or "`ncl <https://www.ncl.ucar.edu/>`__" etc. but also any utilities such as "`ncks <http://nco.sourceforge.net/>`__", "`cdo <https://code.mpimet.mpg.de/projects/cdo>`__", etc.
+  - The *key* is the name of the required executable, e.g. languages such as "`python <https://www.python.org/>`__" or "`ncl <https://www.ncl.ucar.edu/>`__" etc. but also any utilities such as "`ncks <http://nco.sourceforge.net/>`__", "`cdo <https://code.mpimet.mpg.de/projects/cdo>`__", etc.
   - The *value* corresponding to each key is an :ref:`array<array>` (list) of strings, which are names of third-party libraries in that language that your diagnostic needs. You do *not* need to list standard libraries or scripts that are provided in a standard installation of your language: eg, in python, you need to list `numpy <https://numpy.org/>`__ but not `math <https://docs.python.org/3/library/math.html>`__. If no third-party libraries are needed, the value should be an empty list.
 
   In the future we plan to offer the capability to request specific `versions <https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/pkg-specs.html#package-match-specifications>`__. For now, please communicate your diagnostic's version requirements to the MDTF organizers.
@@ -191,22 +191,22 @@ Example
 .. _multi_file:
 
 ``multi_file_ok``: 
-  Boolean. Optional: assumed ``false`` if not specified. If set to ``true``, the diagnostic is signalling that it's able to accept data for a single variable that may be spread out in multiple files, to be aggregated along the time dimension (eg through the use of `xarray <http://xarray.pydata.org/en/stable/generated/xarray.open_mfdataset.html>`__.) Aggregation along the time dimension is the only type of aggregation the diagnostic will need to consider. 
+  Boolean. Optional: assumed ``false`` if not specified. If set to ``true``, the diagnostic is signalling that it's able to accept data for a single variable that may be spread out in multiple files, to be aggregated along the time dimension (e.g. through the use of `xarray <http://xarray.pydata.org/en/stable/generated/xarray.open_mfdataset.html>`__.) Aggregation along the time dimension is the only type of aggregation the diagnostic will need to consider. 
 
-  If ``false``, the framework will ensure all data for a single variable is presented as a single netCDF file. This may lead to large filesizes if your diagnostic uses high-frequency data, in which case you should consider setting a limit via ``max_duration``.
+  If ``false``, the framework will ensure all data for a single variable is presented as a single netCDF file. This may lead to large file sizes if your diagnostic uses high-frequency data, in which case you should consider setting a limit via ``max_duration``.
 
 ``min_duration``, ``max_duration``: 
   :ref:`Time durations<time_duration>`. Optional: assumed ``"any"`` if not specified. Set minimum and maximum length of the analysis period for which the diagnostic should be run: this overrides any choices the user makes at runtime. Some example uses of this setting are:
   
-  - If your diagnostic uses low-frequency (eg seasonal) data, you may want to set ``min_duration`` to ensure the sample size will be large enough for your results to be statistically meaningful. 
-  - On the other hand, if your diagnostic uses high-frequency (eg hourly) data, you may want to set ``max_duration`` to prevent the framework from attempting to download a large volume of data for your diagnostic if the framework is called with a multi-decadal analysis period.
+  - If your diagnostic uses low-frequency (e.g. seasonal) data, you may want to set ``min_duration`` to ensure the sample size will be large enough for your results to be statistically meaningful. 
+  - On the other hand, if your diagnostic uses high-frequency (e.g. hourly) data, you may want to set ``max_duration`` to prevent the framework from attempting to download a large volume of data for your diagnostic if the framework is called with a multi-decadal analysis period.
 
 The following properties can optionally be set individually for each variable in the varlist :ref:`section<sec_varlist>`. If so, they will override the global settings given here.
 
 .. _dims_ordered:
 
 ``dimensions_ordered``: 
-  Boolean. Optional: assumed ``false`` if not specified. If set to ``true``, the framework will ensure that the dimensions of each variable's array are given in the same order as listed in ``dimensions``. **If set to false, your diagnostic is responsible for handling arbitrary dimension orders**: eg. it should *not* assume that 3D data will be presented as (time, lat, lon).
+  Boolean. Optional: assumed ``false`` if not specified. If set to ``true``, the framework will ensure that the dimensions of each variable's array are given in the same order as listed in ``dimensions``. **If set to false, your diagnostic is responsible for handling arbitrary dimension orders**: e.g. it should *not* assume that 3D data will be presented as (time, lat, lon).
 
 .. _freq_target:
 
@@ -287,7 +287,7 @@ Time
   **Required**. Must be ``"time"``.
 
 ``units``: 
-  String. Optional, defaults to "day". Units the diagnostic expects the dimension to be in. Currently the diagnostic only supports time axes of the form "<units> since <reference data>", and the value given here is interpreted in this sense (eg. settings this to "day" would accommodate a dimension of the form "[decimal] days since 1850-01-01".)
+  String. Optional, defaults to "day". Units the diagnostic expects the dimension to be in. Currently the diagnostic only supports time axes of the form "<units> since <reference data>", and the value given here is interpreted in this sense (e.g. settings this to "day" would accommodate a dimension of the form "[decimal] days since 1850-01-01".)
 
 ``calendar``: 
   String, Optional. One of the CF convention `calendars <http://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#calendar>`__ or the string ``"any"``. **Defaults to "any" if not given**. Calendar convention used by your diagnostic. Only affects the number of days per month.
@@ -337,7 +337,7 @@ This section is an :ref:`object<object>` contains properties that apply to the m
 
 **Note** that this includes "auxiliary coordinates" in the CF conventions terminology and similar ancillary information. If your diagnostic needs, eg, cell areas or volumes, orography data, etc., each piece of data should be listed as a separate entry here, *even if* their use is conventionally implied by the use of other variables.
 
-Each entry corresponds to a distinct data file (or set of files, if ``multi_file_ok`` is ``true``) downloaded by the framework. If your framework needs the same physical quantity sampled with different properties (eg. slices of a variable at multiple pressure levels), specify them as multiple entries.
+Each entry corresponds to a distinct data file (or set of files, if ``multi_file_ok`` is ``true``) downloaded by the framework. If your framework needs the same physical quantity sampled with different properties (e.g. slices of a variable at multiple pressure levels), specify them as multiple entries.
 
 Varlist entry example
 ^^^^^^^^^^^^^^^^^^^^^
@@ -362,7 +362,7 @@ Varlist entry properties
 The *key* in a varlist key-value pair is the name your diagnostic uses to refer to this variable (and must be unique). The value of the key-value pair is an :ref:`object<object>` containing properties specific to that variable:
 
 ``standard_name``: 
-  String, **required**. `Standard name <http://cfconventions.org/Data/cf-standard-names/72/build/cf-standard-name-table.html>`__ of the variable as defined by the `CF conventions <http://cfconventions.org/>`__, or a commonly used synonym as employed in the CMIP6 MIP tables (eg. "ua" instead of "eastward_wind"). 
+  String, **required**. `Standard name <http://cfconventions.org/Data/cf-standard-names/72/build/cf-standard-name-table.html>`__ of the variable as defined by the `CF conventions <http://cfconventions.org/>`__, or a commonly used synonym as employed in the CMIP6 MIP tables (e.g. "ua" instead of "eastward_wind"). 
 
 ``path_variable``: 
   String, **optional** but recommended. Name of the shell environment variable the framework will set with the location of this data. **This is the only currently supported method for communicating the location of model data to your diagnostic.** If omitted, set to ``<key>_FILE``, where ``<key>`` is the key to the varlist entry (case-sensitive). See the environment variable :doc:`documentation <ref_envvars>` for details. 
@@ -383,7 +383,7 @@ The *key* in a varlist key-value pair is the name your diagnostic uses to refer 
   **Required**. List of strings, which must be selected the keys of entries in the :ref:`dimensions<sec_dimensions>` section. Dimensions of the array containing the variable's data. **Note** that the framework will not reorder dimensions (transpose) unless ``dimensions_ordered`` is additionally set to ``true``.
 
 ``dimensions_ordered``: 
-  Boolean. Optional: assumed ``false`` if not specified. If ``true``, the framework will ensure that the dimensions of this variable's array are given in the same order as listed in ``dimensions``. **If set to false, your diagnostic is responsible for handling arbitrary dimension orders**: eg. it should *not* assume that 3D data will be presented as (time, lat, lon). If given here, overrides the values set globally in the ``data`` section (see :ref:`description<dims_ordered>` there).
+  Boolean. Optional: assumed ``false`` if not specified. If ``true``, the framework will ensure that the dimensions of this variable's array are given in the same order as listed in ``dimensions``. **If set to false, your diagnostic is responsible for handling arbitrary dimension orders**: e.g. it should *not* assume that 3D data will be presented as (time, lat, lon). If given here, overrides the values set globally in the ``data`` section (see :ref:`description<dims_ordered>` there).
 
 .. _item_var_coords:
 
@@ -393,7 +393,7 @@ The *key* in a varlist key-value pair is the name your diagnostic uses to refer 
   - *keys* are the key (name) of an entry in the :ref:`dimensions<sec_dimensions>` section.
   - *values* are a single number (integer or floating-point) corresponding to the value of the slice to extract. **Units** of this number are taken to be the ``units`` property of the dimension named as the key.
 
-  In order to request multiple slices (eg. wind velocity on multiple pressure levels, with each level saved to a different file), create one varlist entry per slice.
+  In order to request multiple slices (e.g. wind velocity on multiple pressure levels, with each level saved to a different file), create one varlist entry per slice.
 
 ``frequency``, ``min_frequency``, ``max_frequency``: 
   :ref:`Time durations<time_duration>`. Optional. Time frequency at which the variable's data is provided. If given here, overrides the values set globally in the ``data`` section (see :ref:`description<freq_target>` there).


### PR DESCRIPTION
Refine documentation on the POD's settings file and environment variables, in advance of the telecon. All changes except the first are fully backward-compatible.

- Correct suffix for dimension coordinate env var names from "_dim" to "_coord" [the latter is what the code currently uses; the docs were in error.]
- Add "<dim name>_bnds" env vars for names of coordinate bounds variables.
- Add optional "axis" attribute to dimensions section.
- Emphasize role of varlist path_variable environment variable for finding model data and define a default name for it.
- Wording changes and longer explanations.