### PR TITLE
Improve error handling for POD mis-specification

### DIFF
--- a/mdtf_framework.py
+++ b/mdtf_framework.py
@@ -15,7 +15,6 @@ if sys.version_info.major != 3 or sys.version_info.minor < 7:
         f"Attempted to run with following python version:\n{sys.version}")
 # passed; continue with imports
 import os
-import logging
 from src import cli
 from src.util import logs
 

--- a/mdtf_framework.py
+++ b/mdtf_framework.py
@@ -35,7 +35,9 @@ def validate_base_environment():
 
 def main():
     # get dir of currently executing script: 
-    code_root = os.path.dirname(os.path.realpath(__file__))
+    code_root = os.path.dirname(os.path.realpath(__file__))    
+    # Cache log info in memory until log file is set up
+    logs.initial_log_config()
 
     # poor man's subparser: argparse's subparser doesn't handle this
     # use case easily, so just dispatch on first argument
@@ -54,13 +56,6 @@ def main():
         # run the actual framework
         print(f"=== Starting {os.path.realpath(__file__)}\n")
         validate_base_environment()
-
-        # Cache log info in memory until log file is set up
-        logs.configure_console_loggers()
-        _log = logging.getLogger()
-        _log.setLevel(logging.NOTSET)
-        log_cache = logs.MultiFlushMemoryHandler(1024*16, flushOnClose=False)
-        _log.addHandler(log_cache)
 
         # not printing help or info, setup CLI normally 
         cli_obj = cli.MDTFTopLevelArgParser(code_root)

--- a/src/core.py
+++ b/src/core.py
@@ -98,6 +98,7 @@ class MDTFFramework(object):
         self.global_env_vars['MPLBACKEND'] = "Agg"
 
     def parse_pod_list(self, pod_list, pod_info_tuple):
+        pod_data = pod_info_tuple.pod_data # pod names -> contents of settings file
         args = util.to_iter(pod_list, set)
         bad_args = []
         pods = []
@@ -108,11 +109,11 @@ class MDTFFramework(object):
             elif arg == 'example' or arg == 'examples':
                 # add example PODs
                 pods.extend([p for p in pod_data if p.startswith('example')])
-            elif arg in pod_info_tuple.realm_data.keys():
+            elif arg in pod_info_tuple.realm_data:
                 # realm_data: realm name -> list of POD names
                 # add all PODs for this realm
-                pods.extend(pod_realms[arg])
-            elif arg in pod_info_tuple.pod_data.keys():
+                pods.extend(pod_info_tuple.realm_data[arg])
+            elif arg in pod_data:
                 # add POD by name
                 pods.append(arg)
             else:

--- a/src/core.py
+++ b/src/core.py
@@ -85,8 +85,9 @@ class MDTFFramework(object):
         most of the functionality is spun out into sub-methods.
         """
         self.parse_env_vars(cli_obj)
-        self.parse_pod_list(cli_obj, pod_info_tuple)
-        self.parse_case_list(cli_obj)
+        pod_list = cli_obj.config.pop('pods', [])
+        self.pod_list = self.parse_pod_list(pod_list, pod_info_tuple)
+        self.parse_case_list(cli_obj, pod_info_tuple)
 
     def parse_env_vars(self, cli_obj):
         # don't think PODs use global env vars?
@@ -96,37 +97,52 @@ class MDTFFramework(object):
         # see https://matplotlib.org/3.2.2/tutorials/introductory/usage.html#what-is-a-backend
         self.global_env_vars['MPLBACKEND'] = "Agg"
 
-    def parse_pod_list(self, cli_obj, pod_info_tuple):
-        pod_data = pod_info_tuple.pod_data
-        all_realms = pod_info_tuple.sorted_lists.get('realms', [])
-        pod_realms = pod_info_tuple.realm_data
+    def parse_pod_list(self, pod_list, pod_info_tuple):
+        pod_data = pod_info_tuple.pod_data # pod name -> contents of settings.jsonc
+        pod_realms = pod_info_tuple.realm_data # realm name -> list of POD names
 
-        args = util.to_iter(cli_obj.config.pop('pods', []), set)
-        if 'example' in args or 'examples' in args:
-            self.pod_list = [p for p in pod_data if p.startswith('example')]
-        elif 'all' in args:
-            self.pod_list = [p for p in pod_data if not p.startswith('example')]
-        else:
-            # specify pods by realm
-            realms = args.intersection(all_realms)
-            args = args.difference(all_realms) # remainder
-            for key in pod_realms:
-                if util.to_iter(key, set).issubset(realms):
-                    self.pod_list.extend(pod_realms[key])
-            # specify pods by name
-            pods = args.intersection(set(pod_data))
-            self.pod_list.extend(list(pods))
-            for arg in args.difference(set(pod_data)): # remainder:
-                print("WARNING: Didn't recognize POD {}, ignoring".format(arg))
-            # exclude examples
-            self.pod_list = [p for p in pod_data if not p.startswith('example')]
-        if not self.pod_list:
+        args = util.to_iter(pod_list, set)
+        bad_args = []
+        pods = []
+        for arg in args:
+            if arg == 'all':
+                # add all PODs except example PODs
+                pods.extend([p for p in pod_data if not p.startswith('example')])
+            elif arg == 'example' or arg == 'examples':
+                # add example PODs
+                pods.extend([p for p in pod_data if p.startswith('example')])
+            elif arg in pod_realms.keys():
+                # add all PODs for this realm
+                pods.extend(pod_realms[arg])
+            elif arg in pod_data.keys():
+                # add POD by name
+                pods.append(arg)
+            else:
+                # unrecognized argument
+                _log.error("POD identifier '%s' not recognized.", arg)
+                bad_args.append(arg)
+
+        if bad_args: 
+            valid_args = ['all', 'examples'] \
+                + pod_info_tuple.sorted_lists['realms'] \
+                + pod_info_tuple.sorted_lists['pods'] 
+            _log.critical(("The following POD identifiers were not recognized: "
+                "[%s].\nRecognized identifiers are: [%s].\n(Received --pods = %s)."),
+                ', '.join(f"'{p}'" for p in bad_args),
+                ', '.join(f"'{p}'" for p in valid_args),
+                str(list(args))
+            )
+            exit(1)
+
+        pods = list(set(pods)) # delete duplicates
+        if not pods:
             _log.critical(("ERROR: no PODs selected to be run. Do `./mdtf info pods`"
                 " for a list of available PODs, and check your -p/--pods argument."
                 f"\nReceived --pods = {str(list(args))}"))
             exit(1)
+        return pods
 
-    def parse_case_list(self, cli_obj):
+    def parse_case_list(self, cli_obj, pod_info_tuple):
         d = cli_obj.config # abbreviate
         if 'CASENAME' in d and d['CASENAME']:
             # defined case from CLI
@@ -139,15 +155,16 @@ class MDTFFramework(object):
             case_list_in = util.to_iter(cli_obj.file_case_list)
         case_list = []
         for i, case_d in enumerate(case_list_in):
-            case_list.append(self.parse_case(i, case_d, cli_obj))
-        self.case_list = [case for case in case_list if case]
+            case = self.parse_case(i, case_d, cli_obj, pod_info_tuple)
+            if case:
+                case_list.append(case)
         if not self.case_list:
             _log.critical(("ERROR: no valid entries in case_list. Please specify "
                 "model run information.\nReceived:"
                 f"\n{util.pretty_print_json(case_list_in)}"))
             exit(1)
 
-    def parse_case(self, n, d, cli_obj):
+    def parse_case(self, n, d, cli_obj, pod_info_tuple):
         # really need to move this into init of DataManager
         if 'CASE_ROOT_DIR' not in d and 'root_dir' in d:
             d['CASE_ROOT_DIR'] = d.pop('root_dir')
@@ -157,7 +174,7 @@ class MDTFFramework(object):
 
         if not ('CASENAME' in d or ('model' in d and 'experiment' in d)):
             _log.warning(("Need to specify either CASENAME or model/experiment "
-                "in caselist entry %s, skipping."), n+1)
+                "in caselist entry #%d, skipping."), n+1)
             return None
         _ = d.setdefault('model', d.get('convention', ''))
         _ = d.setdefault('experiment', '')
@@ -165,20 +182,20 @@ class MDTFFramework(object):
 
         for field in ['FIRSTYR', 'LASTYR', 'convention']:
             if not d.get(field, None):
-                _log.warning(("No value set for %s in caselist entry %s, "
+                _log.warning(("No value set for %s in caselist entry #%d, "
                     "skipping."), field, n+1)
                 return None
         # if pods set from CLI, overwrite pods in case list
-        d['pod_list'] = self.set_case_pod_list(d, cli_obj)
+        d['pod_list'] = self.set_case_pod_list(d, cli_obj, pod_info_tuple)
         return d
 
-    def set_case_pod_list(self, case, cli_obj):
+    def set_case_pod_list(self, case, cli_obj, pod_info_tuple):
         # if pods set from CLI, overwrite pods in case list
         # already finalized self.pod-list by the time we get here
         if not cli_obj.is_default['pods'] or not case.get('pod_list', None):
             return self.pod_list
         else:
-            return case['pod_list']
+            return self.parse_pod_list(case['pod_list'], pod_info_tuple)
 
     def verify_paths(self, config, p):
         # needs to be here, instead of PathManager, because we subclass it in 

--- a/src/core.py
+++ b/src/core.py
@@ -98,9 +98,6 @@ class MDTFFramework(object):
         self.global_env_vars['MPLBACKEND'] = "Agg"
 
     def parse_pod_list(self, pod_list, pod_info_tuple):
-        pod_data = pod_info_tuple.pod_data # pod name -> contents of settings.jsonc
-        pod_realms = pod_info_tuple.realm_data # realm name -> list of POD names
-
         args = util.to_iter(pod_list, set)
         bad_args = []
         pods = []
@@ -111,10 +108,11 @@ class MDTFFramework(object):
             elif arg == 'example' or arg == 'examples':
                 # add example PODs
                 pods.extend([p for p in pod_data if p.startswith('example')])
-            elif arg in pod_realms.keys():
+            elif arg in pod_info_tuple.realm_data.keys():
+                # realm_data: realm name -> list of POD names
                 # add all PODs for this realm
                 pods.extend(pod_realms[arg])
-            elif arg in pod_data.keys():
+            elif arg in pod_info_tuple.pod_data.keys():
                 # add POD by name
                 pods.append(arg)
             else:
@@ -124,8 +122,8 @@ class MDTFFramework(object):
 
         if bad_args: 
             valid_args = ['all', 'examples'] \
-                + pod_info_tuple.sorted_lists['realms'] \
-                + pod_info_tuple.sorted_lists['pods'] 
+                + pod_info_tuple.sorted_realms \
+                + pod_info_tuple.sorted_pods
             _log.critical(("The following POD identifiers were not recognized: "
                 "[%s].\nRecognized identifiers are: [%s].\n(Received --pods = %s)."),
                 ', '.join(f"'{p}'" for p in bad_args),

--- a/src/mdtf_info.py
+++ b/src/mdtf_info.py
@@ -2,7 +2,11 @@
 """
 import os
 import collections
+from json import JSONDecodeError
 from src import util
+
+import logging
+_log = logging.getLogger(__name__)
 
 PodDataTuple = collections.namedtuple(
     'PodDataTuple', 'sorted_lists pod_data realm_data'
@@ -12,22 +16,37 @@ def load_pod_settings(code_root, pod=None, pod_list=None):
     """
     # only place we can put it would be util.py if we want to avoid circular imports
     _pod_dir = 'diagnostics'
-    _pod_settings = 'settings.jsonc'
-    def _load_one_json(pod):
+    _file_name = 'settings.jsonc'
+
+    def _load_one_json(pod_):
+        pod_dir = os.path.join(code_root, _pod_dir, pod_)
+        settings_path = os.path.join(pod_dir, _file_name)
         try:
-            d = util.read_json(
-                os.path.join(code_root, _pod_dir, pod, _pod_settings)
-            )
-            assert 'settings' in d
+            d = util.read_json(settings_path)
+            for section in ['settings', 'varlist']:
+                if section not in d:
+                    raise AssertionError(f"'{section}' entry not found in '{_file_name}'.")
+        except util.MDTFFileNotFoundError as exc:
+            if not os.path.isdir(pod_dir):
+                raise util.PodConfigError((f"'{pod_}' directory not found in "
+                    f"'{os.path.join(code_root, _pod_dir)}'."), pod_)
+            elif not os.path.isfile(settings_path):
+                raise util.PodConfigError((f"'{_file_name}' file not found in "
+                    f"'{pod_dir}'."), pod_)
+            else:
+                raise exc
+        except (JSONDecodeError, AssertionError) as exc:
+            raise util.PodConfigError((f"Syntax error in '{_file_name}': "
+                f"{str(exc)}."), pod_)
         except Exception as exc:
-            raise util.PodConfigError(
-                "Syntax error encountered when reading settings.jsonc.", pod) from exc
+            raise util.PodConfigError((f"Error encountered in reading '{_file_name}': "
+                f"{repr(exc)}."), pod_)
         return d
 
     # get list of pods
     if not pod_list:
         pod_list = os.listdir(os.path.join(code_root, _pod_dir))
-        pod_list = [s for s in pod_list if not s.startswith(('_','.'))]
+        pod_list = [s for s in pod_list if not s.startswith(('_', '.'))]
         pod_list.sort(key=str.lower)
     if pod == 'list':
         return pod_list
@@ -48,8 +67,8 @@ def load_pod_settings(code_root, pod=None, pod_list=None):
     for p in pod_list:
         try:
             d = _load_one_json(p)
-            assert d
         except Exception as exc:
+            _log.error(exc)
             bad_pods.append(p)
             continue
         pods[p] = d
@@ -64,8 +83,10 @@ def load_pod_settings(code_root, pod=None, pod_list=None):
         else:
             realm_list.update(_realm)
         realms[_realm].append(p)
-    for p in bad_pods:
-        pod_list.remove(p)
+    if bad_pods:
+        _log.critical(("Errors were encountered when finding the following PODS: "
+            "[%s]."), ', '.join(f"'{p}'" for p in bad_pods))
+        exit(1)
     return PodDataTuple(
         pod_data=pods, realm_data=realms,
         sorted_lists={

--- a/src/mdtf_info.py
+++ b/src/mdtf_info.py
@@ -9,7 +9,7 @@ import logging
 _log = logging.getLogger(__name__)
 
 PodDataTuple = collections.namedtuple(
-    'PodDataTuple', 'sorted_lists pod_data realm_data'
+    'PodDataTuple', 'sorted_pods sorted_realms pod_data realm_data'
 )
 def load_pod_settings(code_root, pod=None, pod_list=None):
     """Wrapper to load POD settings files, used by ConfigManager and CLIInfoHandler.
@@ -89,10 +89,8 @@ def load_pod_settings(code_root, pod=None, pod_list=None):
         exit(1)
     return PodDataTuple(
         pod_data=pods, realm_data=realms,
-        sorted_lists={
-            "pods": pod_list,
-            "realms": sorted(list(realm_list), key=str.lower)
-        }
+        sorted_pods=pod_list,
+        sorted_realms=sorted(list(realm_list), key=str.lower)
     )
 
 
@@ -107,9 +105,9 @@ class InfoCLIHandler(object):
 
         self.code_root = code_root
         pod_info_tuple = load_pod_settings(self.code_root)
-        self.pod_list = pod_info_tuple.sorted_lists.get('pods', [])
+        self.pod_list = pod_info_tuple.sorted_pods
+        self.realm_list = pod_info_tuple.sorted_realms
         self.pods = pod_info_tuple.pod_data
-        self.realm_list = pod_info_tuple.sorted_lists.get('realms', [])
         self.realms = pod_info_tuple.realm_data
 
         # build list of recognized topics, in order

--- a/src/util/logs.py
+++ b/src/util/logs.py
@@ -7,8 +7,6 @@ import datetime
 import subprocess
 import signal
 
-from . import basic, exceptions
-
 import logging
 import logging.config
 import logging.handlers

--- a/src/util/logs.py
+++ b/src/util/logs.py
@@ -6,11 +6,18 @@ import argparse
 import datetime
 import subprocess
 import signal
+
+from . import basic, exceptions
+
 import logging
 import logging.config
 import logging.handlers
-
 _log = logging.getLogger(__name__)
+
+class MDTFConsoleHandler(logging.StreamHandler):
+    """Dummy class to designate logging to stdout or stderr from the root logger.
+    """
+    pass
 
 class MultiFlushMemoryHandler(logging.handlers.MemoryHandler):
     """Subclass :py:class:`logging.handlers.MemoryHandler` to enable flushing
@@ -39,12 +46,12 @@ class MultiFlushMemoryHandler(logging.handlers.MemoryHandler):
         finally:
             self.release()
 
-    def transfer_to_non_streams(self, logger):
+    def transfer_to_non_console(self, logger):
         """Transfer contents of buffer to all non-console-based handlers attached 
-        to logger (handlers that aren't :py:class:`~logging.StreamHandler`.)
+        to *logger* (handlers that aren't :py:class:`MDTFConsoleHandler`.)
 
         If no handlers are attached to the logger, a warning is printed and the
-        buffer is transferred to the :py:data:`logging.lastResort` handler, i.e.
+        buffer is transferred to the :py:class:`logging.lastResort` handler, i.e.
         printed to stderr.
         
         Args:
@@ -53,13 +60,11 @@ class MultiFlushMemoryHandler(logging.handlers.MemoryHandler):
         """
         no_transfer_flag = True
         for h in logger.handlers:
-            if not isinstance(h, MultiFlushMemoryHandler) \
-                and not (isinstance(h, logging.StreamHandler) \
-                    and not isinstance(h, logging.FileHandler)):
+            if not isinstance(h, (MultiFlushMemoryHandler, MDTFConsoleHandler)):
                 self.transfer(h)
                 no_transfer_flag = False
         if no_transfer_flag:
-            logger.warning("No non-console-based loggers configured.")
+            logger.warning("No non-console loggers configured.")
             self.transfer(logging.lastResort)
 
 class HeaderFileHandler(logging.FileHandler):
@@ -295,7 +300,7 @@ def git_info():
 
 # ------------------------------------------------------------------------------
 
-def signal_logger(caller_name, signum=None, frame=None):
+def signal_logger(caller_name, signum=None, frame=None, log=_log):
     """Lookup signal name from number and write to log.
     
     Taken from `<https://stackoverflow.com/a/2549950>`__.
@@ -309,12 +314,12 @@ def signal_logger(caller_name, signum=None, frame=None):
             k:v for v, k in reversed(sorted(list(signal.__dict__.items()))) \
                 if v.startswith('SIG') and not v.startswith('SIG_')
         }
-        _log.info(
+        log.info(
             "%s caught signal %s (%s)",
             caller_name, sig_lookup.get(signum, 'UNKNOWN'), signum
         )
     else:
-        _log.info("%s caught unknown signal.", caller_name)
+        log.info("%s caught unknown signal.", caller_name)
 
 def _set_excepthook(root_logger):
     """Ensure all uncaught exceptions, other than user KeyboardInterrupt, are 
@@ -428,39 +433,52 @@ def case_log_config(config_mgr, **new_paths):
 
     if first_call:
         # transfer cache contents to newly-configured loggers and delete it
-        temp_log_cache.transfer_to_non_streams(root_logger)
+        temp_log_cache.transfer_to_non_console(root_logger)
         temp_log_cache.close()
         root_logger.removeHandler(temp_log_cache)
         _log.debug('Contents of log cache transferred.')
 
-def configure_console_loggers():
-    """Configure console loggers for top-level script. This is redundant with
-    what's in logging.jsonc, but for debugging purposes we want to get console 
-    output set up before we've parsed input paths, read config files, etc.
+def initial_log_config():
+    """Configure the root logger for logging to console and to a cache provided
+    by :class:`MultiFlushMemoryHandler`. For debugging purposes 
+    we want to get console output set up before we've read in the real log config
+    files (which requires doing a full parse of the user input).
     """
     logging.captureWarnings(True)
+    # log uncaught exceptions
+    root_logger = logging.getLogger()
+    _set_excepthook(root_logger)
     log_d = {
         "version": 1,
-        "disable_existing_loggers":  False,
-        "root": {"level": "NOTSET", "handlers": ["debug", "stdout", "stderr"]},
+        "disable_existing_loggers":  True,        
+        "root": {
+            "level": "NOTSET", 
+            "handlers": ["debug", "stdout", "stderr", "cache"]
+        },
         "handlers": {
             "debug": {
-                "class": "logging.StreamHandler",
+                "()": "src.util.logs.MDTFConsoleHandler",
                 "formatter": "level",
-                "level" : logging.DEBUG,
-                "stream" : "ext://sys.stdout"
+                "level": logging.DEBUG,
+                "stream": "ext://sys.stdout"
             },
             "stdout": {
-                "class": "logging.StreamHandler",
+                "()": "src.util.logs.MDTFConsoleHandler",
                 "formatter": "normal",
-                "level" : logging.INFO,
-                "stream" : "ext://sys.stdout"
+                "level": logging.INFO,
+                "stream": "ext://sys.stdout"
             },
             "stderr": {
-                "class": "logging.StreamHandler",
+                "()": "src.util.logs.MDTFConsoleHandler",
                 "formatter": "level",
-                "level" : logging.WARNING,
-                "stream" : "ext://sys.stderr"
+                "level": logging.WARNING,
+                "stream": "ext://sys.stderr"
+            },
+            "cache": {
+                "()": "src.util.logs.MultiFlushMemoryHandler",
+                "level": logging.NOTSET,
+                "capacity": 8*1024,
+                "flushOnClose": False
             }
         },
         "formatters": {


### PR DESCRIPTION
**Description**
The following set of errors in identifying and specifying PODs were treated as non-fatal (affected PODs were ignored). This PR changes these to fatal errors, logging a relevant error message and exiting immediately.
- Missing settings.jsonc file
- JSON syntax errors in the settings.jsonc file (error message from python's json parser is passed through).
- Missing 'settings' or 'varlist' section in settings.jsonc file
- User requests a POD not that wasn't found or recognized, either in the run-wide `pod-list` or in a case-specific `pod_list` 

Associated issue #: NOAA-GFDL/MDTF-diagnostics#179

**How Has This Been Tested?**
Verified that correct output was logged when the above conditions were met.

**Checklist:**
- [X] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [X] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/ subdirectory, and include a main_driver script template html, and settings.jsonc
- [ ] The main_driver script header has all of the information in the POD documentation, excluding the "More about this diagnostic" section
- [ ] The POD directory and html template have the same short name as my POD
- [ ] The html template has a 1-paragraph synopsis of the POD and links to the main documentation
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with conda_env_setup.sh 
- [X] The POD scripts do not access the internet or networked resources
- [X] I have commented the code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have created the directory input_data/obs_data/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have added information about the raw data files to the documentation
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [X] The repository contains no extra test scripts or data files
- [X] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
