### PR TITLE
Always use mamba for conda env installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,8 @@ install:
   - conda info -a
 
   # MDTF-specific setup: 
-  # install mamba (https://github.com/mamba-org/mamba) for faster dependency resolution
-  - conda install mamba -n base -c conda-forge   
-  # install all conda envs, using mamba
-  - $TRAVIS_BUILD_DIR/src/conda/conda_env_setup.sh --all --mamba --conda_root "$HOME/miniconda"
+  # install all conda envs used by package and PODs
+  - $TRAVIS_BUILD_DIR/src/conda/conda_env_setup.sh --all --conda_root "$HOME/miniconda"
 
   - df -h # Log space remaining for data
 

--- a/src/conda/conda_env_setup.sh
+++ b/src/conda/conda_env_setup.sh
@@ -93,7 +93,9 @@ while (( "$#" )); do
 done
 popd > /dev/null   # restore CWD
 
-# setup conda in non-interactive shell
+# setup conda for non-interactive shell
+# NB: 'conda' isn't an executable; it's created as a shell alias. This is why we
+# invoke it as 'conda' below, instead of the absolute path in $CONDA_EXE.
 if [ -z "$_MDTF_CONDA_ROOT" ]; then
     set -- # clear cmd line
     . "${script_dir}/conda_init.sh" -v
@@ -117,15 +119,13 @@ if [ "$make_envs" = "true" ]; then
     # present
     _INSTALL_EXE=$( command -v mamba ) || true
     mamba_temp="false"
-    echo "$CONDA_EXE"
-    echo "$_INSTALL_EXE"
     if [[ ! -x "$_INSTALL_EXE" ]]; then
         echo "Couldn't find mamba executable; installing in temp environment."
         mamba_temp="true"
-        "$CONDA_EXE" create --force -qy -n _MDTF_install_temp
-        "$CONDA_EXE" install -qy mamba -n _MDTF_install_temp -c conda-forge
+        conda create --force -qy -n _MDTF_install_temp
+        conda install -qy mamba -n _MDTF_install_temp -c conda-forge
         # still no idea why this works but "conda activate" doesn't
-        . "${_CONDA_ROOT}/bin/activate" _MDTF_install_temp
+        conda activate _MDTF_install_temp
         _INSTALL_EXE=$( command -v mamba ) || true
     fi
     if [[ ! -x "$_INSTALL_EXE" ]]; then
@@ -140,21 +140,22 @@ if [ "$make_envs" = "true" ]; then
         # get env name from reading "name:" attribute of yaml file 
         env_name=$( sed -n "s/^[[:space:]]*name:[[:space:]]*\([[:alnum:]_\-]*\)[[:space:]]*/\1/p" "$env_file" )
         if [ -z "$_CONDA_ENV_ROOT" ]; then
-            echo "Creating conda env ${env_name}..."
-            "$_INSTALL_EXE" env create --force -q -f="$env_file"
+            # need to set manually, otherwise mamba will install in a subdir
+            # of its env's directory
+            conda_prefix="${_CONDA_ROOT}/envs/${env_name}"
         else
             conda_prefix="${_CONDA_ENV_ROOT}/${env_name}"
-            echo "Creating conda env ${env_name} in ${conda_prefix}..."
-            "$_INSTALL_EXE" env create --force -q -p="$conda_prefix" -f="$env_file"
         fi
+        echo "Creating conda env ${env_name} in ${conda_prefix}..."
+        "$_INSTALL_EXE" env create --force -q -p="$conda_prefix" -f="$env_file"
         echo "... conda env ${env_name} created."
     done
-    "$_INSTALL_EXE" clean -ay
+    "$_INSTALL_EXE" clean -aqy
 
     if [ "$mamba_temp" = "true" ]; then
         # delete the temp env we used for the install
-        . "${_CONDA_ROOT}/bin/deactivate" _MDTF_install_temp
-        "$CONDA_EXE" env remove -y -n _MDTF_install_temp
+        conda deactivate
+        conda env remove -y -n _MDTF_install_temp
     fi
 fi
 


### PR DESCRIPTION
**Description**
The previous PR (#163) only used mamba in Travis CI, and did not present this functionality to users. Based on the positive reception at today's meeting, the current PR edits the install script to always use mamba in a way that will be transparent to the user.

If the mamba executable isn't on the $PATH when conda_env_setup.sh is invoked, the installation is bootstrapped by first creating a temporary conda environment named "_MDTF_install_temp" and installing only the mamba package in it. If this is done, the environment is deleted after the installs. The `--mamba` flag on conda_env_setup.sh has been removed -- no documentation changes are needed, since now conda_env_setup.sh is used the same as before.

Associated issue # (#160)

**How Has This Been Tested?**
Confirmed environments build correctly locally, and on [Travis](https://travis-ci.org/github/tsjackson-noaa/MDTF-diagnostics/builds/762412412)

**Checklist:**
- [X] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/ subdirectory, and include a main_driver script template html, and settings.jsonc
- [ ] The main_driver script header has all of the information in the POD documentation, excluding the "More about this diagnostic" section
- [ ] The POD directory and html template have the same short name as my POD
- [ ] The html template has a 1-paragraph synopsis of the POD and links to the main documentation
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with conda_env_setup.sh 
- [ ] The POD scripts do not access the internet or networked resources
- [X] I have commented the code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have created the directory input_data/obs_data/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have added information about the raw data files to the documentation
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [X] The repository contains no extra test scripts or data files
- [X] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
