### PR TITLE
Critical bug fix for case list parsing

### DIFF
--- a/.github/workflows/mdtf_tests.yml
+++ b/.github/workflows/mdtf_tests.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
       - develop
+  pull_request:
+    branches:
+      - main
+      - develop
 defaults:
   run:
     shell: bash -l {0}

--- a/src/core.py
+++ b/src/core.py
@@ -157,11 +157,12 @@ class MDTFFramework(object):
             case = self.parse_case(i, case_d, cli_obj, pod_info_tuple)
             if case:
                 case_list.append(case)
-        if not self.case_list:
-            _log.critical(("ERROR: no valid entries in case_list. Please specify "
+        if not case_list:
+            _log.critical(("No valid entries in case_list. Please specify "
                 "model run information.\nReceived:"
                 f"\n{util.pretty_print_json(case_list_in)}"))
             exit(1)
+        self.case_list = case_list
 
     def parse_case(self, n, d, cli_obj, pod_info_tuple):
         # really need to move this into init of DataManager


### PR DESCRIPTION
**Description**
Fixes bug introduced by PR NOAA-GFDL/MDTF-diagnostics#183 which caused case list to never be recognized.

This bug was caught by CI (https://github.com/NOAA-GFDL/MDTF-diagnostics/runs/2327438137) after the PR was merged.   To catch errors such as these earlier, change the GitHub actions configuration to run the existing test suite on all PRs targeting the /develop or /main branches.

**How Has This Been Tested?**
Reproduced error on local test case, and verified that the commit fixed the issue (package ran to successful exit). Changes to GH actions haven't been tested.

**Checklist:**
- [X] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [X] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/ subdirectory, and include a main_driver script template html, and settings.jsonc
- [ ] The main_driver script header has all of the information in the POD documentation, excluding the "More about this diagnostic" section
- [ ] The POD directory and html template have the same short name as my POD
- [ ] The html template has a 1-paragraph synopsis of the POD and links to the main documentation
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with conda_env_setup.sh 
- [ ] The POD scripts do not access the internet or networked resources
- [ ] I have commented the code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have created the directory input_data/obs_data/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have added information about the raw data files to the documentation
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
- [X] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
