### PR TITLE
Commit docs files needed to fix RTD build

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -24,16 +24,27 @@ sys.path.insert(0, os.path.abspath(os.path.join(cwd, '..', 'src')))
 import recommonmark
 from recommonmark.transform import AutoStructify
 
-# mock out imports of non-standard library modules here if needed in future
-autodoc_mock_imports = []
+# mock out imports of non-standard library modules
+autodoc_mock_imports = [
+    'numpy', 'xarray', 'cftime', 'cfunits', 'cf_xarray', 
+    'pandas', 'intake', 'intake_esm'
+]
+# need to manually mock out explicit patching of cf_xarray.accessor done 
+# on import in xr_parser
 import unittest.mock as mock
-for module_name in autodoc_mock_imports:
-    sys.modules[module_name] = mock.Mock()
+mock_accessor = mock.Mock()
+mock_attrs = {
+    '__name__': 'accessor', '__doc__': '', # for functools.wraps
+    'CFDatasetAccessor': object, 'CFDataArrayAccessor': object
+}
+mock_accessor.configure_mock(**mock_attrs)
+sys.modules['cf_xarray'] = mock.Mock()
+setattr(sys.modules['cf_xarray'], 'accessor', mock_accessor)
 
 # -- Project information -----------------------------------------------------
 
 project = u'MDTF Diagnostics'
-copyright = u'2020, Model Diagnostics Task Force'
+copyright = u'2021, Model Diagnostics Task Force'
 author = u'Model Diagnostics Task Force'
 
 # The short X.Y version
@@ -92,7 +103,9 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = [u'_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = [u'_build', 'Thumbs.db',
+    '**/test_*'
+]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'default'
@@ -102,18 +115,18 @@ pygments_style = 'default'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#
 html_theme = 'alabaster'
 
-# Theme options are theme-specific and customize the look and feel of a theme
-# further.  For a list of options available for each theme, see the
-# documentation.
-#
+# Theme options are theme-specific.
+# See https://alabaster.readthedocs.io/en/latest/customization.html
 html_theme_options = {
+    'page_width': '1024px',
+    'sidebar_collapse': True,
+    'fixed_sidebar': True,
     'extra_nav_links' : {
-        "Getting Started (PDF)": "https://mdtf-diagnostics.readthedocs.io/en/latest/_static/MDTF_getting_started.pdf",
-        "Developer's Walkthough (PDF)": "https://mdtf-diagnostics.readthedocs.io/en/latest/_static/MDTF_walkthrough.pdf",
-        "Full documentation (PDF)": "https://mdtf-diagnostics.readthedocs.io/_/downloads/en/latest/pdf/"
+        "Getting Started [PDF]": "https://mdtf-diagnostics.readthedocs.io/en/latest/_static/MDTF_getting_started.pdf",
+        "Developer's Walkthough [PDF]": "https://mdtf-diagnostics.readthedocs.io/en/latest/_static/MDTF_walkthrough.pdf",
+        "Full documentation [PDF]": "https://mdtf-diagnostics.readthedocs.io/_/downloads/en/latest/pdf/"
     }
 }
 
@@ -125,7 +138,7 @@ html_static_path = ['_static']
 
 # # Paths (filenames) here must be relative to (under) html_static_path as above:
 # html_css_files = [
-#     'custom.css',
+#     '_static/custom.css',
 # ]
 
 # Custom sidebar templates, must be a dictionary that maps document names
@@ -160,19 +173,20 @@ latex_elements = {
     'pointsize': '11pt',
     # fonts
     'fontpkg': r'''
-        \usepackage{fontspec}
+        \RequirePackage{fontspec}
         % RTD uses a texlive installation on linux; apparently xelatex can only
         % find fonts by filename in this situation.
         \setmainfont{texgyretermes-regular.otf}
         \setsansfont{Heuristica-Bold.otf}
     ''',
+    'geometry': r"\usepackage[xetex,letterpaper]{geometry}",
     # chapter style
-    'fncychap': '\\usepackage[Bjarne]{fncychap}',
+    'fncychap': r"\usepackage[Bjarne]{fncychap}",
     # Latex figure (float) alignment
     'figure_align': 'H',
     # Additional stuff for the LaTeX preamble.
     'preamble': r"""
-        \usepackage{unicode-math}
+        \RequirePackage{unicode-math}
         \makeatletter
         \fancypagestyle{normal}{
             \fancyhf{}
@@ -189,6 +203,7 @@ latex_elements = {
             \fancyfoot[LE,RO]{{\py@HeaderFamily\thepage}}
             \renewcommand{\footrulewidth}{0pt}
         }
+        \setlength{\headheight}{13.61pt} % otherwise get errors from fancyhdr
         \makeatother
     """,
     'extraclassoptions': 'openany'
@@ -228,13 +243,8 @@ latex_documents = [
 ]
 
 latex_additional_files = [
-    'latex/sphinxmdtfhowto.cls',
     'latex/latexmkrc'
 ]
-
-# latex_docclass = {
-#     'mdtfhowto': 'mdtfhowto'
-# }
 
 latex_logo = 'img/CPO_MAPP_MDTF_Logo.jpg'
 
@@ -298,12 +308,17 @@ epub_exclude_files = ['search.html']
 # set options, see http://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
 autodoc_member_order = 'bysource'
 autodoc_default_options = {
+    'autoclass_content': 'both',
     'member-order': 'bysource',
-    'special-members': '__init__',
     'private-members': False,
-    'undoc-members': True,
-    'show-inheritance': True
+    'undoc-members': False,
+    'show-inheritance': False
 }
+
+# exclude unit tests from docs
+# https://stackoverflow.com/a/21449475
+def autodoc_skip_member(app, what, name, obj, skip, options):
+    return skip or name.startswith("test_")
 
 # generate autodocs by running sphinx-apidoc when evaluated on readthedocs.org.
 # source: https://github.com/readthedocs/readthedocs.org/issues/1139#issuecomment-398083449

--- a/doc/copy_external_docs.py
+++ b/doc/copy_external_docs.py
@@ -24,6 +24,7 @@ Diagnostics reference
 ---------------------
 .. toctree::
    :maxdepth: 2
+
    pod_summary
 """
 
@@ -34,6 +35,7 @@ Site-specific information
 .. toctree::
    :maxdepth: 1
    :numbered: 2
+
 """
 
 def find_copy_make_toc(type_, docs_dir, search_root, header):


### PR DESCRIPTION
**Description**
The v3-beta3 release broke the readthedocs website (e.g., the table of contents sections for site-specific info and the POD descriptions are currently missing on https://mdtf-diagnostics.readthedocs.io/en/latest/). This PR cherry-picks the configuration file and external_docs extension from PR NOAA-GFDL/MDTF-diagnostics#141, which is the minimal number of files needed to fix this bug. (The contents of the files contain additional updates from NOAA-GFDL/MDTF-diagnostics#141 which aren't needed to fix this bug and don't introduce new bugs; I'm submitting them as-is rather than reverting these changes.)

**How Has This Been Tested?**
Contents of the PR build correctly on readthedocs.com : https://mdtf-diagnostics-test-docs.readthedocs.io/en/feature-rtd-bugfix/

**Checklist:**
- [X] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [X] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/ subdirectory, and include a main_driver script template html, and settings.jsonc
- [ ] The main_driver script header has all of the information in the POD documentation, excluding the "More about this diagnostic" section
- [ ] The POD directory and html template have the same short name as my POD
- [ ] The html template has a 1-paragraph synopsis of the POD and links to the main documentation
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with conda_env_setup.sh 
- [ ] The POD scripts do not access the internet or networked resources
- [X] I have commented the code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have created the directory input_data/obs_data/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have added information about the raw data files to the documentation
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [X] The repository contains no extra test scripts or data files
- [X] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
