### PR TITLE
Add numba and scikit-learn to python3 base yaml

### DIFF
--- a/src/conda/env_python3_base.yml
+++ b/src/conda/env_python3_base.yml
@@ -17,3 +17,5 @@ dependencies:
 - cartopy=0.18
 - pint=0.16
 - dask=2021.03.0
+- numba=0.53.1
+- scikit-learn=0.24.2


### PR DESCRIPTION
**Description**
Adds numba and scikit-learn modules to the python3 base yaml file

#206 

**Checklist:**
- [x] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/ subdirectory, and include a main_driver script template html, and settings.jsonc
- [ ] The main_driver script header has all of the information in the POD documentation, excluding the "More about this diagnostic" section
- [ ] The POD directory and html template have the same short name as my POD
- [ ] The html template has a 1-paragraph synopsis of the POD and links to the main documentation
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with conda_env_setup.sh 
- [ ] The POD scripts do not access the internet or networked resources
- [ ] I have commented the code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have created the directory input_data/obs_data/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have added information about the raw data files to the documentation
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
- [x] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
