### PR TITLE
Use mamba for conda environment installs in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,11 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  # MDTF-specific setup: install all conda envs
-  - $TRAVIS_BUILD_DIR/src/conda/conda_env_setup.sh --all --conda_root "$HOME/miniconda"
+  # MDTF-specific setup: 
+  # install mamba (https://github.com/mamba-org/mamba) for faster dependency resolution
+  - conda install mamba -n base -c conda-forge   
+  # install all conda envs, using mamba
+  - $TRAVIS_BUILD_DIR/src/conda/conda_env_setup.sh --all --mamba --conda_root "$HOME/miniconda"
 
   - df -h # Log space remaining for data
 


### PR DESCRIPTION
**Description**

This PR adds a CLI flag, `--mamba`, to the conda_env_setup.sh script in order to install the package's environments using [mamba](https://github.com/mamba-org/mamba), a faster drop-in replacement for conda's dependency resolution mechanisms. Mamba is assumed to have been installed into the current conda environment by the user. The travis.yml configuration is updated to use this option.

No changes are made to any of the conda environments installed by the package, or to the runtime code (activating/deactivating environments for the framework and individual PODs), because none are needed -- mamba will tell you to use conda for activating/deactivating environments that already exist. Mamba is only invoked during environment installation.

This PR **does not** change the user install instructions, since this would add the complexity of 1) instructing users to install mamba before installing the package, and 2) reminding users to activate a conda environment that contains mamba before updating the environments. I'm agnostic on this issue, though, and can update the documentation if requested.

Associated issue # : #160

**How Has This Been Tested?**

Results from [Travis CI](https://travis-ci.org/github/tsjackson-noaa/MDTF-diagnostics/branches) are shown below. Using mamba reduces end-to-end CI run time by ~ a third. 

| wall-clock run times:                                                                                                                         | xenial total | xenial install | macos total | macos install |
| ------------------------------------------------------------------------------------------- | ------- | ------- | ------- | -------- | 
| [develop](https://travis-ci.org/github/tsjackson-noaa/MDTF-diagnostics/builds/762163606) | 9m 41s | 8m 38s | 20m 1s | 17m 9s |
| [this PR](https://travis-ci.org/github/tsjackson-noaa/MDTF-diagnostics/builds/762180114) | 6m 15s | 5m 7s | 11m 59s | 9m 5s |
| % of develop | 64% | 59% | 60% | 53% |

**Checklist:**
- [X] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/ subdirectory, and include a main_driver script template html, and settings.jsonc
- [ ] The main_driver script header has all of the information in the POD documentation, excluding the "More about this diagnostic" section
- [ ] The POD directory and html template have the same short name as my POD
- [ ] The html template has a 1-paragraph synopsis of the POD and links to the main documentation
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with conda_env_setup.sh 
- [ ] The POD scripts do not access the internet or networked resources
- [X] I have commented the code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have created the directory input_data/obs_data/[pod short name]
- [X] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have added information about the raw data files to the documentation
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [X] The repository contains no extra test scripts or data files
- [X] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
