### PR TITLE
Strip trailing whitespace from code

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -26,4 +26,3 @@ python:
     - method: pip
       path: .
   system_packages: false
-  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 # This Travis-CI file only runs unit tests on the MDTF code.
-# It does not make use of external test data and does not test the scientific 
+# It does not make use of external test data and does not test the scientific
 # content of individual diagnostics.
 
-# Config validator: https://config.travis-ci.com/explore 
+# Config validator: https://config.travis-ci.com/explore
 
 jobs:
   include:
@@ -17,7 +17,7 @@ jobs:
       env:
         - MINICONDA_INSTALLER="https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
 
-before_install: 
+before_install:
   # TRAVIS_BUILD_DIR = abs path to checked-out repo
   - BUILD_PARENT="$( cd "$( dirname "$TRAVIS_BUILD_DIR" )" >/dev/null 2>&1 && pwd )"
   - POD_OUTPUT="${BUILD_PARENT}/wkdir/MDTF_NCAR-CAM5.timeslice_2000_2003"
@@ -27,7 +27,7 @@ before_install:
   - cd "$BUILD_PARENT"
 
 install:
-# miniconda setup taken from official guide at 
+# miniconda setup taken from official guide at
 # https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/use-conda-with-travis-ci.html
   # - sudo apt update
   - wget $MINICONDA_INSTALLER -O miniconda.sh;
@@ -39,7 +39,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  # MDTF-specific setup: 
+  # MDTF-specific setup:
   # install all conda envs used by package and PODs
   - $TRAVIS_BUILD_DIR/src/conda/conda_env_setup.sh --all --conda_root "$HOME/miniconda"
 
@@ -71,11 +71,11 @@ script:
 
   # try running EOF_500hPa and example PODs
   - ./mdtf -v -f "${TRAVIS_BUILD_DIR}/tests/travis_test.jsonc"
-  # EOF_500hPa 
+  # EOF_500hPa
   - ls "${POD_OUTPUT}/EOF_500hPa/obs"
   - ls "${POD_OUTPUT}/EOF_500hPa/model"
   - cat "${POD_OUTPUT}/EOF_500hPa/EOF_500hPa.log"
-  # example 
+  # example
   - ls "${POD_OUTPUT}/example/obs"
   - ls "${POD_OUTPUT}/example/model"
   - cat "${POD_OUTPUT}/example/example.log"

--- a/data/fieldlist_CMIP.jsonc
+++ b/data/fieldlist_CMIP.jsonc
@@ -18,9 +18,9 @@
       "axis": "Z"
     },
     "standard_hybrid_sigma": {
-      "standard_name": "atmosphere_hybrid_sigma_pressure_coordinate", 
-      "units": "1", 
-      "axis": "Z", 
+      "standard_name": "atmosphere_hybrid_sigma_pressure_coordinate",
+      "units": "1",
+      "axis": "Z",
       "positive": "down"
     }
   },
@@ -196,7 +196,7 @@
       "units": "kg m-2",
       "ndim": 3
     },
-    // Variables for SM_ET_coupling module 
+    // Variables for SM_ET_coupling module
     "mrsos": {
       "standard_name": "mass_content_of_water_in_soil_layer",
       "units": "kg m-2",

--- a/data/fieldlist_GFDL.jsonc
+++ b/data/fieldlist_GFDL.jsonc
@@ -8,7 +8,7 @@
   "models": ["AM4", "CM4", "ESM4", "SPEAR"], // others?
   "coords" : {
     // only used for taking slices, unit conversion
-    // 'PLACEHOLDER' prefix indicates that coordinate names are to be set based 
+    // 'PLACEHOLDER' prefix indicates that coordinate names are to be set based
     // on their values in model data
     "lon": {"axis": "X", "standard_name": "longitude", "units": "degrees_east"},
     "lat": {"axis": "Y", "standard_name": "latitude", "units": "degrees_north"},
@@ -181,7 +181,7 @@
       "units": "kg m-2",
       "ndim": 3
     }
-    // Variables for SM_ET_coupling module 
+    // Variables for SM_ET_coupling module
     // "mrsos": {
     //   "standard_name": "mass_content_of_water_in_soil_layer",
     //   "units": "kg m-2",

--- a/data/fieldlist_NCAR.jsonc
+++ b/data/fieldlist_NCAR.jsonc
@@ -197,7 +197,7 @@
       "units": "kg m-2",
       "ndim": 3
     }
-    // Variables for SM_ET_coupling module 
+    // Variables for SM_ET_coupling module
     // "mrsos": {
     //   "standard_name": "mass_content_of_water_in_soil_layer",
     //   "units": "kg m-2",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,10 +26,10 @@ from recommonmark.transform import AutoStructify
 
 # mock out imports of non-standard library modules
 autodoc_mock_imports = [
-    'numpy', 'xarray', 'cftime', 'cfunits', 'cf_xarray', 
+    'numpy', 'xarray', 'cftime', 'cfunits', 'cf_xarray',
     'pandas', 'intake', 'intake_esm'
 ]
-# need to manually mock out explicit patching of cf_xarray.accessor done 
+# need to manually mock out explicit patching of cf_xarray.accessor done
 # on import in xr_parser
 import unittest.mock as mock
 mock_accessor = mock.Mock()
@@ -215,22 +215,22 @@ latex_documents = [
     (
         # "Main" PDF containing all source files. This is built automatically by
         # ReadTheDocs (filename is fixed by the RTD account name).
-        'tex_all', 'mdtf-diagnostics.tex', 
+        'tex_all', 'mdtf-diagnostics.tex',
         u'MDTF Diagnostics Documentation', author, 'manual'
     ),(
-        # Secondary PDF. Sphinx will build multiple PDFs, but as far as I can 
-        # tell, ReadTheDocs won't (linked open issues in prior commits to this 
-        # file?). Instead these are currently built manually and checked into 
-        # /docs/static_. The ".tex_" extension is to prevent an error in RTD's 
+        # Secondary PDF. Sphinx will build multiple PDFs, but as far as I can
+        # tell, ReadTheDocs won't (linked open issues in prior commits to this
+        # file?). Instead these are currently built manually and checked into
+        # /docs/static_. The ".tex_" extension is to prevent an error in RTD's
         # build process if it finds multiple .tex files, and doesn't affect sphinx.
-        'tex_getting_started', 'MDTF_getting_started.tex_', 
-        u"MDTF Getting Started Guide", 
-        r"Thomas Jackson (GFDL) \and Yi-Hung Kuo (UCLA) \and Dani Coleman (NCAR)", 
+        'tex_getting_started', 'MDTF_getting_started.tex_',
+        u"MDTF Getting Started Guide",
+        r"Thomas Jackson (GFDL) \and Yi-Hung Kuo (UCLA) \and Dani Coleman (NCAR)",
         'manual'
     ),(
         # another secondary PDF.
-        'tex_walkthrough', 'MDTF_walkthrough.tex_', 
-        u"MDTF Developer's Walkthrough", 
+        'tex_walkthrough', 'MDTF_walkthrough.tex_',
+        u"MDTF Developer's Walkthrough",
         (
         r"Yi-Hung Kuo\textsuperscript{a} \and Dani Coleman\textsuperscript{b} "
         r"\and Thomas Jackson\textsuperscript{c} \and Chih-Chieh (Jack) Chen\textsuperscript{b} "
@@ -339,7 +339,7 @@ def run_apidoc(_):
 
 # -- Extensions to the Napoleon GoogleDocstring class ---------------------
 # copied from: https://michaelgoerz.net/notes/extending-sphinx-napoleon-docstring-sections.html
-# purpose: provide correct formatting of class attributes when documented 
+# purpose: provide correct formatting of class attributes when documented
 # with Google-style docstrings.
 
 from sphinx.ext.napoleon.docstring import GoogleDocstring

--- a/doc/copy_external_docs.py
+++ b/doc/copy_external_docs.py
@@ -1,17 +1,17 @@
-"""Simple Sphinx extension to copy source files from outside the Sphinx 
+"""Simple Sphinx extension to copy source files from outside the Sphinx
 TOCtree root.
 This is a longstanding limitation of sphinx; see
 https://github.com/sphinx-doc/sphinx/issues/701 and
 https://stackoverflow.com/q/10199233 .
 This extension implements a workaround that simply copies the source files into
-the Sphinx source directory before compilation, and generates the table of 
+the Sphinx source directory before compilation, and generates the table of
 contents automatically.
-Implementation is based on 
+Implementation is based on
 https://gist.github.com/khaeru/3185679f4dd83b16a0648f6036fb000e
 by Paul Natsuo Kishimoto; adapted to python2 and the specific MDTF directory
 structure.
 Specifically, we use this to copy POD documentation files and site-specific
-documentation files, stores alongside individual PODs and site files in 
+documentation files, stores alongside individual PODs and site files in
 /diagnostics and /sites.
 """
 import os
@@ -61,7 +61,7 @@ def find_copy_make_toc(type_, docs_dir, search_root, header):
         if os.path.isdir(os.path.join(search_root, x)) and x[0].isalnum()
     ]
     # Case-insensitive alpha sort
-    entries = sorted(entries, key=(lambda s: s.lower())) # handles unicode 
+    entries = sorted(entries, key=(lambda s: s.lower())) # handles unicode
     # put example POD documentation first
     if 'example' in entries:
         entries.remove('example')
@@ -72,7 +72,7 @@ def find_copy_make_toc(type_, docs_dir, search_root, header):
         entries.insert(0, 'local')
 
     # find documentation files
-    # = all non-PDF files (.rst and graphics) in /doc subdirectory 
+    # = all non-PDF files (.rst and graphics) in /doc subdirectory
     docs = []
     for entry in entries:
         doc_dir = os.path.join(search_root, entry, 'doc')
@@ -84,11 +84,11 @@ def find_copy_make_toc(type_, docs_dir, search_root, header):
 
     # copy the docs we found
     iter_ = status_iterator(
-        docs, 'Copying {} files... '.format(type_), 
+        docs, 'Copying {} files... '.format(type_),
         color='purple', stringify_func=_docname
     )
     for source in iter_:
-        shutil.copy2(source, sphinx_dir)        
+        shutil.copy2(source, sphinx_dir)
 
     # create toc file, either "pod_toc.rst" or "site_toc.rst"
     toc_path = os.path.join(docs_dir, 'sphinx', '{}_toc.rst'.format(type_))
@@ -114,6 +114,6 @@ def config_inited(app, config):
 
 
 def setup(app):
-    # call the above function in the Sphinx build process after the 'config' 
+    # call the above function in the Sphinx build process after the 'config'
     # object has been initialized but before anything else
     app.connect('config-inited', config_inited)

--- a/mdtf_framework.py
+++ b/mdtf_framework.py
@@ -4,7 +4,7 @@
 # See http://gfdl.noaa.gov/mdtf-diagnostics.
 
 # NOTE: Under the standard installation procedure, users should never call this
-# script directly, but should instead call the "mdtf" wrapper shell script 
+# script directly, but should instead call the "mdtf" wrapper shell script
 # created during installation.
 
 import sys
@@ -19,9 +19,9 @@ from src import cli
 from src.util import logs
 
 def validate_base_environment():
-    """Check that the package's required third-party dependencies (listed in 
+    """Check that the package's required third-party dependencies (listed in
     src/conda/env_base.yml) are accessible.
-    """        
+    """
     # checking existence of one third-party module is imperfect, but will
     # catch the most common case where user hasn't installed environments
     try:
@@ -33,8 +33,8 @@ def validate_base_environment():
             "at mdtf-diagnostics.rtfd.io/en/latest/sphinx/start_install.html.")
 
 def main():
-    # get dir of currently executing script: 
-    code_root = os.path.dirname(os.path.realpath(__file__))    
+    # get dir of currently executing script:
+    code_root = os.path.dirname(os.path.realpath(__file__))
     # Cache log info in memory until log file is set up
     logs.initial_log_config()
 
@@ -46,7 +46,7 @@ def main():
         cli_obj = cli.MDTFTopLevelArgParser(code_root)
         cli_obj.print_help()
         return 0 # will actually exit from print_help
-    elif sys.argv[1].lower() == 'info': 
+    elif sys.argv[1].lower() == 'info':
         from src import mdtf_info
         # "subparser" for command-line info
         mdtf_info.InfoCLIHandler(code_root, sys.argv[2:])
@@ -56,7 +56,7 @@ def main():
         print(f"=== Starting {os.path.realpath(__file__)}\n")
         validate_base_environment()
 
-        # not printing help or info, setup CLI normally 
+        # not printing help or info, setup CLI normally
         cli_obj = cli.MDTFTopLevelArgParser(code_root)
         framework = cli_obj.dispatch()
         exit_code = framework.main()

--- a/sites/NOAA_GFDL/cli_gfdl.jsonc
+++ b/sites/NOAA_GFDL/cli_gfdl.jsonc
@@ -1,11 +1,11 @@
 // Configuration for command-line arguments for MDTF-diagnostics driver script.
-// This is used by install.py to generate cli.jsonc. 
+// This is used by install.py to generate cli.jsonc.
 // DO NOT modify this file. Instead, edit cli.jsonc.
 //
-// Entries here are used in framework/cli.py to configure command-line options 
+// Entries here are used in framework/cli.py to configure command-line options
 // accepted by the script. Syntax is based on python's argparse library, see
-// https://docs.python.org/2.7/library/argparse.html or 
-// https://docs.python.org/2.7/howto/argparse.html. 
+// https://docs.python.org/2.7/library/argparse.html or
+// https://docs.python.org/2.7/howto/argparse.html.
 //
 // All text to the right of an unquoted "//" is a comment and ignored, as well
 // as blank lines (JSONC quasi-standard.)
@@ -173,14 +173,14 @@
           "name": "verbose",
           "short_name": "v",
           "help": "Increase console log verbosity level. -v prints debug information.",
-          "default" : 0, 
-          "action": "count" 
+          "default" : 0,
+          "action": "count"
         },{
           "name": "quiet",
           "short_name": "q",
           "help": "Decrease console log verbosity level. -q prints warnings only, -qq prints errors only, and -qqq prints no output.",
-          "default" : 0, 
-          "action": "count" 
+          "default" : 0,
+          "action": "count"
         },{
           "name": "file_transfer_timeout",
           "help": "Time (in seconds) to wait before giving up on transferring a data file to the local filesystem. Set to zero to disable.",

--- a/sites/NOAA_GFDL/cli_plugins.jsonc
+++ b/sites/NOAA_GFDL/cli_plugins.jsonc
@@ -1,6 +1,6 @@
 // Configuration of CLI plugins for code provided in /src. These options are
 // spliced into the CLI configuration in src/cli_template.jsonc. The contents of
-// both of these files may be overridden by configuration in /sites if a 
+// both of these files may be overridden by configuration in /sites if a
 // site-specific installation is selected.
 //
 {

--- a/sites/NOAA_GFDL/cli_subcommands.jsonc
+++ b/sites/NOAA_GFDL/cli_subcommands.jsonc
@@ -1,5 +1,5 @@
 // Configuration for the top-level subcommands offered by the mdtf.py driver
-// script. This is read by MDTFSubcommandDispatch. 
+// script. This is read by MDTFSubcommandDispatch.
 //
 // DO NOT modify this file. Instead, run 'mdtf install', which will generate a
 // copy in /sites which you can edit.
@@ -7,7 +7,7 @@
 // All text to the right of an unquoted "//" is a comment and ignored, as well
 // as blank lines (JSONC quasi-standard.)
 {
-  "title": "COMMANDS", 
+  "title": "COMMANDS",
   "description": "Subcommand functionality. Use '%(prog)s <command> --help' to get help on options specific to each command.",
   "help": null,
   "metavar": "<command> is one of:",

--- a/sites/NOAA_GFDL/default_gfdl.jsonc
+++ b/sites/NOAA_GFDL/default_gfdl.jsonc
@@ -1,16 +1,16 @@
 // Configuration for MDTF-diagnostics driver script.
 //
 // All text to the right of an unquoted "//" is a comment and ignored, as well
-// as blank lines (JSONC quasi-standard.) 
+// as blank lines (JSONC quasi-standard.)
 //
-// Copy this file and customize the setting values as needed. Pass it to the 
-// framework at the end of the command line (positionally) or with the 
+// Copy this file and customize the setting values as needed. Pass it to the
+// framework at the end of the command line (positionally) or with the
 // -f/--config-file flag.
 //
 {
   // The cases below correspond to the different test data sets.
   //
-  // Note that the mdtf package does not yet handle multiple cases. 
+  // Note that the mdtf package does not yet handle multiple cases.
   //
   "case_list" : [
     {
@@ -34,7 +34,7 @@
     }
   ],
   // PATHS ---------------------------------------------------------------------
-  // Location of input and output data. If a relative path is given, it's 
+  // Location of input and output data. If a relative path is given, it's
   // resolved relative to the MDTF-diagnostics code directory.
 
   // Parent directory containing results from different models.
@@ -56,20 +56,20 @@
   // GFDL ----------------------------------------------------------------------
   // Settings specific to operation at GFDL.
 
-  // If running on GFDL PPAN, set $MDTF_TMPDIR to this location and 
+  // If running on GFDL PPAN, set $MDTF_TMPDIR to this location and
   // create temp files here. Must be accessible via gcp.
   "GFDL_PPAN_TEMP": "$TMPDIR",
 
-  // If running on a GFDL workstation, set $MDTF_TMPDIR to this location 
+  // If running on a GFDL workstation, set $MDTF_TMPDIR to this location
   // and create temp files here. Must be accessible via gcp.
   "GFDL_WS_TEMP": "/net2/$USER/tmp",
-  
-  // Set flag to run framework in 'online' mode, processing data as part of the 
-  // FRE pipeline. Normally this is done by calling the mdtf_gfdl.csh wrapper 
+
+  // Set flag to run framework in 'online' mode, processing data as part of the
+  // FRE pipeline. Normally this is done by calling the mdtf_gfdl.csh wrapper
   // script from the XML.
   "frepp": false,
 
-  // Set flag search entire /pp/ directory for model data; default is to 
+  // Set flag search entire /pp/ directory for model data; default is to
   // restrict to model component passed by FRE. Ignored if --frepp is not set.
   "ignore_component": false,
 
@@ -79,7 +79,7 @@
   // Method used to fetch model data.
   "data_manager": "GFDL_auto",
 
-  // Time (in seconds) to wait before giving up on transferring a data file to 
+  // Time (in seconds) to wait before giving up on transferring a data file to
   // the local filesystem. Set to zero to disable.
   "file_transfer_timeout": 900,
 
@@ -90,22 +90,22 @@
   // Settings affecting the runtime environment of the PODs.
   "environment_manager": "conda",
 
-  // Path to the Anaconda installation. Only used if environment_manager='Conda'. 
+  // Path to the Anaconda installation. Only used if environment_manager='Conda'.
   // Set equal to "" to use conda from your system's $PATH.
   "conda_root": "/home/oar.gfdl.mdtf/miniconda3",
 
-  // Root directory for Anaconda environment installs. Only used if 
-  // environment_manager = 'Conda'. Set equal to '' to install in your system's 
+  // Root directory for Anaconda environment installs. Only used if
+  // environment_manager = 'Conda'. Set equal to '' to install in your system's
   // default location.
   "conda_env_root": "/home/oar.gfdl.mdtf/miniconda3/envs",
 
-  // Root directory for python virtual environments. Only used if 
-  // environment_manager = 'Virtualenv'. Set equal to '' to install in your 
+  // Root directory for python virtual environments. Only used if
+  // environment_manager = 'Virtualenv'. Set equal to '' to install in your
   // system's default location.
   "venv_root": "./envs/venv",
 
-  // Root directory for R packages requested by PODs. Only used if 
-  // environment_manager = 'Virtualenv'. Set equal to '' to install in your 
+  // Root directory for R packages requested by PODs. Only used if
+  // environment_manager = 'Virtualenv'. Set equal to '' to install in your
   // system library.
   "r_lib_root": "./envs/r_libs",
 
@@ -121,7 +121,7 @@
   // Set flag to save HTML and bitmap plots in a .tar file.
   "make_variab_tar": false,
 
-  // Set flag to overwrite results in OUTPUT_DIR; otherwise results saved under 
+  // Set flag to overwrite results in OUTPUT_DIR; otherwise results saved under
   // a unique name.
   "overwrite": false,
 
@@ -129,12 +129,12 @@
   // Settings used in debugging.
 
   // Log verbosity level.
-  "verbose": 1, 
+  "verbose": 1,
 
   // Set flag for framework test. Data is fetched but PODs are not run.
   "test_mode": false,
 
-  // Set flag for framework test. No external commands are run and no remote 
+  // Set flag for framework test. No external commands are run and no remote
   // data is copied. Implies test_mode.
   "dry_run": false
 }

--- a/sites/NOAA_GFDL/gfdl.py
+++ b/sites/NOAA_GFDL/gfdl.py
@@ -1,4 +1,4 @@
-"""Code specific to the computing environment at NOAA's Geophysical Fluid 
+"""Code specific to the computing environment at NOAA's Geophysical Fluid
 Dynamics Laboratory (Princeton, NJ, USA).
 """
 import os
@@ -6,7 +6,7 @@ import io
 import dataclasses
 import shutil
 import tempfile
-from src import (util, core, diagnostic, data_manager, 
+from src import (util, core, diagnostic, data_manager,
     preprocessor, environment_manager, output_manager, cmip6)
 from sites.NOAA_GFDL import gfdl_util
 
@@ -74,7 +74,7 @@ class GFDLMDTFFramework(core.MDTFFramework):
             (keep_temp or p.WORKING_DIR == p.OUTPUT_DIR):
             gfdl_util.rmtree_wrapper(p.WORKING_DIR)
         util.check_dirs(p.CODE_ROOT, p.OBS_DATA_REMOTE, create=False)
-        util.check_dirs(p.MODEL_DATA_ROOT, p.OBS_DATA_ROOT, p.WORKING_DIR, 
+        util.check_dirs(p.MODEL_DATA_ROOT, p.OBS_DATA_ROOT, p.WORKING_DIR,
             create=True)
         # Use GCP to create OUTPUT_DIR on a volume that may be read-only
         if not os.path.exists(p.OUTPUT_DIR):
@@ -85,18 +85,18 @@ class GFDLMDTFFramework(core.MDTFFramework):
 
 @util.mdtf_dataclass
 class GfdlDiagnostic(diagnostic.Diagnostic):
-    """Wrapper for Diagnostic that adds writing a placeholder directory 
-    (POD_OUT_DIR) to the output as a lockfile if we're running in frepp 
+    """Wrapper for Diagnostic that adds writing a placeholder directory
+    (POD_OUT_DIR) to the output as a lockfile if we're running in frepp
     cooperative mode.
     """
     # extra dataclass fields
     _has_placeholder: bool = False
 
     def pre_run_setup(self):
-        """Extra code only applicable in frepp cooperative mode. If this code is 
+        """Extra code only applicable in frepp cooperative mode. If this code is
         called, all the POD's model data has been generated. Write a placeholder
-        directory to POD_OUT_DIR, so if frepp invokes the MDTF package again 
-        while we're running, only our results will be written to the overall 
+        directory to POD_OUT_DIR, so if frepp invokes the MDTF package again
+        while we're running, only our results will be written to the overall
         output.
         """
         super(GfdlDiagnostic, self).pre_run_setup()
@@ -114,7 +114,7 @@ class GfdlDiagnostic(diagnostic.Diagnostic):
                         self) from exc
                 except Exception as chained_exc:
                     _log.error(chained_exc)
-                    self.exceptions.log(chained_exc)    
+                    self.exceptions.log(chained_exc)
 
 # ------------------------------------------------------------------------
 
@@ -145,7 +145,7 @@ class GCPFetchMixin(data_manager.AbstractFetchMixin):
             util.run_command(['dmget','-t','-v'] + list(paths),
                 timeout= len(paths) * self.timeout,
                 dry_run=self.dry_run
-            ) 
+            )
             _log.info("Successful exit of dmget.")
 
     def _get_fetch_method(self, method=None):
@@ -180,11 +180,11 @@ class GCPFetchMixin(data_manager.AbstractFetchMixin):
             local_path = os.path.join(tmpdir, os.path.basename(path))
             _log.info(f"\tFetching {path[len(self.attrs.CASE_ROOT_DIR):]}")
             util.run_command(cp_command + [
-                smartsite + path, 
+                smartsite + path,
                 # gcp requires trailing slash, ln ignores it
                 smartsite + tmpdir + os.sep
-            ], 
-                timeout=self.timeout, 
+            ],
+                timeout=self.timeout,
                 dry_run=self.dry_run
             )
             local_paths.append(local_path)
@@ -192,8 +192,8 @@ class GCPFetchMixin(data_manager.AbstractFetchMixin):
 
 
 class GFDL_GCP_FileDataSourceBase(
-    data_manager.OnTheFlyDirectoryHierarchyQueryMixin, 
-    GCPFetchMixin, 
+    data_manager.OnTheFlyDirectoryHierarchyQueryMixin,
+    GCPFetchMixin,
     data_manager.DataframeQueryDataSourceBase
 ):
     """Base class for DataSources that access data on GFDL's internal filesystems
@@ -221,7 +221,7 @@ class GFDL_GCP_FileDataSourceBase(
             self.overwrite = True
             # flag to not overwrite config and .tar: want overwrite for frepp
             self.file_overwrite = True
-            # if overwrite=False, WK_DIR & OUT_DIR will have been set to a 
+            # if overwrite=False, WK_DIR & OUT_DIR will have been set to a
             # unique name in parent's init. Set it back so it will be overwritten.
             d = paths.model_paths(self, overwrite=True)
             self.MODEL_WK_DIR = d.MODEL_WK_DIR
@@ -234,7 +234,7 @@ class GFDL_UDA_CMIP6DataSourceAttributes(data_manager.CMIP6DataSourceAttributes)
         super(GFDL_UDA_CMIP6DataSourceAttributes, self).__post_init__(model, experiment)
 
 class Gfdludacmip6DataManager(
-    data_manager.CMIP6ExperimentSelectionMixin, 
+    data_manager.CMIP6ExperimentSelectionMixin,
     GFDL_GCP_FileDataSourceBase
 ):
     """DataSource for accessing CMIP6 data stored on spinning disk at /uda/CMIP6.
@@ -253,7 +253,7 @@ class GFDL_archive_CMIP6DataSourceAttributes(data_manager.CMIP6DataSourceAttribu
         super(GFDL_archive_CMIP6DataSourceAttributes, self).__post_init__(model, experiment)
 
 class Gfdlarchivecmip6DataManager(
-    data_manager.CMIP6ExperimentSelectionMixin, 
+    data_manager.CMIP6ExperimentSelectionMixin,
     GFDL_GCP_FileDataSourceBase
 ):
     """DataSource for accessing more extensive set of CMIP6 data on DMF tape-backed
@@ -262,7 +262,7 @@ class Gfdlarchivecmip6DataManager(
     _FileRegexClass = cmip6.CMIP6_DRSPath
     _DirectoryRegex = cmip6.drs_directory_regex
     _AttributesClass = GFDL_archive_CMIP6DataSourceAttributes
-    _fetch_method = "gcp" 
+    _fetch_method = "gcp"
     _convention = "CMIP" # hard-code naming convention
 
 
@@ -273,7 +273,7 @@ class GFDL_data_CMIP6DataSourceAttributes(data_manager.CMIP6DataSourceAttributes
         super(GFDL_data_CMIP6DataSourceAttributes, self).__post_init__(model, experiment)
 
 class Gfdldatacmip6DataManager(
-    data_manager.CMIP6ExperimentSelectionMixin, 
+    data_manager.CMIP6ExperimentSelectionMixin,
     GFDL_GCP_FileDataSourceBase
 ):
     """DataSource for accessing pre-publication CMIP6 data on /data_cmip6.
@@ -286,9 +286,9 @@ class Gfdldatacmip6DataManager(
 # RegexPattern that matches any string (path) that doesn't end with ".nc".
 _ignore_non_nc_regex = util.RegexPattern(r".*(?<!\.nc)")
 # match files ending in .nc only if they aren't of the form .tile#.nc
-# (negative lookback) 
+# (negative lookback)
 _ignore_tiles_regex = util.RegexPattern(r".*\.tile\d\.nc$")
-# match any paths corresponding to time average data (/av/), since currently 
+# match any paths corresponding to time average data (/av/), since currently
 # we only deal with timeseries data (/ts/)
 _ignore_time_avg_regex = util.RegexPattern(r"/?([a-zA-Z0-9_-]+)/av/\S*")
 # RegexPattern matching any of the above -- description of files that are OK
@@ -298,7 +298,7 @@ pp_ignore_regex = util.ChainedRegexPattern(
 )
 
 # can't combine these with the path regexes (below) since static dir regex should
-# only be used with static files 
+# only be used with static files
 _pp_dir_regex = util.RegexPattern(r"""
         /?                      # maybe initial separator
         (?P<component>[a-zA-Z0-9_-]+)/     # component name
@@ -309,7 +309,7 @@ _pp_dir_regex = util.RegexPattern(r"""
 )
 _pp_static_dir_regex = util.RegexPattern(r"""
         /?                      # maybe initial separator
-        (?P<component>[a-zA-Z0-9_-]+)     # component name             
+        (?P<component>[a-zA-Z0-9_-]+)     # component name
     """,
     defaults={
         'frequency': util.FXDateFrequency, 'chunk_freq': util.FXDateFrequency
@@ -325,7 +325,7 @@ _pp_ts_regex = util.RegexPattern(r"""
         (?P<component>[a-zA-Z0-9_-]+)/     # component name
         ts/                     # timeseries;
         (?P<frequency>\w+)/     # ts freq
-        (?P<chunk_freq>\w+)/    # data chunk length   
+        (?P<chunk_freq>\w+)/    # data chunk length
         (?P=component)\.        # component name (again)
         (?P<start_date>\d+)-(?P<end_date>\d+)\.   # file's date range
         (?P<variable>[a-zA-Z0-9_-]+)\.       # field name
@@ -334,9 +334,9 @@ _pp_ts_regex = util.RegexPattern(r"""
 )
 _pp_static_regex = util.RegexPattern(r"""
         /?                      # maybe initial separator
-        (?P<component>[a-zA-Z0-9_-]+)/     # component name 
+        (?P<component>[a-zA-Z0-9_-]+)/     # component name
         (?P=component)     # component name (again)
-        \.static\.nc             # static frequency, netCDF file extension                
+        \.static\.nc             # static frequency, netCDF file extension
     """,
     defaults={
         'variable': 'static',
@@ -368,7 +368,7 @@ class PPTimeseriesDataFile():
             self.frequency = util.DateFrequency(self.frequency)
         if self.start_date == util.FXDateMin \
             and self.end_date == util.FXDateMax:
-            # Assume we're dealing with static/fx-frequency data, so use special 
+            # Assume we're dealing with static/fx-frequency data, so use special
             # placeholder values
             self.date_range = util.FXDateRange
             if not self.frequency.is_static:
@@ -382,7 +382,7 @@ class PPTimeseriesDataFile():
 
 @util.mdtf_dataclass
 class PPDataSourceAttributes(data_manager.DataSourceAttributesBase):
-    """Data-source-specific attributes for the DataSource corresponding to 
+    """Data-source-specific attributes for the DataSource corresponding to
     model data in the /pp/ directory hierarchy.
     """
     convention: str = util.MANDATORY
@@ -436,7 +436,7 @@ class GfdlppDataManager(GFDL_GCP_FileDataSourceBase):
 
     @property
     def var_expt_cols(self):
-        # Catalog columns whose values must "be the same for each variable", ie  
+        # Catalog columns whose values must "be the same for each variable", ie
         # are irrelevant but must be constrained to a unique value.
         return self.var_expt_key_cols
 
@@ -452,7 +452,7 @@ class GfdlppDataManager(GFDL_GCP_FileDataSourceBase):
             # unique value, no need to filter
             return df
         filter_val = func(values)
-        _log.debug("Selected experiment attribute %s='%s' for %s (out of %s).", 
+        _log.debug("Selected experiment attribute %s='%s' for %s (out of %s).",
             col_name, filter_val, obj_name, values)
         return df[df[col_name] == filter_val]
 
@@ -467,20 +467,20 @@ class GfdlppDataManager(GFDL_GCP_FileDataSourceBase):
         return df
 
     def resolve_expt(self, df, obj):
-        """Disambiguate experiment attributes that must be the same for all 
+        """Disambiguate experiment attributes that must be the same for all
         variables.
         """
         # no-op since no attributes in this category
         return df
 
     def resolve_pod_expt(self, df, obj):
-        """Disambiguate experiment attributes that must be the same for all 
+        """Disambiguate experiment attributes that must be the same for all
         variables for each POD:
 
         - Select the model component name according to the following heuristics:
             i) select component names containing 'cmip' (case-insensitive). ii)
-            if that selects multiple components, break the tie by selecting the 
-            component with the fewest words (separated by '_'), or, failing that, 
+            if that selects multiple components, break the tie by selecting the
+            component with the fewest words (separated by '_'), or, failing that,
             the shortest overall name.
         """
         def _heuristic_tiebreaker(str_list):
@@ -505,7 +505,7 @@ class GfdlppDataManager(GFDL_GCP_FileDataSourceBase):
 
     def resolve_var_expt(self, df, obj):
         """Disambiguate arbitrary experiment attributes on a per-variable basis:
- 
+
         - Take the shortest chunk_frequency, to minimize transferring data that's
             outside of the query date range.
         """
@@ -513,7 +513,7 @@ class GfdlppDataManager(GFDL_GCP_FileDataSourceBase):
         if 'component' in self.var_expt_cols:
             col_name = 'component'
             df = df.sort_values(col_name).iloc[[0]]
-            _log.debug("Selected experiment attribute '%s'='%s' for %s.", 
+            _log.debug("Selected experiment attribute '%s'='%s' for %s.",
                 col_name, df[col_name].iloc[0], obj.name)
         return df
 
@@ -523,7 +523,7 @@ class GfdlautoDataManager(object):
     /uda via :class:`Gfdludacmip6DataManager`.
     """
     def __new__(cls, case_dict, *args, **kwargs):
-        """Dispatch DataManager instance creation based on the contents of 
+        """Dispatch DataManager instance creation based on the contents of
         case_dict."""
         config = core.ConfigManager()
         dir_ = case_dict.get('CASE_ROOT_DIR', config.CASE_ROOT_DIR)
@@ -531,10 +531,10 @@ class GfdlautoDataManager(object):
             dispatched_cls = GfdlppDataManager
         else:
             dispatched_cls = Gfdludacmip6DataManager
-            # could use more careful logic here, but for now assume CMIP6 on 
+            # could use more careful logic here, but for now assume CMIP6 on
             # /uda as a fallback
-            
-        _log.debug("%s: Dispatched DataManager to %s.", 
+
+        _log.debug("%s: Dispatched DataManager to %s.",
             cls.__name__, dispatched_cls.__name__)
         obj = dispatched_cls.__new__(dispatched_cls)
         obj.__init__(case_dict)
@@ -548,7 +548,7 @@ class GfdlautoDataManager(object):
 class GfdlvirtualenvEnvironmentManager(
     environment_manager.VirtualenvEnvironmentManager
     ):
-    # Use module files to switch execution environments, as defined on 
+    # Use module files to switch execution environments, as defined on
     # GFDL workstations and PP/AN cluster.
 
     def __init__(self):
@@ -618,17 +618,17 @@ class GFDLHTMLPodOutputManager(output_manager.HTMLPodOutputManager):
         self.frepp_mode = config.get('frepp', False)
 
     def make_output(self):
-        """Only run output steps (including logging error on index.html) 
+        """Only run output steps (including logging error on index.html)
         if POD ran on this invocation.
         """
         if not self.frepp_mode:
             super(GFDLHTMLPodOutputManager, self).make_output()
         elif self._pod._has_placeholder:
-            _log.debug('POD %s has frepp placeholder, generating output.', 
+            _log.debug('POD %s has frepp placeholder, generating output.',
                 self._pod.name)
             super(GFDLHTMLPodOutputManager, self).make_output()
-        else: 
-            _log.debug('POD %s does not have frepp placeholder; not generating output.', 
+        else:
+            _log.debug('POD %s does not have frepp placeholder; not generating output.',
                 self._pod.name)
 
 class GFDLHTMLOutputManager(output_manager.HTMLOutputManager):
@@ -646,7 +646,7 @@ class GFDLHTMLOutputManager(output_manager.HTMLOutputManager):
         super(GFDLHTMLOutputManager, self).__init__(case)
 
     def make_html(self, case, cleanup=False):
-        """Never cleanup html if we're in frepp_mode, since framework may run 
+        """Never cleanup html if we're in frepp_mode, since framework may run
         later when another component finishes. Instead just append current
         progress to CASE_TEMP_HTML.
         """

--- a/sites/NOAA_GFDL/gfdl_util.py
+++ b/sites/NOAA_GFDL/gfdl_util.py
@@ -40,7 +40,7 @@ class ModuleManager(util.Singleton):
         (output, error) = proc.communicate()
         if proc.returncode != 0:
             raise util.MDTFCalledProcessError(
-                returncode=proc.returncode, 
+                returncode=proc.returncode,
                 cmd=' '.join([cmd, 'python'] + args), output=error)
         exec(output)
 
@@ -78,7 +78,7 @@ class ModuleManager(util.Singleton):
         """Wrapper for module list.
         """
         return os.environ['LOADEDMODULES'].split(':')
-    
+
     def revert_state(self):
         mods_to_unload = self.modules_i_loaded.difference(self.user_modules)
         for mod in mods_to_unload:
@@ -91,7 +91,7 @@ class ModuleManager(util.Singleton):
 # ========================================================================
 
 def gcp_wrapper(source_path, dest_dir, timeout=None, dry_run=None):
-    """Wrapper for file and recursive directory copying using the GFDL 
+    """Wrapper for file and recursive directory copying using the GFDL
     site-specific General Copy Program (`https://gitlab.gfdl.noaa.gov/gcp/gcp`__.)
     Assumes GCP environment module has been loaded beforehand, and calls GCP in
     a subprocess.
@@ -117,7 +117,7 @@ def gcp_wrapper(source_path, dest_dir, timeout=None, dry_run=None):
     _log.info('\tGCP {} -> {}'.format(source[-1], dest[-1]))
     util.run_command(
         ['gcp', '--sync', '-v', '-cd'] + source + dest,
-        timeout=timeout, 
+        timeout=timeout,
         dry_run=dry_run
     )
 
@@ -128,7 +128,7 @@ def make_remote_dir(dest_dir, timeout=None, dry_run=None):
         os.makedirs(dest_dir)
     except OSError as exc:
         # use GCP for this because output dir might be on a read-only filesystem.
-        # apparently trying to test this with os.access is less robust than 
+        # apparently trying to test this with os.access is less robust than
         # just catching the error
         _log.debug("os.makedirs at %s failed (%r); trying GCP.", dest_dir, exc)
         tmpdirs = core.TempDirManager()
@@ -185,7 +185,7 @@ def is_on_tape_filesystem(path):
         for s in ['/arch', '/ptmp', '/work', '/uda'])
 
 def rmtree_wrapper(path):
-    """Attempt to workaround errors with :py:func:`shutil.rmtree` on NFS 
+    """Attempt to workaround errors with :py:func:`shutil.rmtree` on NFS
     filesystems.
     """
     # Standard shutil.rmtree raises ``OSError: [Errno 39] Directory not empty``,

--- a/sites/NOAA_GFDL/mdtf_gfdl.csh
+++ b/sites/NOAA_GFDL/mdtf_gfdl.csh
@@ -30,7 +30,7 @@ set script_path
 ## set paths
 set REPO_DIR="/home/Oar.Gfdl.Mdteam/DET/analysis/mdtf/MDTF-diagnostics"
 set OBS_DATA_DIR="/home/Oar.Gfdl.Mdteam/DET/analysis/mdtf/obs_data"
-# output always written to $out_dir; unset below to skip copy/linking to 
+# output always written to $out_dir; unset below to skip copy/linking to
 # MDteam experiment directory.
 set OUTPUT_HTML_DIR="/home/Oar.Gfdl.Mdteam/internal_html/mdtf_output"
 set INPUT_DIR="${TMPDIR}/inputdata"
@@ -68,7 +68,7 @@ set flags=()
 # NB analysis doesn't have getopts
 # reference: https://github.com/blackberry/GetOpt/blob/master/getopt-parse.tcsh
 set temp=(`getopt -s tcsh -o Y:Z: --long component_only,save_nc,yr1:,yr2: -- $argu:q`)
-if ($? != 0) then 
+if ($? != 0) then
     echo "Command line parse error 1" >/dev/stderr
     exit 1
 endif
@@ -77,10 +77,10 @@ eval set argv=\($temp:q\) # argv needed for shift etc. to work
 while (1)
     switch($1:q)
     case --component_only:
-        set cmpt_args=( '--component' "$COMPONENT" '--data_freq' "$DATA_FREQ" '--chunk_freq' "$CHUNK_FREQ" ) ; shift 
+        set cmpt_args=( '--component' "$COMPONENT" '--data_freq' "$DATA_FREQ" '--chunk_freq' "$CHUNK_FREQ" ) ; shift
         breaksw;
     case --save_nc:
-        set flags=( '--save_nc' ) ; shift 
+        set flags=( '--save_nc' ) ; shift
         breaksw;
     case -Y:
     case --yr1:
@@ -103,14 +103,14 @@ set yr2 = `echo ${yr2} | sed 's/^0*//g'`
 
 
 ## configure env modules
-if ( ! $?MODULESHOME ) then       
+if ( ! $?MODULESHOME ) then
     echo "\$MODULESHOME is undefined"
     exit 1
 else
     if ( "$MODULESHOME" == "" )  then
         echo "\$MODULESHOME is empty"
         exit 1
-    else 
+    else
         source $MODULESHOME/init/tcsh
         # should probably 'module purge'
         if ( `where module` == "" ) then
@@ -128,7 +128,7 @@ foreach mod ( 'gcp' 'python/2.7.12' 'perlbrew' )
     if ( $status != 0 ) then
         module load $mod
     endif
-end	
+end
 ( module list -t ) |& cat # log modules being used
 
 ## clean up tmpdir
@@ -153,7 +153,7 @@ $flags:q
 echo 'script exit'
 
 ## copy/link output files, if requested
-if ( ! $?OUTPUT_HTML_DIR ) then       
+if ( ! $?OUTPUT_HTML_DIR ) then
     echo "Complete -- Exiting"
     exit 0
 endif
@@ -169,7 +169,7 @@ if ($? == 0) then
     echo "Configuring data for experiments website"
 
     set shaOut = `perl -e "use Digest::SHA qw(sha1_hex); print sha1_hex('${out_dir}');"`
-    set mdteamDir="${OUTPUT_HTML_DIR}/${shaOut}"	
+    set mdteamDir="${OUTPUT_HTML_DIR}/${shaOut}"
     if ( ! -d ${mdteamDir} ) then
         mkdir -p "${mdteamDir}"
         echo "Symlinking ${out_dir}/${mdtf_dir} to ${mdteamDir}/mdtf"

--- a/sites/NOAA_GFDL/tests/test_gfdl.py
+++ b/sites/NOAA_GFDL/tests/test_gfdl.py
@@ -11,8 +11,8 @@ from src.core import MDTFFramework
 DOING_TRAVIS = (os.environ.get('TRAVIS', False) == 'true')
 DOING_MDTF_DATA_TESTS = ('--data_tests' in sys.argv)
 DOING_SETUP = DOING_MDTF_DATA_TESTS and not DOING_TRAVIS
-# All this is a workaround because tests are programmatically generated at 
-# import time, but the tests are skipped at runtime. We're skipping tests 
+# All this is a workaround because tests are programmatically generated at
+# import time, but the tests are skipped at runtime. We're skipping tests
 # because we're not in an environment where we have the data to set them up,
 # so we just throw everything in an if-block to ensure they don't get generated
 # if they're going to be skipped later.
@@ -23,7 +23,7 @@ DOING_SETUP = DOING_MDTF_DATA_TESTS and not DOING_TRAVIS
 
 #     case_list = shared.get_test_data_configuration()
 
-#     # write temp configuration, one for each POD  
+#     # write temp configuration, one for each POD
 #     temp_config = config.copy()
 #     temp_config['pod_list'] = []
 #     temp_config['settings']['make_variab_tar'] = False
@@ -47,8 +47,8 @@ class TestModuleManager(unittest.TestCase):
         _ = gfdl_util.ModuleManager()
 
     def tearDown(self):
-        # call _reset method clearing ModuleManager for unit testing, 
-        # otherwise the second, third, .. tests will use the instance created 
+        # call _reset method clearing ModuleManager for unit testing,
+        # otherwise the second, third, .. tests will use the instance created
         # in the first test instead of being properly initialized
         temp = gfdl_util.ModuleManager()
         temp.revert_state()
@@ -67,7 +67,7 @@ class TestModuleManager(unittest.TestCase):
         cmd = '{}/bin/modulecmd'.format(os.environ['MODULESHOME'])
         for mod in gfdl._current_module_versions.values():
             # module list writes to stderr, because all module user output does
-            list1 = subprocess.check_output([cmd, 'python', 'avail', '-t', mod], 
+            list1 = subprocess.check_output([cmd, 'python', 'avail', '-t', mod],
                 stderr=subprocess.STDOUT).splitlines()
             list1 = [s for s in list1 if not s.endswith(':')]
             self.assertNotEqual(list1, [],
@@ -76,7 +76,7 @@ class TestModuleManager(unittest.TestCase):
     def test_module_list(self):
         cmd = '{}/bin/modulecmd'.format(os.environ['MODULESHOME'])
         # module list writes to stderr, because all module user output does
-        list1 = subprocess.check_output([cmd, 'python', 'list', '-t'], 
+        list1 = subprocess.check_output([cmd, 'python', 'list', '-t'],
             stderr=subprocess.STDOUT).splitlines()
         del list1[0]
         list1 = set([s.replace('(default)','') for s in list1])
@@ -173,7 +173,7 @@ class TestFreppArgParsing(unittest.TestCase):
     def test_parse_mdtf_args_frepp_caselist(self):
         # overwrite defaults and command-line
         d = gfdl_util.parse_frepp_stub(self.frepp_stub)
-        args = {'frepp': True}        
+        args = {'frepp': True}
         mdtf = MDTFFramework.__new__(MDTFFramework)
         config = self.config_test.copy()
         config = MDTFFramework.parse_mdtf_args([d, args], config)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
 # Initialize package logging tree
-# Real loggers should be configured by scripts that import this package; see 
+# Real loggers should be configured by scripts that import this package; see
 # https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,4 +1,4 @@
-"""Classes related to customizing the framework's command line interface and 
+"""Classes related to customizing the framework's command line interface and
 setting option values from user input.
 """
 import os
@@ -31,14 +31,14 @@ def canonical_arg_name(str_):
     return str_.lstrip('-').rstrip().replace('-', '_')
 
 def plugin_key(plugin_name):
-    """Ignore spaces and underscores in supplied choices for CLI plugins, and 
+    """Ignore spaces and underscores in supplied choices for CLI plugins, and
     make matching of plugin names case-insensititve.
     """
     return re.sub(r"[\s_]+", "", plugin_name).lower()
 
 def word_wrap(str_):
     """Clean whitespace and produces better word wrapping for multi-line help
-    and description strings. Explicit paragraph breaks must be encoded as a 
+    and description strings. Explicit paragraph breaks must be encoded as a
     double newline ( ``\n\n`` ).
     """
     paragraphs = textwrap.dedent(str_).split('\n\n')
@@ -48,15 +48,15 @@ def word_wrap(str_):
 
 def read_config_files(code_root, file_name, site=""):
     """Utility function to read a *pair* of configuration files (one for the
-    framework defaults, another optional one for site-specific config.) 
+    framework defaults, another optional one for site-specific config.)
 
     Args:
         file_name (str): Name of file to search for. We search for the file
             in all subdirectories of :meth:`._CLIConfigHandler.site_dir`
             and :meth:`._CLIConfigHandler.framework_dir`, respectively.
 
-    Returns: a tuple of the two files' contents. First entry is the 
-        site specific file (empty dict if that file isn't found) and second 
+    Returns: a tuple of the two files' contents. First entry is the
+        site specific file (empty dict if that file isn't found) and second
         is the framework file (fatal error; exit immediately if not found.)
     """
     src_dir = os.path.join(code_root, 'src')
@@ -74,12 +74,12 @@ def read_config_file(code_root, file_name, site=""):
     return site_d
 
 class CustomHelpFormatter(
-        argparse.RawDescriptionHelpFormatter, 
+        argparse.RawDescriptionHelpFormatter,
         argparse.ArgumentDefaultsHelpFormatter
     ):
-    """Modify help text formatter to only display variable placeholder 
-    ("metavar") once, to save space. Taken from 
-    `<https://stackoverflow.com/a/16969505>`__. Also inherit from 
+    """Modify help text formatter to only display variable placeholder
+    ("metavar") once, to save space. Taken from
+    `<https://stackoverflow.com/a/16969505>`__. Also inherit from
     RawDescriptionHelpFormatter in order to preserve line breaks in description
     only (`<https://stackoverflow.com/a/18462760>`__).
     """
@@ -111,7 +111,7 @@ class CustomHelpFormatter(
             return ', '.join(parts)
 
     def _get_help_string(self, action):
-        """Only print the argument's default in the help string if it's defined. 
+        """Only print the argument's default in the help string if it's defined.
         Based on `<https://stackoverflow.com/a/34545549>`__.
         """
         help_str = action.help
@@ -130,27 +130,27 @@ class CustomHelpFormatter(
 
 
 class RecordDefaultsAction(argparse.Action):
-    """:py:class:`~argparse.Action` that adds a boolean to record if user 
+    """:py:class:`~argparse.Action` that adds a boolean to record if user
     actually set argument's value, or if we're using the default value specified
-    in the parser. From `<https://stackoverflow.com/a/50936474>`__. This also 
-    re-implements the 'store_true' and 'store_false' actions, in order to give 
+    in the parser. From `<https://stackoverflow.com/a/50936474>`__. This also
+    re-implements the 'store_true' and 'store_false' actions, in order to give
     defaults information on boolean flags.
 
     If the user specifies a value for ``<option>``, the :meth:`__call__` method
-    adds a variable named ``<option>_is_default_`` to the returned 
-    :py:class:`argparse.Namespace`. This information is used by 
-    :meth:`.MDTFArgParser.parse_args` to populate the ``is_default`` attribute 
+    adds a variable named ``<option>_is_default_`` to the returned
+    :py:class:`argparse.Namespace`. This information is used by
+    :meth:`.MDTFArgParser.parse_args` to populate the ``is_default`` attribute
     of :class:`.MDTFArgParser`.
 
-    Subclasses of :py:class:`argparse.Action` are only called on user-supplied 
-    values, not default values. If the ``call_on_defaults`` flag is set on a 
-    subclass, :meth:`.MDTFArgParser.parse_args` will also call the action on 
+    Subclasses of :py:class:`argparse.Action` are only called on user-supplied
+    values, not default values. If the ``call_on_defaults`` flag is set on a
+    subclass, :meth:`.MDTFArgParser.parse_args` will also call the action on
     default values.
     """
     default_value_suffix = '_is_default_'
     call_on_defaults = False # call action on default values
 
-    def __init__(self, option_strings, dest, nargs=None, const=None, 
+    def __init__(self, option_strings, dest, nargs=None, const=None,
         default=None, type=None, **kwargs):
         if isinstance(default, bool):
             nargs = 0             # behave like a flag
@@ -160,7 +160,7 @@ class RecordDefaultsAction(argparse.Action):
             nargs = 1
             const = None
         super(RecordDefaultsAction, self).__init__(
-            option_strings, dest, nargs=nargs, const=const, default=default, 
+            option_strings, dest, nargs=nargs, const=const, default=default,
             type=type, **kwargs
         )
 
@@ -175,8 +175,8 @@ class RecordDefaultsAction(argparse.Action):
         setattr(namespace, self.dest+self.default_value_suffix, False)
 
 class PathAction(RecordDefaultsAction):
-    """:py:class:`~argparse.Action` that performs shell environment variable 
-    expansion and resolution of relative paths, using 
+    """:py:class:`~argparse.Action` that performs shell environment variable
+    expansion and resolution of relative paths, using
     :func:`src.util.filesystem.resolve_path`.
     """
     call_on_defaults = True
@@ -186,12 +186,12 @@ class PathAction(RecordDefaultsAction):
         path = util.from_iter(values)
         if path is None:
             path = ''
-        # Don't do anything else here: may need to use env vars to properly 
+        # Don't do anything else here: may need to use env vars to properly
         # resolve paths, so that's now done later, in core.PathManager.__init__()
         super(PathAction, self).__call__(parser, namespace, path, option_string)
 
 class ClassImportAction(RecordDefaultsAction):
-    """:py:class:`~argparse.Action` to import classes on demand. Values are 
+    """:py:class:`~argparse.Action` to import classes on demand. Values are
     looked up from the 'cli_plugins.jsonc' file.
     Placeholder used to trigger behavior when arguments are parsed.
     """
@@ -218,7 +218,7 @@ class PluginArgAction(ClassImportAction):
 
 @dataclasses.dataclass
 class CLIArgument(object):
-    """Class holding configuration options for a single argument of an 
+    """Class holding configuration options for a single argument of an
     :py:class:`argparse.ArgumentParser`, with several custom options to simplify
     the parsing of CLIs defined in JSON files.
     """
@@ -309,23 +309,23 @@ class CLIArgument(object):
             self.help = argparse.SUPPRESS
 
     def add(self, target_p):
-        """Adds the CLI argument to the parser ``target_p``. Wraps 
+        """Adds the CLI argument to the parser ``target_p``. Wraps
         :py:meth:`~argparse.ArgumentParser.add_argument`.
 
         Args:
             target_p: Parser object (or parser group, or subparser) to which the
-                argument will be added. 
+                argument will be added.
         """
         kwargs = {k:v for k,v in dataclasses.asdict(self).items() \
                 if v is not None and k not in [
-                'name', 'arg_flags', 'is_positional', 'short_name', 'hidden'        
+                'name', 'arg_flags', 'is_positional', 'short_name', 'hidden'
             ]}
         return target_p.add_argument(*self.arg_flags, **kwargs)
 
 @dataclasses.dataclass
 class CLIArgumentGroup(object):
-    """Class holding configuration options for an 
-    :py:class:`argparse.ArgumentParser` `argument group 
+    """Class holding configuration options for an
+    :py:class:`argparse.ArgumentParser` `argument group
     <https://docs.python.org/3.7/library/argparse.html#argument-groups>`__.
     """
     title: str
@@ -334,7 +334,7 @@ class CLIArgumentGroup(object):
 
     @classmethod
     def from_dict(cls, d):
-        """Initialize an instance of this object from a nested dict obtained 
+        """Initialize an instance of this object from a nested dict obtained
         from reading a JSON file.
         """
         args_list = d.get('arguments', [])
@@ -342,18 +342,18 @@ class CLIArgumentGroup(object):
         return cls(**d)
 
     def add(self, target_p):
-        """Adds the CLI argument group, as well as all arguments it contains, 
-        to the parser ``target_p``. Wraps 
+        """Adds the CLI argument group, as well as all arguments it contains,
+        to the parser ``target_p``. Wraps
         :py:meth:`~argparse.ArgumentParser.add_argument_group`.
 
         Args:
             target_p: Parser object (or parser group, or subparser) to which the
-                argument group will be added. 
+                argument group will be added.
         """
         if self.arguments:
             # only add group if it has > 0 arguments
             kwargs = {k:v for k,v in dataclasses.asdict(self).items() \
-                if v is not None and k in ['title', 'description']} 
+                if v is not None and k in ['title', 'description']}
             arg_gp = target_p.add_argument_group(**kwargs)
             for arg in self.arguments:
                 _ = arg.add(arg_gp)
@@ -361,8 +361,8 @@ class CLIArgumentGroup(object):
 
 @dataclasses.dataclass
 class CLIParser(object):
-    """Class holding configuration options for an instance of 
-    :py:class:`argparse.ArgumentParser` (or equivalently a subparser or a 
+    """Class holding configuration options for an instance of
+    :py:class:`argparse.ArgumentParser` (or equivalently a subparser or a
     command plugin).
     """
     prog: str = None
@@ -382,7 +382,7 @@ class CLIParser(object):
 
     @classmethod
     def from_dict(cls, d):
-        """Initialize an instance of this object from a nested dict obtained 
+        """Initialize an instance of this object from a nested dict obtained
         from reading a JSON file.
         """
         args_list = d.get('arguments', [])
@@ -429,7 +429,7 @@ class CLIParser(object):
                 arg.default = arg.choices[0]
 
         # add everything
-        if self.arguments: 
+        if self.arguments:
             for arg in self.arguments:
                 # add arguments not in any group
                 _ = arg.add(target_p)
@@ -454,16 +454,16 @@ class CLIParser(object):
             setattr(target_p, 'description', description_text)
 
     def add_plugin_args(self, preparsed_d):
-        """Revise arguments after we know what plugins are being used. This 
+        """Revise arguments after we know what plugins are being used. This
         annotates the help string of the plugin selector argument and configures
-        its ``choices`` attribute. It then inserts the plugin-specifc CLI 
+        its ``choices`` attribute. It then inserts the plugin-specifc CLI
         arguments following that argument.
 
         Args:
-            preparsed_d: dict of results of the preparsing operation. Keys are 
-                the destination strings of the plugin selector arguments 
-                (identified by having their ``action`` set to 
-                :class:`.PluginArgAction`), and values are the values assigned 
+            preparsed_d: dict of results of the preparsing operation. Keys are
+                the destination strings of the plugin selector arguments
+                (identified by having their ``action`` set to
+                :class:`.PluginArgAction`), and values are the values assigned
                 to them by preparsing.
         """
         def _add_plugins_to_arg_list(arg_list, splice_d):
@@ -507,8 +507,8 @@ class CLIParser(object):
 
 @dataclasses.dataclass
 class CLICommand(object):
-    """Class holding configuration options for a subcommand (invoked via a 
-    subparser) or a plugin. 
+    """Class holding configuration options for a subcommand (invoked via a
+    subparser) or a plugin.
     """
     name: str
     entry_point: str
@@ -531,7 +531,7 @@ class CLICommand(object):
             self.cli = CLIParser.from_dict(self.cli)
 
     def import_target(self):
-        """Imports the function or class referred to by the ``entry_point`` 
+        """Imports the function or class referred to by the ``entry_point``
         attribute.
         """
         mod_name, cls_name = self.entry_point.split(':')
@@ -556,30 +556,30 @@ class CLICommand(object):
 
 DefaultsFileTypes = enum.Enum('DefaultsFileTypes', 'USER SITE GLOBAL')
 DefaultsFileTypes.__doc__ = """
-    :py:class:`~enum.Enum` to distinguish the three different categories of 
+    :py:class:`~enum.Enum` to distinguish the three different categories of
     input settings files. In order of precedence:
 
     1. ``USER``: Input settings read from a file supplied by the user.
     2. ``SITE``: Settings specific to the given site (``--site`` flag.)
     3. ``GLOBAL``: Settings applicable to all sites. The main intended use case
-        of this file is to enable the user to configure a default site at 
+        of this file is to enable the user to configure a default site at
         install time.
 """
 
 class CLIConfigManager(util.Singleton):
-    """:class:`~src.util.Singleton` to handle search, loading and parsing 
-    of configuration files for the CLI and CLI default values. We encapsulate 
-    this functionality in its own class, instead of :class:`.MDTFArgParser` or 
-    its children, to try to make the code easier to understand (not out of 
+    """:class:`~src.util.Singleton` to handle search, loading and parsing
+    of configuration files for the CLI and CLI default values. We encapsulate
+    this functionality in its own class, instead of :class:`.MDTFArgParser` or
+    its children, to try to make the code easier to understand (not out of
     necessity).
 
     .. warning::
-       This is intended to be initialized by a calling script *before* being 
+       This is intended to be initialized by a calling script *before* being
        referenced by the classes in this module.
     """
     def __init__(self, code_root=None, skip_defaults=False):
         # singleton, so this will only be invoked once
-        
+
         self.code_root = code_root
         self.skip_defaults = skip_defaults
         self.site = self.default_site
@@ -593,7 +593,7 @@ class CLIConfigManager(util.Singleton):
         self.defaults_files = dict()
         self.site_defaults = {'site': self.default_site}
         self.user_defaults = dict()
-    
+
     default_site = 'local'
     defaults_filename = "defaults.jsonc"
     subcommands_filename = "cli_subcommands.jsonc"
@@ -654,8 +654,8 @@ class CLIConfigManager(util.Singleton):
             return None
 
     def read_subcommands(self):
-        """Populates ``subcommands`` and ``subparser_kwargs`` attributes with 
-        contents of CLI plugin files for the framework and site. Site-specific 
+        """Populates ``subcommands`` and ``subparser_kwargs`` attributes with
+        contents of CLI plugin files for the framework and site. Site-specific
         subcommand definitions override those defined on the framework.
         """
         (site_d, fmwk_d) = read_config_files(
@@ -704,7 +704,7 @@ class CLIConfigManager(util.Singleton):
                     CLICommand(name=kk, **vv, code_root=self.code_root)
 
     def get_plugin(self, plugin_name, choice_of_plugin=None):
-        """Lookup requested CLI plugin from ``plugins`` attribute, logging 
+        """Lookup requested CLI plugin from ``plugins`` attribute, logging
         appropriate errors where KeyErrors would be raised.
 
         Args:
@@ -717,7 +717,7 @@ class CLIConfigManager(util.Singleton):
             choices if only the first argument is given.
         """
         if plugin_name not in self.plugins:
-            _log.error('Plugin %s not found (recognized: %s)', 
+            _log.error('Plugin %s not found (recognized: %s)',
                 plugin_name, str(list(self.plugins.keys()))
             )
             return dict()
@@ -744,8 +744,8 @@ class MDTFArgParser(argparse.ArgumentParser):
     - Customized help text formatting provided by :class:`.CustomHelpFormatter`.
     - Recording whether the user specified each argument value, or whether the
       default was used, via :class:`.RecordDefaultsAction`.
-    - Better bookkeeping of `argument groups 
-      <https://docs.python.org/3.7/library/argparse.html#argument-groups>`__, 
+    - Better bookkeeping of `argument groups
+      <https://docs.python.org/3.7/library/argparse.html#argument-groups>`__,
       e.g. which arguments belong to which group.
     """
     def __init__(self, *args, **kwargs):
@@ -767,8 +767,8 @@ class MDTFArgParser(argparse.ArgumentParser):
         return argv
 
     def iter_actions(self):
-        """Iterator over :py:class:`~argparse.Action` objects associated with 
-        all user-defined arguments in parser, as well as those for any 
+        """Iterator over :py:class:`~argparse.Action` objects associated with
+        all user-defined arguments in parser, as well as those for any
         subcommands.
         """
         def _iter_all_actions():
@@ -781,13 +781,13 @@ class MDTFArgParser(argparse.ArgumentParser):
                     yield act
 
         def _pred(act):
-            return not isinstance(act, 
+            return not isinstance(act,
                 (argparse._HelpAction, argparse._VersionAction))
 
         return filter(_pred, _iter_all_actions())
 
     def _set_is_default(self, parsed_args):
-        """Populates the ``is_default`` attribute based on whether the user 
+        """Populates the ``is_default`` attribute based on whether the user
         explicitly specified a value, or whether a default was used.
 
         Args:
@@ -799,21 +799,21 @@ class MDTFArgParser(argparse.ArgumentParser):
                 default_value_flag = act.dest + act.default_value_suffix
                 if default_value_flag in parsed_args:
                     self.is_default[act.dest] = False
-                    # delete the flag set by RecordDefaultsAction.__call__, 
+                    # delete the flag set by RecordDefaultsAction.__call__,
                     # since we're transferring the information to is_default
                     del parsed_args[default_value_flag]
                 else:
                     self.is_default[act.dest] = True
             else:
                 # check if value is equal to default; doesn't handle the case
-                # where the user set the option equal to its default value 
+                # where the user set the option equal to its default value
                 # (which is why RecordDefaultsAction is necessary.)
                 self.is_default[act.dest] = (act.dest is act.default)
 
     def _call_actions_on_defaults(self, namespace):
         """Subclasses of :py:class:`argparse.Action` are only called on
-        user-supplied values, not default values. If the ``call_on_defaults`` 
-        flag has been set on our custom actions, call the action on default 
+        user-supplied values, not default values. If the ``call_on_defaults``
+        flag has been set on our custom actions, call the action on default
         values to do the same parsing for default values that we would've done
         for user input.
         """
@@ -823,8 +823,8 @@ class MDTFArgParser(argparse.ArgumentParser):
                 act(self, namespace, values, None)
 
     def _default_argv(self, parsed_args):
-        """Utility method returning the arguments passed to the parser for 
-        lowest-priority defaults in 
+        """Utility method returning the arguments passed to the parser for
+        lowest-priority defaults in
         :meth:`.MDTFArgParser.parse_known_args`.
         """
         config = CLIConfigManager()
@@ -834,14 +834,14 @@ class MDTFArgParser(argparse.ArgumentParser):
     def parse_known_args(self, args=None, namespace=None):
         """Wrapper for :py:meth:`~argparse.ArgumentParser.parse_known_args` which
         handles intermediate levels of default settings derived from the
-        user's settings files. These override defaults defined in the parser 
+        user's settings files. These override defaults defined in the parser
         itself. The precedence order is:
 
-        1. Argument values explictly given by the user on the command line, as 
+        1. Argument values explictly given by the user on the command line, as
            recorded in the ``is_default`` attribute of :class:`.MDTFArgParser`.
         2. Argument values from a file the user gave via the ``-f`` flag.
            (CLIConfigManager.defaults[DefaultsFileTypes.USER]).
-        3. Argument values specified as the default values in the argument 
+        3. Argument values specified as the default values in the argument
            parser, which in turn are set with the following precedence order:
 
            a. Default values from a site-specfic file (defaults.jsonc), stored in
@@ -851,15 +851,15 @@ class MDTFArgParser(argparse.ArgumentParser):
            c. Default values hard-coded in the CLI definition file itself.
 
         Args:
-            args (optional): String or list of strings to parse. If a single 
-                string is passed, it's split using :py:meth:`shlex.split`. 
+            args (optional): String or list of strings to parse. If a single
+                string is passed, it's split using :py:meth:`shlex.split`.
                 If not supplied, the default behavior parses :py:meth:`sys.argv`.
-            namespace (optional): An object to store the parsed arguments. 
+            namespace (optional): An object to store the parsed arguments.
                 The default is a new empty :py:class:`argparse.Namespace` object.
 
         Returns:
-            Tuple of 1) populated namespace containing parsed arguments and 2) 
-            unrecognized arguments, as with 
+            Tuple of 1) populated namespace containing parsed arguments and 2)
+            unrecognized arguments, as with
             :py:meth:`argparse.ArgumentParser.parse_known_args`.
         """
         def _to_dict(ns):
@@ -881,7 +881,7 @@ class MDTFArgParser(argparse.ArgumentParser):
         parsed_args = _to_dict(parsed_args)
         self._set_is_default(parsed_args)
         # Highest priority: options that were explicitly set by user on CLI
-        # Note that is_default[opt] = None (not True or False) if no default 
+        # Note that is_default[opt] = None (not True or False) if no default
         # value is defined for that option.
         user_cli_opts = {k:v for k,v in parsed_args.items() \
             if not self.is_default.get(k, True)}
@@ -919,7 +919,7 @@ class MDTFArgParser(argparse.ArgumentParser):
 
 class MDTFArgPreparser(MDTFArgParser):
     """Parser class used to "preparse" plugin selector arguments, to determine
-    which plugins to use. Plugin selector arguments are identified by having 
+    which plugins to use. Plugin selector arguments are identified by having
     their ``action`` set to :class:`.PluginArgAction`.
     """
     def __init__(self):
@@ -944,7 +944,7 @@ class MDTFArgPreparser(MDTFArgParser):
         keys = [act.dest for act in self.iter_actions() \
             if isinstance(act, PluginArgAction)]
         return {k: d.get(k, None) for k in keys}
-            
+
 
 class MDTFTopLevelArgParser(MDTFArgParser):
     """Class for constructing the command-line interface, parsing the options,
@@ -960,7 +960,7 @@ class MDTFTopLevelArgParser(MDTFArgParser):
             self.argv = sys.argv[1:]
         else:
             self.argv = self.split_args(argv)
-        
+
         self.file_case_list = []
         self.config = dict()
         self.log_config = dict()
@@ -980,7 +980,7 @@ class MDTFTopLevelArgParser(MDTFArgParser):
     def iter_group_actions(self, subcommand=None, group=None):
         groups = util.to_iter(group)
         for arg_gp in self.iter_arg_groups(subcommand=subcommand):
-            if groups: 
+            if groups:
                 if arg_gp.title in groups:
                     yield from arg_gp.arguments
             else:
@@ -988,7 +988,7 @@ class MDTFTopLevelArgParser(MDTFArgParser):
 
     def add_input_file_arg(self, target_p):
         """Convenience method to add the flag to pass a user-designated defaults
-        file to the parser ``target_p`` (either the top-level parser, or the 
+        file to the parser ``target_p`` (either the top-level parser, or the
         preparser.)
         """
         kwargs = {'type': str}
@@ -996,26 +996,26 @@ class MDTFTopLevelArgParser(MDTFArgParser):
             kwargs.update({
                 'metavar': "INPUT_FILE",
                 'help': word_wrap("""
-                    Path to a user configuration file that sets options listed 
-                    here. This can be a JSONC file of the form given in 
-                    sample_input.jsonc, or a text file containing command-line 
-                    arguments. Options set explicitly on the command line will 
+                    Path to a user configuration file that sets options listed
+                    here. This can be a JSONC file of the form given in
+                    sample_input.jsonc, or a text file containing command-line
+                    arguments. Options set explicitly on the command line will
                     still override settings in this file.
                 """)
-            })     
+            })
         target_p.add_argument('--input_file', '--input-file', '-f', **kwargs)
 
     def init_user_defaults(self):
         """Set user defaults using values read in from a configuration
-        file in one of two formats. 
-        
+        file in one of two formats.
+
         Args:
             config_str (str): contents of the configuration file, either:
 
             1. A JSON/JSONC file of key-value pairs. This is parsed using
                 :func:`~src.util.filesystem.parse_json`.
             2. A plain text file containing flags and arguments as they would
-                be passed on the command line (except shell expansions are not 
+                be passed on the command line (except shell expansions are not
                 performed). This is parsed by the :meth:`MDTFArgParser.parse_args`
                 method of the configured parser.
 
@@ -1061,24 +1061,24 @@ class MDTFTopLevelArgParser(MDTFArgParser):
 
     def add_site_arg(self, target_p):
         """Convenience method to add the argument flag to select which
-        site-specific code to use, to the parser ``target_p`` (either the 
+        site-specific code to use, to the parser ``target_p`` (either the
         top-level parser, or the preparser.)
         """
         config = CLIConfigManager()
         kwargs = {'default': config.default_site, 'nargs': 1}
-        
+
         if isinstance(target_p, MDTFTopLevelArgParser):
             kwargs.update({
                 'choices': self.sites,
                 'help': word_wrap(f"""
-                    Site-specific functionality to use. Options below are 
+                    Site-specific functionality to use. Options below are
                     specific to the selected value '{self.site}'.
                 """)
             })
         target_p.add_argument('--site', '-s', **kwargs)
 
     def init_site(self):
-        """We allow site-specific installations to customize the CLI, so before 
+        """We allow site-specific installations to customize the CLI, so before
         we construct the CLI parser we need to determine what site to use. We do
         this by running a parser that only looks for the ``--site`` flag.
 
@@ -1092,7 +1092,7 @@ class MDTFTopLevelArgParser(MDTFArgParser):
         self.sites = [d for d in os.listdir(config.sites_dir) \
             if os.path.isdir(os.path.join(config.sites_dir, d)) \
                 and not d.startswith(('.','_'))]
-        # TODO: if we're checking to see if installer has been run, only set 
+        # TODO: if we're checking to see if installer has been run, only set
         # self.installed = True if default_site in self.sites
         self.installed = True
 
@@ -1101,7 +1101,7 @@ class MDTFTopLevelArgParser(MDTFArgParser):
         site = util.from_iter(site_p.parse_site(self.argv, default_site))
         if site not in self.sites \
             and not (site == default_site and not self.installed):
-            _log.critical("Requested site %s not found in sites directory %s.", 
+            _log.critical("Requested site %s not found in sites directory %s.",
                 site, config.sites_dir)
             exit(2) # exit code for  CLI syntax error
         config.default_site = default_site
@@ -1110,7 +1110,7 @@ class MDTFTopLevelArgParser(MDTFArgParser):
         config.read_defaults(DefaultsFileTypes.SITE)
 
     def add_contents(self, target_p):
-        """Convenience method to fully configure a parser ``target_p`` (either 
+        """Convenience method to fully configure a parser ``target_p`` (either
         the top-level parser, or the preparser), adding subparsers for all
         subcommands.
         """
@@ -1122,8 +1122,8 @@ class MDTFTopLevelArgParser(MDTFArgParser):
         cmd.cli.configure(target_p)
 
     def setup(self):
-        """Method to wrap all configuration methods needed to configure the 
-        parser before calling parse_arg: reading the defaults files and 
+        """Method to wrap all configuration methods needed to configure the
+        parser before calling parse_arg: reading the defaults files and
         configuring plugins based on existing values.
         """
         config = CLIConfigManager()
@@ -1144,9 +1144,9 @@ class MDTFTopLevelArgParser(MDTFArgParser):
         self.configure()
 
     def configure(self):
-        """Method that assembles the top-level CLI parser. Options specific to 
-        the script are hard-coded here; CLI options for each subcommand are 
-        given in jsonc configuration files for each command which are read in 
+        """Method that assembles the top-level CLI parser. Options specific to
+        the script are hard-coded here; CLI options for each subcommand are
+        given in jsonc configuration files for each command which are read in
         here. See associated documentation for :class:`~src.cli.MDTFArgParser`
         for information on the configuration file mechanism.
         """
@@ -1155,7 +1155,7 @@ class MDTFTopLevelArgParser(MDTFArgParser):
             usage="%(prog)s [options] [CASE_ROOT_DIR]",
             description=word_wrap("""
                 Driver script for the NOAA Model Diagnostics Task Force (MDTF)
-                package, which runs process-oriented diagnostics (PODs) on climate 
+                package, which runs process-oriented diagnostics (PODs) on climate
                 model data. See documentation at https://mdtf-diagnostics.rtfd.io.
             """),
             add_help=True,
@@ -1198,7 +1198,7 @@ class MDTFTopLevelArgParser(MDTFArgParser):
 
         # finally parse the user's CLI arguments
         self.config = vars(self.parse_args(args))
-        # log use of site-wide default files here (not earlier, in case user 
+        # log use of site-wide default files here (not earlier, in case user
         # just wanted --help or --version)
         defaults_text = config.site_default_text()
         if defaults_text:
@@ -1221,8 +1221,8 @@ class MDTFTopLevelSubcommandArgParser(MDTFTopLevelArgParser):
     """
 
     def _default_argv(self, parsed_args):
-        """Utility method returning the arguments passed to the parser for 
-        lowest-priority defaults in 
+        """Utility method returning the arguments passed to the parser for
+        lowest-priority defaults in
         :meth:`.MDTFArgParser.parse_known_args`.
         """
         config = CLIConfigManager()
@@ -1232,7 +1232,7 @@ class MDTFTopLevelSubcommandArgParser(MDTFTopLevelArgParser):
         ]
 
     def add_contents(self, target_p):
-        """Convenience method to fully configure a parser ``target_p`` (either 
+        """Convenience method to fully configure a parser ``target_p`` (either
         the top-level parser, or the preparser), adding subparsers for all
         subcommands.
         """
@@ -1252,9 +1252,9 @@ class MDTFTopLevelSubcommandArgParser(MDTFTopLevelArgParser):
             cmd.cli.configure(cmd.parser)
 
     def configure(self):
-        """Method that assembles the top-level CLI parser. Options specific to 
-        the script are hard-coded here; CLI options for each subcommand are 
-        given in jsonc configuration files for each command which are read in 
+        """Method that assembles the top-level CLI parser. Options specific to
+        the script are hard-coded here; CLI options for each subcommand are
+        given in jsonc configuration files for each command which are read in
         here. See associated documentation for :class:`~src.cli.MDTFArgParser`
         for information on the configuration file mechanism.
         """

--- a/src/cli_plugins.jsonc
+++ b/src/cli_plugins.jsonc
@@ -1,6 +1,6 @@
 // Configuration of CLI plugins for code provided in /src. These options are
 // spliced into the CLI configuration in src/cli_template.jsonc. The contents of
-// both of these files may be overridden by configuration in /sites if a 
+// both of these files may be overridden by configuration in /sites if a
 // site-specific installation is selected.
 //
 {

--- a/src/cli_subcommands.jsonc
+++ b/src/cli_subcommands.jsonc
@@ -1,5 +1,5 @@
 // Configuration for the top-level subcommands offered by the mdtf.py driver
-// script. This is read by MDTFSubcommandDispatch. 
+// script. This is read by MDTFSubcommandDispatch.
 //
 // DO NOT modify this file. Instead, run 'mdtf install', which will generate a
 // copy in /sites which you can edit.
@@ -7,7 +7,7 @@
 // All text to the right of an unquoted "//" is a comment and ignored, as well
 // as blank lines (JSONC quasi-standard.)
 {
-  "title": "COMMANDS", 
+  "title": "COMMANDS",
   "description": "Subcommand functionality. Use '%(prog)s <command> --help' to get help on options specific to each command.",
   "help": null,
   "metavar": "<command> is one of:",

--- a/src/cli_template.jsonc
+++ b/src/cli_template.jsonc
@@ -1,11 +1,11 @@
 // Configuration for command-line arguments for MDTF-diagnostics driver script.
-// This is used by install.py to generate cli.jsonc. 
+// This is used by install.py to generate cli.jsonc.
 // DO NOT modify this file. Instead, edit cli.jsonc.
 //
-// Entries here are used in framework/cli.py to configure command-line options 
+// Entries here are used in framework/cli.py to configure command-line options
 // accepted by the script. Syntax is based on python's argparse library, see
-// https://docs.python.org/2.7/library/argparse.html or 
-// https://docs.python.org/2.7/howto/argparse.html. 
+// https://docs.python.org/2.7/library/argparse.html or
+// https://docs.python.org/2.7/howto/argparse.html.
 //
 // All text to the right of an unquoted "//" is a comment and ignored, as well
 // as blank lines (JSONC quasi-standard.)
@@ -141,14 +141,14 @@
           "name": "verbose",
           "short_name": "v",
           "help": "Increase console log verbosity level. -v prints debug information.",
-          "default" : 0, 
-          "action": "count" 
+          "default" : 0,
+          "action": "count"
         },{
           "name": "quiet",
           "short_name": "q",
           "help": "Decrease console log verbosity level. -q prints warnings only, -qq prints errors only, and -qqq prints no output.",
-          "default" : 0, 
-          "action": "count" 
+          "default" : 0,
+          "action": "count"
         },{
           "name": "file_transfer_timeout",
           "help": "Time (in seconds) to wait before giving up on transferring a data file to the local filesystem. Set to zero to disable.",

--- a/src/cmip6.py
+++ b/src/cmip6.py
@@ -1,10 +1,10 @@
 """Code to parse CMIP6 controlled vocabularies and elements of the CMIP6 DRS.
 
-Specifications for the above were taken from the planning document 
-`<http://goo.gl/v1drZl>`__, which doesn't seem to have a permanent link. The 
+Specifications for the above were taken from the planning document
+`<http://goo.gl/v1drZl>`__, which doesn't seem to have a permanent link. The
 CMIP6 controlled vocabularies (lists of registered MIPs, modeling centers, etc.)
-are derived from data in the 
-`PCMDI/cmip6-cmor-tables <https://github.com/PCMDI/cmip6-cmor-tables>`__ 
+are derived from data in the
+`PCMDI/cmip6-cmor-tables <https://github.com/PCMDI/cmip6-cmor-tables>`__
 repo, which is included as a subtree under ``/data``.
 
 .. warning::
@@ -23,7 +23,7 @@ class CMIP6_CVs(util.Singleton):
     """Interface for looking up information from the CMIP6 CV file.
 
     .. note::
-       Lookups are implemented in an ad-hoc way with :class:`util.MultiMap`; a 
+       Lookups are implemented in an ad-hoc way with :class:`util.MultiMap`; a
        more robust solution would use sqlite.
     """
     def __init__(self, unittest=False):
@@ -33,7 +33,7 @@ class CMIP6_CVs(util.Singleton):
             file_ = 'dummy_filename'
         else:
             paths = core.PathManager()
-            file_ = os.path.join(paths.CODE_ROOT, 'data', 
+            file_ = os.path.join(paths.CODE_ROOT, 'data',
                 'cmip6-cmor-tables','Tables','CMIP6_CV.json')
         self._contents = util.read_json(file_)
         self._contents = self._contents['CV']
@@ -51,7 +51,7 @@ class CMIP6_CVs(util.Singleton):
         self._lookups = dict()
 
     def _make_cv(self):
-        """Populate the *cv* attribute of :class:`CMIP6_CVs` with the tables 
+        """Populate the *cv* attribute of :class:`CMIP6_CVs` with the tables
         read in during __init__().
 
         Do this on-demand rather than in __init__, in case this information isn't
@@ -68,10 +68,10 @@ class CMIP6_CVs(util.Singleton):
 
         Args:
             category (str): the CV category to use to validate values.
-            items (str or list of str): Entries whose validity we'd like to 
+            items (str or list of str): Entries whose validity we'd like to
                 check.
 
-        Returns: boolean or list of booleans, corresponding to the validity of 
+        Returns: boolean or list of booleans, corresponding to the validity of
             the entries in *items*.
         """
         self._make_cv()
@@ -117,7 +117,7 @@ class CMIP6_CVs(util.Singleton):
         """Lookup the corresponding *dest* values for *source_items* (keys).
 
         Args:
-            source_items (str or list): one or more keys 
+            source_items (str or list): one or more keys
             source (str): the CV category that the items in *source_items*
                 belong to.
             dest (str): the CV category we'd like the corresponding values for.
@@ -132,7 +132,7 @@ class CMIP6_CVs(util.Singleton):
 
     def lookup_single(self, source_item, source, dest):
         """The same as :meth:`lookup`, but perform lookup for a single
-        *source_item*, and raise KeyError if the number of values returned is 
+        *source_item*, and raise KeyError if the number of values returned is
         != 1.
         """
         _lookup = self.get_lookup(source, dest)
@@ -147,15 +147,15 @@ class CMIP6_CVs(util.Singleton):
     # ----------------------------------
 
     def table_id_from_freq(self, frequency):
-        """Specialized lookup to determine which MIP tables use data at the 
+        """Specialized lookup to determine which MIP tables use data at the
         requested *frequency*.
 
         Should really be handled as a special case of :meth:`lookup`.
 
         Args:
-            frequency (:class:`CMIP6DateFrequency`): DateFrequency 
+            frequency (:class:`CMIP6DateFrequency`): DateFrequency
 
-        Returns: list of MIP table ``table_id`` names, if any, that use data at 
+        Returns: list of MIP table ``table_id`` names, if any, that use data at
             the given *frequency*.
         """
         self._make_cv()
@@ -178,7 +178,7 @@ class CMIP6DateFrequency(util.DateFrequency):
         'fx': 0, 'yr': 1, 'mo': 2, 'day': 3,
         'hr': 5, # includes minutes
         'min': 6, # = subhr, minutes and seconds
-        }  
+        }
     _regex = re.compile(r"""
         ^
         (?P<quantity>(1|3|6)?)
@@ -187,7 +187,7 @@ class CMIP6DateFrequency(util.DateFrequency):
         $
     """, re.VERBOSE)
 
-    @classmethod    
+    @classmethod
     def _parse_input_string(cls, quantity, unit):
         if not quantity:
             match = re.match(cls._regex, unit)
@@ -212,7 +212,7 @@ class CMIP6DateFrequency(util.DateFrequency):
                 md['quantity'] = 1
             else:
                 md['quantity'] = int(md['quantity'])
-            
+
             if not md['avg']:
                 md['avg'] = 'Mean'
             elif md['avg'] in ['C', 'CM']:
@@ -246,7 +246,7 @@ class CMIP6DateFrequency(util.DateFrequency):
                 return s + 'CM'
             else:
                 return s + 'C'
-        else: 
+        else:
             raise ValueError("Malformed data {} {}".format(self.quantity, self.unit))
     __str__ = format
 
@@ -268,11 +268,11 @@ variant_label_regex = util.RegexPattern(r"""
 )
 @util.regex_dataclass(variant_label_regex)
 class CMIP6_VariantLabel():
-    """Dataclass which represents and parses the CMIP6 DRS variant label identifier 
+    """Dataclass which represents and parses the CMIP6 DRS variant label identifier
     string.
-    
+
     References: `<https://earthsystemcog.org/projects/wip/mip_table_about>`__,
-    although this doesn't document all cases used in CMIP6. See also note 8 on 
+    although this doesn't document all cases used in CMIP6. See also note 8 on
     page 9 of `<http://goo.gl/v1drZl>`__.
     """
     variant_label: str = util.MANDATORY
@@ -328,7 +328,7 @@ class CMIP6_MIPTable():
             self.region = 'Antarctica'
         elif self.table_suffix == 'g':
             self.region = 'Greenland'
-        else: 
+        else:
             self.region = None
 
 grid_label_regex = util.RegexPattern(r"""
@@ -370,7 +370,7 @@ class CMIP6_GridLabel():
             self.region = 'Antarctica'
         elif self.region == 'g':
             self.region = 'Greenland'
-        else: 
+        else:
             self.region = None
 
 drs_directory_regex = util.RegexPattern(r"""
@@ -391,7 +391,7 @@ drs_directory_regex = util.RegexPattern(r"""
 )
 @util.regex_dataclass(drs_directory_regex)
 class CMIP6_DRSDirectory(CMIP6_VariantLabel, CMIP6_MIPTable, CMIP6_GridLabel):
-    """Dataclass which represents and parses the DRS directory, using regex 
+    """Dataclass which represents and parses the DRS directory, using regex
     defined above.
 
     Reference: `<http://goo.gl/v1drZl>`__, page 17.
@@ -438,7 +438,7 @@ drs_filename_regex = util.ChainedRegexPattern(
 )
 @util.regex_dataclass(drs_filename_regex)
 class CMIP6_DRSFilename(CMIP6_VariantLabel, CMIP6_MIPTable, CMIP6_GridLabel):
-    """Dataclass which represents and parses the DRS filename, using regex 
+    """Dataclass which represents and parses the DRS filename, using regex
     defined above.
 
     Reference: `<http://goo.gl/v1drZl>`__, page 14-15.
@@ -457,7 +457,7 @@ class CMIP6_DRSFilename(CMIP6_VariantLabel, CMIP6_MIPTable, CMIP6_GridLabel):
     def __post_init__(self, *args):
         if self.start_date == util.FXDateMin \
             and self.end_date == util.FXDateMax:
-            # Assume we're dealing with static/fx-frequency data, so use special 
+            # Assume we're dealing with static/fx-frequency data, so use special
             # placeholder values
             self.date_range = util.FXDateRange
             if not self.frequency.is_static: # frequency inferred from table_id
@@ -483,4 +483,3 @@ class CMIP6_DRSPath(CMIP6_DRSDirectory, CMIP6_DRSFilename):
     directory: CMIP6_DRSDirectory = ""
     filename: CMIP6_DRSFilename = ""
 
-    

--- a/src/conda/conda_env_setup.sh
+++ b/src/conda/conda_env_setup.sh
@@ -5,21 +5,21 @@
 set -Eeo pipefail
 # Enable extended globbing, see
 # https://www.gnu.org/software/bash/manual/bashref.html#Pattern-Matching
-shopt -s extglob 
+shopt -s extglob
 
-# get directory this script is located in, resolving any 
+# get directory this script is located in, resolving any
 # symlinks/aliases (https://stackoverflow.com/a/246128)
 _source="${BASH_SOURCE[0]}"
 while [ -h "$_source" ]; do # resolve $_source until the file is no longer a symlink
     script_dir="$( cd -P "$( dirname "$_source" )" >/dev/null 2>&1 && pwd )"
     _source="$( readlink "$_source" )"
-    # if $_source was a relative symlink, we need to resolve it relative to the 
+    # if $_source was a relative symlink, we need to resolve it relative to the
     # path where the symlink file was located
-    [[ $_source != /* ]] && _source="$script_dir/$_source" 
+    [[ $_source != /* ]] && _source="$script_dir/$_source"
 done
 script_dir="$( cd -P "$( dirname "$_source" )" >/dev/null 2>&1 && pwd )"
 
-# relative paths resolved relative to repo directory, which is grandparent 
+# relative paths resolved relative to repo directory, which is grandparent
 # of dir this script is in
 repo_dir="$( cd -P "$script_dir" >/dev/null 2>&1 && cd ../../ && pwd )"
 
@@ -38,7 +38,7 @@ while (( "$#" )); do
             ;;
         -e|--env)
             # specify one env by name
-            env_glob="env_${2}.yml" 
+            env_glob="env_${2}.yml"
             if [ ! -f "${script_dir}/${env_glob}" ]; then
                 echo "ERROR: ${script_dir}/${env_glob} not found."
                 exit 1
@@ -47,7 +47,7 @@ while (( "$#" )); do
             ;;
         --dev-only)
             # dev and base only (for Travis CI/ auto testing)
-            env_glob="env_@(base|dev).yml" 
+            env_glob="env_@(base|dev).yml"
             shift 1
             ;;
         --all-dev)
@@ -114,7 +114,7 @@ if [ "$make_envs" = "true" ]; then
         echo "To use envs interactively, run \"conda config --append envs_dirs $_CONDA_ENV_ROOT\""
     fi
 
-    # install envs with mamba (https://github.com/mamba-org/mamba) for 
+    # install envs with mamba (https://github.com/mamba-org/mamba) for
     # performance reasons; need to find mamba executable, or install it if not
     # present
     _INSTALL_EXE=$( command -v mamba ) || true
@@ -137,7 +137,7 @@ if [ "$make_envs" = "true" ]; then
     "$_INSTALL_EXE" clean -qi
     for env_file in "${script_dir}/"${env_glob}; do
         [ -e "$env_file" ] || continue # catch the case where nothing matches
-        # get env name from reading "name:" attribute of yaml file 
+        # get env name from reading "name:" attribute of yaml file
         env_name=$( sed -n "s/^[[:space:]]*name:[[:space:]]*\([[:alnum:]_\-]*\)[[:space:]]*/\1/p" "$env_file" )
         if [ -z "$_CONDA_ENV_ROOT" ]; then
             # need to set manually, otherwise mamba will install in a subdir

--- a/src/conda/conda_init.sh
+++ b/src/conda/conda_init.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-# This is a workaround to permit switching conda environments in a 
+# This is a workaround to permit switching conda environments in a
 # non-interactive shell.
-# The script is what's placed in ~/.bashrc by 'conda init bash'; 
-# this doesn't get sourced by bash in non-interactive mode so we have to 
+# The script is what's placed in ~/.bashrc by 'conda init bash';
+# this doesn't get sourced by bash in non-interactive mode so we have to
 # do it manually. See https://github.com/conda/conda/issues/7980 .
 
-# NOTE this has only been tested with conda 4.7.10 and later; I know earlier 
+# NOTE this has only been tested with conda 4.7.10 and later; I know earlier
 # versions had things in different places.
 
 # parse aruments manually
@@ -64,10 +64,10 @@ if [ ! -d "$_CONDA_ROOT" ]; then
         if [ $_v -eq 2 ]; then echo "CONDA_ROOT set from environment"; fi
     fi
 fi
-# if not, run user's shell in interactive mode. Subshell output could have 
+# if not, run user's shell in interactive mode. Subshell output could have
 # arbitrary text output in it, since user's init scripts may be setting prompt
-# and generating output in any number of ways. We try to extract the paths by 
-# delimiting them with (hopefully uncommon) vertical tab characters (\v) and 
+# and generating output in any number of ways. We try to extract the paths by
+# delimiting them with (hopefully uncommon) vertical tab characters (\v) and
 # using awk to extract whatever text is found between those two field separators.
 if [ ! -d "$_CONDA_ROOT" ]; then
     if [ $_v -eq 2 ]; then echo "Setting conda from $SHELL -i"; fi

--- a/src/conda/env_dev.yml
+++ b/src/conda/env_dev.yml
@@ -1,4 +1,4 @@
-# Conda environment for development work. 
+# Conda environment for development work.
 name: _MDTF_dev
 channels:
 - conda-forge

--- a/src/conflict_resolution.py
+++ b/src/conflict_resolution.py
@@ -24,7 +24,7 @@ def require_all_same(option_dict, option_fn, tiebreaker_fn=None):
 
 def same_for_subsets(option_dict, subsets, option_fn, tiebreaker_fn=None):
     if set(option_dict) != set(k for k in chain.from_iterable(subsets)):
-        raise AssertionError('Union of subsets is different than set of all keys.')   
+        raise AssertionError('Union of subsets is different than set of all keys.')
 
     choices = dict.fromkeys(option_dict)
     for subset in subsets:
@@ -49,14 +49,14 @@ def minimum_cover(option_dict, option_fn, tiebreaker_fn=None):
     """Determine experiment component(s) from heuristics.
 
     1. Pick all data from the same component if possible, and from as few
-        components if not. See `<https://en.wikipedia.org/wiki/Set_cover_problem>`__ 
+        components if not. See `<https://en.wikipedia.org/wiki/Set_cover_problem>`__
         and `<http://www.martinbroadhurst.com/greedy-set-cover-in-python.html>`__.
 
-    2. If multiple components satisfy (1) equally well, use a tie-breaking 
-        heuristic (:meth:`~gfdl.GfdlppDataManager._component_tiebreaker`). 
+    2. If multiple components satisfy (1) equally well, use a tie-breaking
+        heuristic (:meth:`~gfdl.GfdlppDataManager._component_tiebreaker`).
 
     Args:
-        datasets (iterable of :class:`~data_manager.DataSetBase`): 
+        datasets (iterable of :class:`~data_manager.DataSetBase`):
             Collection of all variables being requested in this DataManager.
 
     Returns: :py:obj:`list` of :py:obj:`str`: name(s) of model components to use.
@@ -96,7 +96,7 @@ def minimum_cover(option_dict, option_fn, tiebreaker_fn=None):
         covered_idx.update(d[elt_to_add])
     assert cover # is not empty
     print("\tDEBUG min_cover:", cover)
-    
+
     choices = dict.fromkeys(option_dict)
     for k in option_dict:
         choices[k] = tiebreaker_fn(

--- a/src/core.py
+++ b/src/core.py
@@ -1,4 +1,4 @@
-"""Common functions and classes used in multiple places in the MDTF code. 
+"""Common functions and classes used in multiple places in the MDTF code.
 """
 import os
 import collections
@@ -35,7 +35,7 @@ class MDTFFramework(object):
             _log.critical("Framework caught exception %r", exc)
             print(''.join(wrapped_exc.format()))
             exit(1)
-        
+
     def configure(self, cli_obj, pod_info_tuple, log_config):
         """Wrapper for all configuration done based on CLI arguments.
         """
@@ -43,7 +43,7 @@ class MDTFFramework(object):
         self.dispatch_classes(cli_obj)
         self.parse_mdtf_args(cli_obj, pod_info_tuple)
         # init singletons
-        config = ConfigManager(cli_obj, pod_info_tuple, 
+        config = ConfigManager(cli_obj, pod_info_tuple,
             self.global_env_vars, self.case_list, log_config)
         paths = PathManager(cli_obj)
         self.verify_paths(config, paths)
@@ -121,7 +121,7 @@ class MDTFFramework(object):
                 _log.error("POD identifier '%s' not recognized.", arg)
                 bad_args.append(arg)
 
-        if bad_args: 
+        if bad_args:
             valid_args = ['all', 'examples'] \
                 + pod_info_tuple.sorted_realms \
                 + pod_info_tuple.sorted_pods
@@ -146,7 +146,7 @@ class MDTFFramework(object):
         if 'CASENAME' in d and d['CASENAME']:
             # defined case from CLI
             cli_d = self._populate_from_cli(cli_obj, 'MODEL')
-            if 'CASE_ROOT_DIR' not in cli_d and d.get('root_dir', None): 
+            if 'CASE_ROOT_DIR' not in cli_d and d.get('root_dir', None):
                 # CASE_ROOT was set positionally
                 cli_d['CASE_ROOT_DIR'] = d['root_dir']
             case_list_in = [cli_d]
@@ -198,7 +198,7 @@ class MDTFFramework(object):
             return self.parse_pod_list(case['pod_list'], pod_info_tuple)
 
     def verify_paths(self, config, p):
-        # needs to be here, instead of PathManager, because we subclass it in 
+        # needs to be here, instead of PathManager, because we subclass it in
         # NOAA_GFDL
         keep_temp = config.get('keep_temp', False)
         # clean out WORKING_DIR if we're not keeping temp files:
@@ -214,8 +214,8 @@ class MDTFFramework(object):
 
     def _print_config(self, cli_obj, config, paths):
         """Log end result of parsing package settings. This is only for the user's
-        benefit; a machine-readable version which is usable for 
-        provenance/reproducibilityis saved by the OutputManager as 
+        benefit; a machine-readable version which is usable for
+        provenance/reproducibilityis saved by the OutputManager as
         config_save.jsonc.
         """
         d = dict()
@@ -240,7 +240,7 @@ class MDTFFramework(object):
     # --------------------------------------------------------------------
 
     def _failed(self):
-        """Overall success/failure of this run of the framework. Return True if 
+        """Overall success/failure of this run of the framework. Return True if
         any case or any POD has failed, else return False.
         """
         if not self.cases:
@@ -289,7 +289,7 @@ class MDTFFramework(object):
 
 
 class ConfigManager(util.Singleton, util.NameSpace):
-    def __init__(self, cli_obj=None, pod_info_tuple=None, global_env_vars=None, 
+    def __init__(self, cli_obj=None, pod_info_tuple=None, global_env_vars=None,
         case_list=None, log_config=None, unittest=False):
         self.update(cli_obj.config)
         if pod_info_tuple is None:
@@ -301,14 +301,14 @@ class ConfigManager(util.Singleton, util.NameSpace):
         else:
             self.global_env_vars = global_env_vars
         self.log_config = log_config
-        # copy srializable version of parsed settings, in order to write 
+        # copy srializable version of parsed settings, in order to write
         # backup config file
-        self.backup_config = copy.deepcopy(cli_obj.config) 
+        self.backup_config = copy.deepcopy(cli_obj.config)
         self.backup_config['case_list'] = copy.deepcopy(case_list)
 
 
 class PathManager(util.Singleton, util.NameSpace):
-    """:class:`~util.Singleton` holding the root directories for all paths used 
+    """:class:`~util.Singleton` holding the root directories for all paths used
     by the code.
     """
     def __init__(self, cli_obj=None, env_vars=None, unittest=False):
@@ -330,7 +330,7 @@ class PathManager(util.Singleton, util.NameSpace):
         if not self.OUTPUT_DIR:
             self.OUTPUT_DIR = self.WORKING_DIR
 
-        # set as attribute any CLI setting that has "action": "PathAction" 
+        # set as attribute any CLI setting that has "action": "PathAction"
         # in its definition in the .jsonc file
         cli_paths = [act.dest for act in cli_obj.iter_actions() \
             if isinstance(act, cli.PathAction)]
@@ -374,8 +374,8 @@ class PathManager(util.Singleton, util.NameSpace):
         d.MODEL_WK_DIR = os.path.join(self.WORKING_DIR, case_wk_dir)
         d.MODEL_OUT_DIR = os.path.join(self.OUTPUT_DIR, case_wk_dir)
         if not overwrite:
-            # bump both WK_DIR and OUT_DIR to same version because name of 
-            # former may be preserved when we copy to latter, depending on 
+            # bump both WK_DIR and OUT_DIR to same version because name of
+            # former may be preserved when we copy to latter, depending on
             # copy method
             d.MODEL_WK_DIR, ver = util.bump_version(
                 d.MODEL_WK_DIR, extra_dirs=[self.OUTPUT_DIR])
@@ -444,8 +444,8 @@ class TempDirManager(util.Singleton):
 
 @util.mdtf_dataclass
 class TranslatedVarlistEntry(data_model.DMVariable):
-    """Class returned by VarlistTranslator.lookup_variable(). Marks some 
-    attributes inherited from DMVariable as participating in 
+    """Class returned by VarlistTranslator.lookup_variable(). Marks some
+    attributes inherited from DMVariable as participating in
     DataSource.query_dataset().
     """
     # to be more correct, we should probably have VarlistTranslator return a
@@ -482,7 +482,7 @@ class FieldlistEntry(data_model.DMDependentVariable):
         1: ('PLACEHOLDER_T_COORD'),
         2: ('PLACEHOLDER_Y_COORD', 'PLACEHOLDER_X_COORD'),
         3: ('PLACEHOLDER_T_COORD', 'PLACEHOLDER_Y_COORD', 'PLACEHOLDER_X_COORD'),
-        4: ('PLACEHOLDER_T_COORD', 'PLACEHOLDER_Z_COORD', 'PLACEHOLDER_Y_COORD', 
+        4: ('PLACEHOLDER_T_COORD', 'PLACEHOLDER_Z_COORD', 'PLACEHOLDER_Y_COORD',
             'PLACEHOLDER_X_COORD')
     }
     _placeholder_class_dict = {
@@ -497,7 +497,7 @@ class FieldlistEntry(data_model.DMDependentVariable):
         # if we only have ndim, map to axes names
         if 'dimensions' not in kwargs and 'ndim' in kwargs:
             kwargs['dimensions'] = cls._ndim_to_axes_set[kwargs.pop('ndim')]
-    
+
         # map dimension names to coordinate objects
         kwargs['coords'] = []
         if 'dimensions' not in kwargs or not kwargs['dimensions']:
@@ -541,11 +541,11 @@ class FieldlistEntry(data_model.DMDependentVariable):
                 c.value, c.units, c.axis, self.name, new_name)
         else:
             _log.debug(("Renaming %s slice of '%s' to '%s' (@ %s %s = %s %s)."),
-                c.axis, self.name, new_name, c.value, c.units, 
+                c.axis, self.name, new_name, c.value, c.units,
                 new_coord.value, new_coord.units
             )
         return new_name
-        
+
 @util.mdtf_dataclass
 class Fieldlist():
     """Class corresponding to a single variable naming convention (single file
@@ -575,7 +575,7 @@ class Fieldlist():
             return (d, temp_d)
 
         def _process_var(section_name, d, temp_d):
-            # build two-stage lookup table (by standard name, then data 
+            # build two-stage lookup table (by standard name, then data
             # dimensionality) -- should just make FieldlistEntry hashable
             section_d = d.pop(section_name, dict())
             for k,v in section_d.items():
@@ -604,7 +604,7 @@ class Fieldlist():
         return self.entries[name]
 
     def to_CF_name(self, name):
-        """Like :meth:`to_CF`, but only return the CF standard name, given the 
+        """Like :meth:`to_CF`, but only return the CF standard name, given the
         name in this convention.
         """
         return self.to_CF(name).standard_name
@@ -613,7 +613,7 @@ class Fieldlist():
         """Look up FieldlistEntry corresponding to the given standard name,
         optionally providing an axes_set to resolve ambiguity.
 
-        TODO: this is a hacky implementation; FieldlistEntry needs to be 
+        TODO: this is a hacky implementation; FieldlistEntry needs to be
         expanded with more ways to uniquely identify variable (eg cell methods).
         """
         if standard_name not in self.lut:
@@ -638,13 +638,13 @@ class Fieldlist():
         return copy.deepcopy(fl_entry)
 
     def from_CF_name(self, standard_name, axes_set=None):
-        """Like :meth:`from_CF`, but only return the variable's name in this 
+        """Like :meth:`from_CF`, but only return the variable's name in this
         convention.
         """
         return self.from_CF(standard_name, axes_set=axes_set).name
 
     def translate_coord(self, coord):
-        """Given a DMCoordinate, look up the corresponding translated DMCoordinate 
+        """Given a DMCoordinate, look up the corresponding translated DMCoordinate
         in this convention.
         """
         ax = coord.axis
@@ -663,21 +663,21 @@ class Fieldlist():
                 raise KeyError((f"Coordinate {coord.name} with standard name "
                     f"'{coord.standard_name}' not defined in convention '{self.name}'."))
             new_coord = lut1[coord.standard_name]
-        
+
         if hasattr(coord, 'is_scalar') and coord.is_scalar:
             new_coord = copy.deepcopy(new_coord)
             new_coord.value = units.convert_scalar_coord(coord, new_coord.units)
         else:
-            new_coord = dc.replace(coord, 
+            new_coord = dc.replace(coord,
                 **(util.filter_dataclass(new_coord, coord)))
         return new_coord
 
     def translate(self, var):
         """Returns TranslatedVarlistEntry instance, with populated coordinate
         axes. Units of scalar coord slices are translated to the units of the
-        conventions' coordinates. Includes logic to translate and rename scalar 
-        coords/slices, e.g. VarlistEntry for 'ua' (intrinsically 4D) @ 500mb 
-        could produce a TranslatedVarlistEntry for 'u500' (3D slice), depending 
+        conventions' coordinates. Includes logic to translate and rename scalar
+        coords/slices, e.g. VarlistEntry for 'ua' (intrinsically 4D) @ 500mb
+        could produce a TranslatedVarlistEntry for 'u500' (3D slice), depending
         on naming convention.
         """
         if var.use_exact_name:
@@ -688,7 +688,7 @@ class Fieldlist():
         else:
             fl_entry = self.from_CF(var.standard_name, var.axes_set)
             new_name = fl_entry.name
-        
+
         new_dims = [self.translate_coord(dim) for dim in var.dims]
         new_scalars = [self.translate_coord(dim) for dim in var.scalar_coords]
         if len(new_scalars) > 1:
@@ -700,14 +700,14 @@ class Fieldlist():
             new_name = fl_entry.scalar_name(var.scalar_coords[0], new_scalars[0])
 
         return util.coerce_to_dataclass(
-            fl_entry, TranslatedVarlistEntry, 
+            fl_entry, TranslatedVarlistEntry,
             name=new_name, coords=(new_dims + new_scalars), convention=self.name
         )
 
 
 class VariableTranslator(util.Singleton):
-    """:class:`~util.Singleton` containing information for different variable 
-    naming conventions. These are defined in the data/fieldlist_*.jsonc 
+    """:class:`~util.Singleton` containing information for different variable
+    naming conventions. These are defined in the data/fieldlist_*.jsonc
     files.
     """
     def __init__(self, code_root=None, unittest=False):
@@ -748,7 +748,7 @@ class VariableTranslator(util.Singleton):
             _log.debug("Using convention '%s' based on alias '%s'.",
                 self.aliases[conv_name], conv_name)
             return self.aliases[conv_name]
-        _log.error("Unrecognized variable name convention '%s'.", 
+        _log.error("Unrecognized variable name convention '%s'.",
             conv_name)
         raise KeyError(conv_name)
 
@@ -773,11 +773,11 @@ class VariableTranslator(util.Singleton):
         return self._fieldlist_method(conv_name, 'to_CF_name', name)
 
     def from_CF(self, conv_name, standard_name, axes_set=None):
-        return self._fieldlist_method(conv_name, 'from_CF', 
+        return self._fieldlist_method(conv_name, 'from_CF',
             standard_name, axes_set=axes_set)
 
     def from_CF_name(self, conv_name, standard_name, axes_set=None):
-        return self._fieldlist_method(conv_name, 'from_CF_name', 
+        return self._fieldlist_method(conv_name, 'from_CF_name',
             standard_name, axes_set=axes_set)
 
     def translate_coord(self, conv_name, coord):

--- a/src/diagnostic.py
+++ b/src/diagnostic.py
@@ -13,7 +13,7 @@ _var_name_env_var_suffix = '_var'
 _file_env_var_suffix = '_FILE'
 
 PodDataFileFormat = util.MDTFEnum(
-    'PodDataFileFormat', 
+    'PodDataFileFormat',
     ("ANY_NETCDF ANY_NETCDF_CLASSIC "
     "ANY_NETCDF3 NETCDF3_CLASSIC NETCDF_64BIT_OFFSET NETCDF_64BIT_DATA "
     "ANY_NETCDF4 NETCDF4_CLASSIC NETCDF4"),
@@ -55,7 +55,7 @@ class VarlistSettings(_VarlistGlobalSettings, _VarlistTimeSettings):
 @util.mdtf_dataclass
 class VarlistCoordinateMixin(object):
     """Base class to describe a single dimension (in the netcdf data model sense)
-    used by one or more variables. Corresponds to list entries in the 
+    used by one or more variables. Corresponds to list entries in the
     "dimensions" section of the POD's settings.jsonc file.
     """
     need_bounds: bool = False
@@ -101,31 +101,31 @@ class VarlistPlaceholderTimeCoordinate(data_model.DMGenericTimeCoordinate, \
     axis = 'T'
 
 @util.mdtf_dataclass
-class VarlistTimeCoordinate(_VarlistTimeSettings, data_model.DMTimeCoordinate, 
+class VarlistTimeCoordinate(_VarlistTimeSettings, data_model.DMTimeCoordinate,
     VarlistCoordinateMixin):
     pass
 
 VarlistEntryRequirement = util.MDTFEnum(
-    'VarlistEntryRequirement', 
-    'REQUIRED OPTIONAL ALTERNATE AUX_COORDINATE', 
+    'VarlistEntryRequirement',
+    'REQUIRED OPTIONAL ALTERNATE AUX_COORDINATE',
     module=__name__
 )
 
 VarlistEntryStatus = util.MDTFIntEnum(
-    'VarlistEntryStatus', 
-    'NOTSET INITED QUERIED FETCHED PREPROCESSED', 
+    'VarlistEntryStatus',
+    'NOTSET INITED QUERIED FETCHED PREPROCESSED',
     module=__name__
 )
 
 @util.mdtf_dataclass
 class VarlistEntry(data_model.DMVariable, _VarlistGlobalSettings):
-    """Class to describe data for a single variable requested by a POD. 
-    Corresponds to list entries in the "varlist" section of the POD's 
+    """Class to describe data for a single variable requested by a POD.
+    Corresponds to list entries in the "varlist" section of the POD's
     settings.jsonc file.
 
     Two VarlistEntries are equal (as determined by the ``__eq__`` method, which
-    compares fields without ``compare=False``) if they specify the same data 
-    product, ie if the same output file from the preprocessor can be symlinked 
+    compares fields without ``compare=False``) if they specify the same data
+    product, ie if the same output file from the preprocessor can be symlinked
     to two different locations.
     """
     _id: int = util.NOTSET # assigned by DataSource (avoids unsafe_hash)
@@ -203,10 +203,10 @@ class VarlistEntry(data_model.DMVariable, _VarlistGlobalSettings):
             - The names for all of this variable's coordinate axes in that file,
             - The names of the bounds variables for all of those coordinate
                 dimensions, if provided by the data.
-        
+
         """
         if not self.active:
-            # Signal to POD's code that vars are not provided by setting 
+            # Signal to POD's code that vars are not provided by setting
             # variable to the empty string
             return {self.env_var: "", self.path_variable: ""}
 
@@ -225,7 +225,7 @@ class VarlistEntry(data_model.DMVariable, _VarlistGlobalSettings):
 
     def query_attrs(self, key_synonyms=None):
         """Returns a dict of attributes relevant for DataSource.query_dataset()
-        (ie, which describe the variable itself and aren't specific to the 
+        (ie, which describe the variable itself and aren't specific to the
         MDTF implementation.)
         """
         if key_synonyms is None:
@@ -296,24 +296,24 @@ class VarlistEntry(data_model.DMVariable, _VarlistGlobalSettings):
         return f"<#{self._id}.{self.pod_name}:{self.name}>"
 
     def iter_shallow_alternates(self):
-        """Iterator over all VarlistEntries referenced as parts of "sets" of 
-        alternates. ("Sets" is in quotes because they're implemented as lists 
-        here, since VarlistEntries aren't immutable.) 
+        """Iterator over all VarlistEntries referenced as parts of "sets" of
+        alternates. ("Sets" is in quotes because they're implemented as lists
+        here, since VarlistEntries aren't immutable.)
         """
         for alt_vs in self.alternates:
             yield from alt_vs
 
     def iter_alternates(self):
-        """Breadth-first traversal of "sets" of alternate VarlistEntries, 
-        alternates for those alternates, etc. ("Sets" is in quotes because 
+        """Breadth-first traversal of "sets" of alternate VarlistEntries,
+        alternates for those alternates, etc. ("Sets" is in quotes because
         they're implemented as lists here, since VarlistEntries aren't immutable.)
-        Unlike :meth:`iter_shallow_alternates`, this is a "deep" iterator, 
+        Unlike :meth:`iter_shallow_alternates`, this is a "deep" iterator,
         yielding alternates of alternates, alternates of those, ... etc. until
         variables with no alternates are encountered or all variables have been
-        yielded. In addition, it yields the "sets" of alternates instead of the 
+        yielded. In addition, it yields the "sets" of alternates instead of the
         VarlistEntries themselves.
 
-        (Recall that all local state (``stack`` and ``already_encountered``) is 
+        (Recall that all local state (``stack`` and ``already_encountered``) is
         maintained across successive calls.)
         """
         def _iter_alternates():
@@ -328,7 +328,7 @@ class VarlistEntry(data_model.DMVariable, _VarlistGlobalSettings):
                     for alt_v_set_of_ve in ve.alternates:
                         if alt_v_set_of_ve not in already_encountered:
                             stack.append(alt_v_set_of_ve)
-        # first value yielded by _iter_alternates is the var itself, so drop 
+        # first value yielded by _iter_alternates is the var itself, so drop
         # that and then start by returning var's alternates
         iterator_ = iter(_iter_alternates())
         next(iterator_)
@@ -353,18 +353,18 @@ class VarlistEntry(data_model.DMVariable, _VarlistGlobalSettings):
         return s
 
 class Varlist(data_model.DMDataSet):
-    """Class to perform bookkeeping for the model variables requested by a 
+    """Class to perform bookkeeping for the model variables requested by a
     single POD.
     """
     @classmethod
     def from_struct(cls, d):
-        """Parse the "dimensions", "data" and "varlist" sections of the POD's 
+        """Parse the "dimensions", "data" and "varlist" sections of the POD's
         settings.jsonc file when instantiating a new Diagnostic() object.
 
         Args:
             d (:py:obj:`dict`): Contents of the POD's settings.jsonc file.
 
-        Returns: 
+        Returns:
             :py:obj:`dict`, keys are names of the dimensions in POD's convention,
             values are :class:`PodDataDimension` objects.
         """
@@ -410,7 +410,7 @@ class Varlist(data_model.DMDataSet):
         return cls(contents = list(vlist_vars.values()))
 
     def find_var(self, v):
-        """If a variable matching v is already present in the Varlist, return 
+        """If a variable matching v is already present in the Varlist, return
         (a reference to) it (so that we don't try to add duplicates), otherwise
         return None.
         """
@@ -423,11 +423,11 @@ class Varlist(data_model.DMDataSet):
 
 @util.mdtf_dataclass
 class Diagnostic(object):
-    """Class holding configuration for a diagnostic script. Object attributes 
-    are read from entries in the settings section of the POD's settings.jsonc 
+    """Class holding configuration for a diagnostic script. Object attributes
+    are read from entries in the settings section of the POD's settings.jsonc
     file upon initialization.
 
-    See `settings file documentation 
+    See `settings file documentation
     <https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_settings.html>`__
     for documentation on attributes.
     """
@@ -451,7 +451,7 @@ class Diagnostic(object):
     POD_OBS_DATA = ""
     POD_WK_DIR = ""
     POD_OUT_DIR = ""
-    
+
     def __post_init__(self):
         self.exceptions = util.ExceptionQueue()
         for k,v in self.runtime_requirements.items():
@@ -481,14 +481,14 @@ class Diagnostic(object):
             for v in pod.iter_vars():
                 v.pod_name = pod_name
         except Exception as exc:
-            raise util.PodConfigError("Caught exception while parsing varlist", 
+            raise util.PodConfigError("Caught exception while parsing varlist",
                 pod_name) from exc
         return pod
 
     @classmethod
     def from_config(cls, pod_name):
         """Usual method of instantiating Diagnostic objects, from the contents
-        of its settings.jsonc file as stored in the 
+        of its settings.jsonc file as stored in the
         :class:`~core.ConfigManager`.
         """
         config = core.ConfigManager()
@@ -504,11 +504,11 @@ class Diagnostic(object):
                 - active = True: only iterate over currently active VarlistEntries
                     (variables that are currently being queried, fetched and
                     preprocessed.)
-                - active = False: only iterate over inactive VarlistEntries 
+                - active = False: only iterate over inactive VarlistEntries
                     (Either alternates which have not yet been considered, or
                     variables which have experienced an error during query-fetch.)
                 - active = None: iterate over all VarlistEntries.
-                
+
         """
         if active is None:
             # default: all variables
@@ -526,7 +526,7 @@ class Diagnostic(object):
         # only need to keep track of this up to pod execution
         if self.failed:
             # Originating exception will have been logged at a higher priority?
-            _log.warning("Execution of POD %s couldn't be completed:\n%s.", 
+            _log.warning("Execution of POD %s couldn't be completed:\n%s.",
                 self.name, self.exceptions.format())
             for v in self.iter_vars():
                 v.active = False
@@ -534,8 +534,8 @@ class Diagnostic(object):
     def update_active_vars(self):
         """Update the status of which VarlistEntries are "active" (not failed
         somewhere in the query/fetch process) based on new information. If the
-        process has failed for a VarlistEntry, try to find a set of alternate 
-        VarlistEntries. If successful, activate them; if not, raise a 
+        process has failed for a VarlistEntry, try to find a set of alternate
+        VarlistEntries. If successful, activate them; if not, raise a
         :class:`PodDataError`.
         """
         _log.debug('Updating active vars for POD %s', self.name)
@@ -559,10 +559,10 @@ class Diagnostic(object):
                 if not alt_success_flag:
                     _log.info("No alternates available for %s.", v.full_name)
                     try:
-                        raise util.PodDataError(f"No alternates available for {v}.", 
+                        raise util.PodDataError(f"No alternates available for {v}.",
                             self) from v.exception
                     except Exception as exc:
-                        self.exceptions.log(exc)    
+                        self.exceptions.log(exc)
                     continue
         self.deactivate_if_failed()
 
@@ -578,32 +578,32 @@ class Diagnostic(object):
             util.check_dirs(os.path.join(self.POD_WK_DIR, d), create=True)
 
     def pre_run_setup(self):
-        """Perform filesystem operations and checks prior to running the POD. 
+        """Perform filesystem operations and checks prior to running the POD.
 
         In order, this 1) sets environment variables specific to the POD, 2)
         creates POD-specific working directories, and 3) checks for the existence
         of the POD's driver script.
 
         Note:
-            The existence of data files is checked with 
+            The existence of data files is checked with
             :meth:`data_manager.DataManager.fetchData`
             and the runtime environment is validated separately as a function of
-            :meth:`environment_manager.EnvironmentManager.run`. This is because 
+            :meth:`environment_manager.EnvironmentManager.run`. This is because
             each POD is run in a subprocess (due to the necessity of supporting
-            multiple languages) so the validation must take place in that 
+            multiple languages) so the validation must take place in that
             subprocess.
 
         Raises: :exc:`~diagnostic.PodRuntimeError` if requirements
-            aren't met. This is re-raised from the 
+            aren't met. This is re-raised from the
             :meth:`~diagnostic.Diagnostic._check_pod_driver` and
-            :meth:`~diagnostic.Diagnostic._check_for_varlist_files` 
+            :meth:`~diagnostic.Diagnostic._check_for_varlist_files`
             subroutines.
         """
         try:
             self.set_pod_env_vars()
             self.check_pod_driver()
         except Exception as exc:
-            raise util.PodRuntimeError("Caught exception during pre_run_setup", 
+            raise util.PodRuntimeError("Caught exception during pre_run_setup",
                 self) from exc
 
     def set_pod_env_vars(self):
@@ -640,10 +640,10 @@ class Diagnostic(object):
         """
         programs = util.get_available_programs()
 
-        if not self.driver:  
+        if not self.driver:
             _log.warning("No valid driver entry found for %s", self.full_name)
             #try to find one anyway
-            try_filenames = [self.name+".", "driver."]      
+            try_filenames = [self.name+".", "driver."]
             file_combos = [ file_root + ext for file_root \
                 in try_filenames for ext in programs]
             _log.debug("Checking for possible driver names in {} {}".format(
@@ -666,7 +666,7 @@ class Diagnostic(object):
         if not os.path.isabs(self.driver): # expand relative path
             self.driver = os.path.join(self.POD_CODE_DIR, self.driver)
         if not os.path.exists(self.driver):
-            raise util.PodRuntimeError(f"Unable to locate driver script {self.driver}.", 
+            raise util.PodRuntimeError(f"Unable to locate driver script {self.driver}.",
                 self)
 
         if self.program == '':

--- a/src/environment_manager.py
+++ b/src/environment_manager.py
@@ -20,32 +20,32 @@ class AbstractEnvironmentManager(abc.ABC):
     def setup(self): pass
 
     @abc.abstractmethod
-    def create_environment(self, env_name): pass 
+    def create_environment(self, env_name): pass
 
     @abc.abstractmethod
-    def get_pod_env(self, pod): pass 
+    def get_pod_env(self, pod): pass
 
     @abc.abstractmethod
-    def activate_env_commands(self, env_name): pass 
+    def activate_env_commands(self, env_name): pass
 
     @abc.abstractmethod
-    def deactivate_env_commands(self, env_name): pass 
+    def deactivate_env_commands(self, env_name): pass
 
     @abc.abstractmethod
-    def destroy_environment(self, env_name): pass 
+    def destroy_environment(self, env_name): pass
 
     def tear_down(self): pass
 
 class NullEnvironmentManager(AbstractEnvironmentManager):
-    """:class:`AbstractEnvironmentManager` which performs no environment 
-    switching. Useful only as a dummy setting for building framework test 
+    """:class:`AbstractEnvironmentManager` which performs no environment
+    switching. Useful only as a dummy setting for building framework test
     harnesses.
     """
     def create_environment(self, env_name):
-        pass 
-    
+        pass
+
     def destroy_environment(self, env_name):
-        pass 
+        pass
 
     def get_pod_env(self, pod):
         pass
@@ -57,11 +57,11 @@ class NullEnvironmentManager(AbstractEnvironmentManager):
         return []
 
 class VirtualenvEnvironmentManager(AbstractEnvironmentManager):
-    """:class:`AbstractEnvironmentManager` that manages dependencies assuming 
-    that current versions of the scripting language executables are already 
+    """:class:`AbstractEnvironmentManager` that manages dependencies assuming
+    that current versions of the scripting language executables are already
     available on ``$PATH``. For python-based PODs, it uses pip and virtualenvs
     to install needed libraries. For R-based PODs, it attempts to install needed
-    libraries into the current user's ``$PATH``. For other scripting languages, 
+    libraries into the current user's ``$PATH``. For other scripting languages,
     no library management is performed.
     """
     def __init__(self):
@@ -91,7 +91,7 @@ class VirtualenvEnvironmentManager(AbstractEnvironmentManager):
             'deactivate'
         ]:
             util.run_shell_command(cmd)
-    
+
     def _create_r_venv(self, env_name, r_pkgs):
         r_pkg_str = ', '.join(['"'+x+'"' for x in r_pkgs])
         if self.r_lib_root != '':
@@ -109,7 +109,7 @@ class VirtualenvEnvironmentManager(AbstractEnvironmentManager):
             util.run_shell_command(cmd)
 
     def destroy_environment(self, env_key):
-        pass 
+        pass
 
     def get_pod_env(self, pod):
         env_key = [pod.name]
@@ -225,7 +225,7 @@ class CondaEnvironmentManager(AbstractEnvironmentManager):
             raise
 
     def destroy_environment(self, env_name):
-        pass 
+        pass
 
     def get_pod_env(self, pod):
         if pod.name in self.env_list:
@@ -243,11 +243,11 @@ class CondaEnvironmentManager(AbstractEnvironmentManager):
             elif 'python3' in langs:
                 return self.env_name_prefix + 'python3_base'
             else:
-                _log.error("Can't find environment providing %s", 
+                _log.error("Can't find environment providing %s",
                     pod.runtime_requirements)
 
     def activate_env_commands(self, env_name):
-        """Source conda_init.sh to set things that aren't set b/c we aren't 
+        """Source conda_init.sh to set things that aren't set b/c we aren't
         in an interactive shell.
         """
         # conda_init for bash defines conda as a shell function; will get error
@@ -259,18 +259,18 @@ class CondaEnvironmentManager(AbstractEnvironmentManager):
         ]
 
     def deactivate_env_commands(self, env_name):
-        return [] 
-    
+        return []
+
 # ============================================================================
 
 class AbstractRuntimeManager(abc.ABC):
     """Interface for RuntimeManagers.
     """
     @abc.abstractmethod
-    def setup(self): pass 
+    def setup(self): pass
 
     @abc.abstractmethod
-    def run(self): pass 
+    def run(self): pass
 
     @abc.abstractmethod
     def tear_down(self): pass
@@ -289,7 +289,7 @@ class SubprocessRuntimePODWrapper(object):
 
     def pre_run_setup(self):
         self.log_handle = io.open(
-            os.path.join(self.pod.POD_WK_DIR, self.pod.name+".log"), 
+            os.path.join(self.pod.POD_WK_DIR, self.pod.name+".log"),
             'w', encoding='utf-8'
         )
         log_str = f"### Starting {self.pod.name}\n"
@@ -328,7 +328,7 @@ class SubprocessRuntimePODWrapper(object):
         raise exc # include in production, or just for debugging?
 
     def run_commands(self):
-        """Produces the shell command(s) to run the POD. 
+        """Produces the shell command(s) to run the POD.
         """
         #return [self.program + ' ' + self.driver]
         return ['/usr/bin/env python -u '+self.pod.driver]
@@ -336,19 +336,19 @@ class SubprocessRuntimePODWrapper(object):
     def run_msg(self):
         """Log message when execution starts.
         """
-        str_ = util.abbreviate_path(self.pod.driver, 
+        str_ = util.abbreviate_path(self.pod.driver,
             self.pod.POD_CODE_DIR, '$POD_CODE_DIR')
         return f"Calling python {str_}"
 
     def validate_commands(self):
-        """Produces the shell command(s) to validate the POD's runtime environment 
-        (ie, check for all requested third-party module dependencies.) 
-        Dependencies are passed as arguments to the shell script 
+        """Produces the shell command(s) to validate the POD's runtime environment
+        (ie, check for all requested third-party module dependencies.)
+        Dependencies are passed as arguments to the shell script
         ``src/validate_environment.sh``, which is invoked in the POD's subprocess
         before the POD is run.
 
         Returns:
-            (:py:obj:`str`): Command-line invocation to validate the POD's 
+            (:py:obj:`str`): Command-line invocation to validate the POD's
                 runtime environment.
         """
         paths = core.PathManager()
@@ -399,16 +399,16 @@ class SubprocessRuntimeManager(AbstractRuntimeManager):
     def __init__(self, pod_dict, EnvMgrClass):
         config = core.ConfigManager()
         self.test_mode = config.test_mode
-        # transfer all pods, even failed ones, because we need to call their 
+        # transfer all pods, even failed ones, because we need to call their
         self.pods = [self._PodWrapperClass(pod=p) for p in pod_dict.values()]
         self.env_mgr = EnvMgrClass()
 
-        # Need to run bash explicitly because 'conda activate' sources 
+        # Need to run bash explicitly because 'conda activate' sources
         # env vars (can't do that in posix sh). tcsh could also work.
         self.bash_exec = find_executable('bash')
-        
+
     def iter_active_pods(self):
-        """Generator iterating over all wrapped pods which haven't been skipped 
+        """Generator iterating over all wrapped pods which haven't been skipped
         due to requirement errors.
         """
         for p in self.pods:
@@ -441,7 +441,7 @@ class SubprocessRuntimeManager(AbstractRuntimeManager):
         assert os.path.isdir(p.pod.POD_WK_DIR)
         env_vars = env_vars_base.copy()
         env_vars.update(p.env_vars)
-        # Need to run bash explicitly because 'conda activate' sources 
+        # Need to run bash explicitly because 'conda activate' sources
         # env vars (can't do that in posix sh). tcsh could also work.
         return subprocess.Popen(
             commands,
@@ -478,7 +478,7 @@ class SubprocessRuntimeManager(AbstractRuntimeManager):
                 continue
         # should use asyncio, instead wait for each process
         # to terminate and close all log files
-        # TODO: stderr gets eaten with current setup; possible to do a proper 
+        # TODO: stderr gets eaten with current setup; possible to do a proper
         # tee if procs are run with asyncio? https://stackoverflow.com/a/59041913
         for p in self.pods:
             if p.process is not None:

--- a/src/install.py
+++ b/src/install.py
@@ -78,7 +78,7 @@ def conda_env_create(envs, code_root, conda_config):
         print(("To use envs interactively, run `conda config --append envs_dirs "
             '"{conda_env_root}"`'.format(**conda_config)))
         flags = flags + ' --env_dir "{conda_env_root}"'.format(**conda_config)
-    else: 
+    else:
         print("Installing envs into system conda")
     try:
         _ = shell_command_wrapper(conda_config['setup_script'] + flags)
@@ -97,7 +97,7 @@ def ftp_download(ftp_config, ftp_data, install_config):
             if num < step_unit:
                 return "%3.1f %s" % (num, x)
             num /= step_unit
-    
+
     try:
         print("Initiating anonymous FTP connection to {}.".format(ftp_config['host']))
         ftp = ftplib.FTP(**ftp_config)
@@ -108,10 +108,10 @@ def ftp_download(ftp_config, ftp_data, install_config):
         # solution from https://stackoverflow.com/a/19693709 tried previously
         ftp.sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
         ftp.voidcmd('NOOP') # test connection
-    except Exception as exc:  
+    except Exception as exc:
         # do whatever we can to cleanup gracefully before exiting
         try: ftp.quit()
-        except Exception: 
+        except Exception:
             pass
         fatal_exception_handler(exc,
             "ERROR: could not establish FTP connection to {}.".format(ftp_config['host'])
@@ -143,7 +143,7 @@ def ftp_download(ftp_config, ftp_data, install_config):
         # ftp may have closed if we hit an error
         ftp.voidcmd('NOOP')
         ftp.quit()
-    except Exception: 
+    except Exception:
         pass
     print("Closed connection to {}.".format(ftp_config['host']))
 
@@ -159,13 +159,13 @@ def untar_data(ftp_data, install_config):
             # Location on Yosemite and earlier
             test_path = "/System/Library/CoreServices/Archive Utility.app"
             if os.path.exists(test_path):
-                tar_cmd = tar_cmd.format(test_path)    
+                tar_cmd = tar_cmd.format(test_path)
             else:
                 print("ERROR: could not find Archive Utility.app.")
                 exit(1)
     else:
         tar_cmd = 'tar -xf '
-    
+
     for f in iter(ftp_data.values()):
         print("Extracting {}".format(f.file))
         cwd = install_config[f.target_dir]
@@ -230,7 +230,7 @@ def framework_test(code_root, output_dir, cli_config):
         log_str = shell_command_wrapper(
             './mdtf -f {input_file}'.format(
                 input_file=os.path.join(code_root, cli_config['config_out'])
-            ), 
+            ),
             cwd=code_root
         )
         log_str = util.to_iter(log_str)
@@ -240,7 +240,7 @@ def framework_test(code_root, output_dir, cli_config):
             raise IOError("Can't find framework output in {}".format(abs_out_dir))
         run_output = max(runs, key=os.path.getmtime)
         with io.open(
-            os.path.join(run_output, 'mdtf_test.log'), 
+            os.path.join(run_output, 'mdtf_test.log'),
             'w', encoding='utf-8'
         ) as f:
             f.write('\n'.join(log_str))
@@ -302,7 +302,7 @@ class MDTFInstaller(object):
         self.get_config(args)
         self.parse_config()
         self.print_config()
-    
+
     def get_config(self, args=None):
         # assemble from CLI
         cli_dict = util.read_json(
@@ -328,7 +328,7 @@ class MDTFInstaller(object):
             d.downloads_list.append('model_cesm')
         if not d.no_am4:
             d.downloads_list.append('model_am4')
-        
+
         # determine runtime setup
         d.pods = 'all'
         d.conda_envmgr = True
@@ -399,7 +399,7 @@ class MDTFInstaller(object):
 # ------------------------------------------------------------------------------
 
 if __name__ == '__main__':
-    # get dir of currently executing script: 
+    # get dir of currently executing script:
     cwd = os.path.dirname(os.path.realpath(__file__))
     code_root, src_dir = os.path.split(cwd)
     install = MDTFInstaller(code_root, os.path.join(src_dir, 'install_settings.jsonc'))

--- a/src/install_settings.jsonc
+++ b/src/install_settings.jsonc
@@ -1,6 +1,6 @@
 // Configuration for command-line arguments for MDTF-diagnostics install script.
 //
-// DO NOT modify this file. Instead, pass the desired option values to the 
+// DO NOT modify this file. Instead, pass the desired option values to the
 // installer script.
 {
   "settings": {
@@ -61,7 +61,7 @@
       "config_in": "src/default_tests.jsonc",
       "config_out": "src/default_tests_out.jsonc",
       "default_keys": [
-        "MODEL_DATA_ROOT", "OBS_DATA_ROOT", "WORKING_DIR", "OUTPUT_DIR", 
+        "MODEL_DATA_ROOT", "OBS_DATA_ROOT", "WORKING_DIR", "OUTPUT_DIR",
         "conda_root", "conda_env_root", "venv_root", "r_lib_root",
         "environment_manager", "pods"
       ]

--- a/src/logging.jsonc
+++ b/src/logging.jsonc
@@ -22,7 +22,7 @@
     },
     "debug": {
         // writes DEBUG statements to stdout
-        // verbosity level set from CLI (--verbose/--quiet) by 
+        // verbosity level set from CLI (--verbose/--quiet) by
         // src.util.logs._set_console_log_level
         "class": "logging.StreamHandler",
         "formatter": "level",
@@ -31,7 +31,7 @@
     },
     "stdout": {
         // writes INFO statements to stdout
-        // verbosity level set from CLI (--verbose/--quiet) by 
+        // verbosity level set from CLI (--verbose/--quiet) by
         // src.util.logs._set_console_log_level
         "class": "logging.StreamHandler",
         "formatter": "normal",
@@ -40,7 +40,7 @@
     },
     "stderr": {
         // writes WARNING and ERROR statements to stderr
-        // verbosity level set from CLI (--verbose/--quiet) by 
+        // verbosity level set from CLI (--verbose/--quiet) by
         // src.util.logs._set_console_log_level
         "class": "logging.StreamHandler",
         "formatter": "level",

--- a/src/mdtf_info.py
+++ b/src/mdtf_info.py
@@ -150,9 +150,9 @@ class InfoCLIHandler(object):
             print('  Variables:')
             for var in dv:
                 var_str = '    {} ({}) @ {} frequency'.format(
-                    var['var_name'].replace('_var',''), 
-                    var.get('requirement',''), 
-                    var['freq'] 
+                    var['var_name'].replace('_var',''),
+                    var.get('requirement',''),
+                    var['freq']
                 )
                 if 'alternates' in var:
                     var_str = var_str + '; alternates: {}'.format(

--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -67,8 +67,8 @@ class HTMLPodOutputManager(HTMLSourceFileMixin):
     def make_pod_html(self, pod):
         """Perform templating on POD's html results page(s).
 
-        A wrapper for :func:`~util.append_html_template`. Looks for all 
-        html files in POD_CODE_DIR, templates them, and copies them to 
+        A wrapper for :func:`~util.append_html_template`. Looks for all
+        html files in POD_CODE_DIR, templates them, and copies them to
         POD_WK_DIR, respecting subdirectory structure (see doc for
         :func:`~util.recursive_copy`).
         """
@@ -96,8 +96,8 @@ class HTMLPodOutputManager(HTMLSourceFileMixin):
         """Convert all vector graphics in `POD_WK_DIR/subdir` to .png files using
         ghostscript.
 
-        All vector graphics files (identified by extension) in any subdirectory 
-        of `POD_WK_DIR/src_subdir` are converted to .png files by running 
+        All vector graphics files (identified by extension) in any subdirectory
+        of `POD_WK_DIR/src_subdir` are converted to .png files by running
         `ghostscript <https://www.ghostscript.com/>`__ in a subprocess.
         Ghostscript is included in the _MDTF_base conda environment. Afterwards,
         any bitmap files (identified by extension) in any subdirectory of
@@ -107,7 +107,7 @@ class HTMLPodOutputManager(HTMLSourceFileMixin):
         Args:
             src_subdir: Subdirectory tree of `POD_WK_DIR` to search for vector
                 graphics files.
-            dest_subdir: Subdirectory tree of `POD_WK_DIR` to move converted 
+            dest_subdir: Subdirectory tree of `POD_WK_DIR` to move converted
                 bitmap files to.
         """
         # Flags to pass to ghostscript for PS -> PNG conversion (in particular
@@ -123,8 +123,8 @@ class HTMLPodOutputManager(HTMLSourceFileMixin):
         )
         for f in files:
             f_stem, _  = os.path.splitext(f)
-            # Append "_MDTF_TEMP" + page number to output files ("%d" = ghostscript's 
-            # template for multi-page output). If input .ps/.pdf file has multiple 
+            # Append "_MDTF_TEMP" + page number to output files ("%d" = ghostscript's
+            # template for multi-page output). If input .ps/.pdf file has multiple
             # pages, this will generate 1 png per page, counting from 1.
             f_out = f_stem + '_MDTF_TEMP_%d.png'
             try:
@@ -132,7 +132,7 @@ class HTMLPodOutputManager(HTMLSourceFileMixin):
                     f'gs {eps_convert_flags} -sOutputFile="{f_out}" {f}'
                 )
             except Exception as exc:
-                _log.error("%s produced malformed plot: %s", 
+                _log.error("%s produced malformed plot: %s",
                     pod.name, f[len(abs_src_subdir):])
                 if isinstance(exc, util.MDTFCalledProcessError):
                     _log.debug("gs error encountered when converting %s for %s:\n%s",
@@ -158,7 +158,7 @@ class HTMLPodOutputManager(HTMLSourceFileMixin):
             abs_src_subdir, ['*.png', '*.gif', '*.jpg', '*.jpeg']
         )
         util.recursive_copy(
-            files, abs_src_subdir, abs_dest_subdir, 
+            files, abs_src_subdir, abs_dest_subdir,
             copy_function=shutil.move, overwrite=False
         )
 
@@ -166,14 +166,14 @@ class HTMLPodOutputManager(HTMLSourceFileMixin):
         """Copy and remove remaining files to `POD_WK_DIR`.
 
         In order, this 1) copies any bitmap figures in any subdirectory of
-        `POD_OBS_DATA` to `POD_WK_DIR/obs` (needed for legacy PODs without 
+        `POD_OBS_DATA` to `POD_WK_DIR/obs` (needed for legacy PODs without
         digested observational data), 2) removes vector graphics if requested,
         3) removes netCDF scratch files in `POD_WK_DIR` if requested.
 
-        Settings are set at runtime, when :class:`~core.ConfigManager` is 
+        Settings are set at runtime, when :class:`~core.ConfigManager` is
         initialized.
         """
-        # copy premade figures (if any) to output 
+        # copy premade figures (if any) to output
         files = util.find_files(
             pod.POD_OBS_DATA, ['*.gif', '*.png', '*.jpg', '*.jpeg']
         )
@@ -197,13 +197,13 @@ class HTMLPodOutputManager(HTMLSourceFileMixin):
                 os.remove(f)
 
     def make_output(self):
-        """Top-level method to make POD-specific output, post-init. Split off 
+        """Top-level method to make POD-specific output, post-init. Split off
         into its own method to make subclassing easier.
-        
+
         In order, this 1) creates the POD's HTML output page from its included
         template, replacing ``CASENAME`` and other template variables with their
         current values, and adds a link to the POD's page from the top-level HTML
-        report; 2) converts the POD's output plots (in PS or EPS vector format) 
+        report; 2) converts the POD's output plots (in PS or EPS vector format)
         to a bitmap format for webpage display; 3) Copies all requested files to
         the output directory and deletes temporary files.
         """
@@ -244,7 +244,7 @@ class HTMLOutputManager(AbstractOutputManager, HTMLSourceFileMixin):
     def append_result_link(self, pod):
         """Update the top level index.html page with a link to this POD's results.
 
-        This simply appends one of two html fragments to index.html: 
+        This simply appends one of two html fragments to index.html:
         pod_result_snippet.html if the POD completed successfully, or
         pod_error_snippet.html if an exception was raised during the POD's setup
         or execution.
@@ -263,9 +263,9 @@ class HTMLOutputManager(AbstractOutputManager, HTMLSourceFileMixin):
         """Check for missing files linked to from POD's html page.
 
         See documentation for :class:`~verify_links.LinkVerifier`. This method
-        calls LinkVerifier to check existence of all files linked to from the 
+        calls LinkVerifier to check existence of all files linked to from the
         POD's own top-level html page (after templating). If any files are
-        missing, an error message listing them is written to the run's index.html 
+        missing, an error message listing them is written to the run's index.html
         (located in src/html/pod_missing_snippet.html).
         """
         _log.info('Checking linked output files for %s', pod.name)
@@ -276,13 +276,13 @@ class HTMLOutputManager(AbstractOutputManager, HTMLSourceFileMixin):
         )
         missing_out = verifier.verify_pod_links(pod.name)
         if missing_out:
-            _log.error('POD %s has missing output files:\n%s', 
+            _log.error('POD %s has missing output files:\n%s',
                 pod.name, '    \n'.join(missing_out))
             template_d = html_templating_dict(pod)
             template_d['missing_output'] = '<br>'.join(missing_out)
             util.append_html_template(
                 self.html_src_file('pod_missing_snippet.html'),
-                self.CASE_TEMP_HTML, 
+                self.CASE_TEMP_HTML,
                 template_d
             )
             pod.exceptions.log(util.MDTFFileNotFoundError(
@@ -295,7 +295,7 @@ class HTMLOutputManager(AbstractOutputManager, HTMLSourceFileMixin):
         """
         dest = os.path.join(self.WK_DIR, self._html_file_name)
         if os.path.isfile(dest):
-            _log.warning("%s: %s exists, deleting.", 
+            _log.warning("%s: %s exists, deleting.",
                 self._html_file_name, case.name)
             os.remove(dest)
 
@@ -346,12 +346,12 @@ class HTMLOutputManager(AbstractOutputManager, HTMLSourceFileMixin):
         """
         if self.WK_DIR == self.OUT_DIR:
             return # no copying needed
-        _log.debug("%s: Copy %s to %s.", 
+        _log.debug("%s: Copy %s to %s.",
             case.name, self.WK_DIR, self.OUT_DIR)
         try:
             if os.path.exists(self.OUT_DIR):
                 if not self.overwrite:
-                    _log.error("%s: %s exists, overwriting.", 
+                    _log.error("%s: %s exists, overwriting.",
                         case.name, self.OUT_DIR)
                 shutil.rmtree(self.OUT_DIR)
         except Exception:
@@ -369,7 +369,7 @@ class HTMLOutputManager(AbstractOutputManager, HTMLSourceFileMixin):
                 pod_output = self._PodOutputManagerClass(pod, self)
                 pod_output.make_output()
             except Exception as exc:
-                # won't go into the HTML output, but will be present in the 
+                # won't go into the HTML output, but will be present in the
                 # summary for the case
                 _log.exception(f"Caught {repr(exc)}.")
                 pod.exceptions.log(exc)
@@ -380,7 +380,7 @@ class HTMLOutputManager(AbstractOutputManager, HTMLSourceFileMixin):
                 if pod.active:
                     self.verify_pod_links(pod)
             except Exception as exc:
-                # won't go into the HTML output, but will be present in the 
+                # won't go into the HTML output, but will be present in the
                 # summary for the case
                 _log.exception(f"Caught {repr(exc)}.")
                 pod.exceptions.log(exc)

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -38,9 +38,9 @@ def copy_as_alternate(old_v, data_mgr, **kwargs):
     return new_v
 
 def edit_request_wrapper(wrapped_edit_request_func):
-    """Decorator implementing the most typical (so far) use case for 
-    :meth:`PreprocessorFunctionBase.edit_request`, in which we look at each 
-    variable request in the varlist separately and, optionally, add a new 
+    """Decorator implementing the most typical (so far) use case for
+    :meth:`PreprocessorFunctionBase.edit_request`, in which we look at each
+    variable request in the varlist separately and, optionally, add a new
     alternate :class:`~VarlistEntry` based on that request.
 
     This decorator wraps a function which either constructs and returns the
@@ -67,12 +67,12 @@ def edit_request_wrapper(wrapped_edit_request_func):
                     else "(not translated)")
                 v_t_name = (str(v.translation) \
                     if getattr(v, 'translation', None) is not None else "(not translated)")
-                _log.debug("%s for %s: add translated %s as alternate for %s", 
+                _log.debug("%s for %s: add translated %s as alternate for %s",
                     self.__class__.__name__, v.full_name, new_v_t_name, v_t_name)
                 new_varlist.append(v)
                 new_varlist.append(new_v)
         pod.varlist = diagnostic.Varlist(contents=new_varlist)
-    
+
     return wrapped_edit_request
 
 class PreprocessorFunctionBase(abc.ABC):
@@ -89,7 +89,7 @@ class PreprocessorFunctionBase(abc.ABC):
         pass
 
     def edit_request(self, data_mgr, pod):
-        """Edit the data requested in the POD's Varlist queue, based on the 
+        """Edit the data requested in the POD's Varlist queue, based on the
         transformations the functionality can perform. If the function can
         transform data in format X to format Y and the POD requests X, this
         method should insert a backup/fallback request for Y.
@@ -103,8 +103,8 @@ class PreprocessorFunctionBase(abc.ABC):
         Args:
             var: :class:`~src.diagnostic.VarlistEntry` instance describing POD's
                 data request: desired end result of preprocessing work.
-            dataset: `xarray.Dataset 
-                <http://xarray.pydata.org/en/stable/generated/xarray.Dataset.html>`__ 
+            dataset: `xarray.Dataset
+                <http://xarray.pydata.org/en/stable/generated/xarray.Dataset.html>`__
                 instance.
         """
         return dataset
@@ -119,21 +119,21 @@ class CropDateRangeFunction(PreprocessorFunctionBase):
         """
         # NB "tm_mday" is not a typo
         t = dt.timetuple()
-        tt = (getattr(t, attr_) for attr_ in 
+        tt = (getattr(t, attr_) for attr_ in
             ('tm_year', 'tm_mon', 'tm_mday', 'tm_hour', 'tm_min', 'tm_sec'))
         return cftime.datetime(*tt, calendar=calendar)
 
     def process(self, var, ds):
         """Parse quantities related to the calendar for time-dependent data.
-        In particular, ``date_range`` was set from user input before we knew the 
-        model's calendar. HACK here to cast those values into `cftime.datetime 
+        In particular, ``date_range`` was set from user input before we knew the
+        model's calendar. HACK here to cast those values into `cftime.datetime
         <https://unidata.github.io/cftime/api.html#cftime.datetime>`__
         objects so they can be compared with the model data's time axis.
         """
         tv_name = var.name_in_model
         t_coord = ds.cf.dim_axes(tv_name).get('T', None)
         if t_coord is None:
-            _log.debug("Exit %s for %s: time-independent.", 
+            _log.debug("Exit %s for %s: time-independent.",
                 self.__class__.__name__, var.full_name)
             return ds
         cal = t_coord.attrs['calendar']
@@ -166,16 +166,16 @@ class CropDateRangeFunction(PreprocessorFunctionBase):
             _log.info(("Requested dates for %s coincide with range of dataset "
                 "'%s -- %s'; left unmodified."),
                 var.full_name,
-                new_t.values[0].strftime('%Y-%m-%d'), 
-                new_t.values[-1].strftime('%Y-%m-%d'), 
+                new_t.values[0].strftime('%Y-%m-%d'),
+                new_t.values[-1].strftime('%Y-%m-%d'),
             )
         else:
             _log.info("Cropped date range of %s from '%s -- %s' to '%s -- %s'.",
                     var.full_name,
-                    t_start.strftime('%Y-%m-%d'), 
-                    t_end.strftime('%Y-%m-%d'), 
-                    new_t.values[0].strftime('%Y-%m-%d'), 
-                    new_t.values[-1].strftime('%Y-%m-%d'), 
+                    t_start.strftime('%Y-%m-%d'),
+                    t_end.strftime('%Y-%m-%d'),
+                    new_t.values[0].strftime('%Y-%m-%d'),
+                    new_t.values[-1].strftime('%Y-%m-%d'),
                 )
         return ds
 
@@ -203,7 +203,7 @@ class PrecipRateToFluxFunction(PreprocessorFunctionBase):
     def edit_request(self, v, pod, data_mgr):
         """Edit the POD's Varlist prior to query. If v has a standard_name in the
         list above, insert an alternate varlist entry whose translation requests
-        the complementary type of variable (ie, if given rate, add an entry for 
+        the complementary type of variable (ie, if given rate, add an entry for
         flux; if given flux, add an entry for rate.)
         """
         std_name = getattr(v, 'standard_name', "")
@@ -226,13 +226,13 @@ class PrecipRateToFluxFunction(PreprocessorFunctionBase):
                 standard_name = self._flux_d[std_name],
                 units = units.to_cfunits(v.units) * self._liquid_water_density
             )
-        
+
         translate = core.VariableTranslator()
         try:
             new_tv = translate.translate(data_mgr.convention, v_to_translate)
         except KeyError as exc:
             _log.debug(("%s edit_request on %s: caught %r when trying to translate "
-                "'%s'; varlist unaltered."), self.__class__.__name__, 
+                "'%s'; varlist unaltered."), self.__class__.__name__,
                 v.full_name, exc, v_to_translate.standard_name)
             return None
         new_v = copy_as_alternate(v, data_mgr)
@@ -259,10 +259,10 @@ class PrecipRateToFluxFunction(PreprocessorFunctionBase):
             new_units = tv.units * self._liquid_water_density
 
         _log.debug(("Assumed implicit factor of water density in units for %s: "
-            "given %s, will convert as %s."), var.full_name, tv.units, new_units)  
+            "given %s, will convert as %s."), var.full_name, tv.units, new_units)
         ds[tv.name].attrs['units'] = str(new_units)
         tv.units = new_units
-        # actual conversion done by ConvertUnitsFunction; this assures 
+        # actual conversion done by ConvertUnitsFunction; this assures
         # units.convert_dataarray is called with correct parameters.
         return ds
 
@@ -272,8 +272,8 @@ class ConvertUnitsFunction(PreprocessorFunctionBase):
     attributes to what's given in the VarlistEntry.
     """
     def process(self, var, ds):
-        """Convert units on the dependent variable and coordinates of var from 
-        what's specified in the dataset attributes to what's given in the 
+        """Convert units on the dependent variable and coordinates of var from
+        what's specified in the dataset attributes to what's given in the
         VarlistEntry. Units attributes are updated on the translated VarlistEntry.
         """
         tv = var.translation # abbreviate
@@ -308,7 +308,7 @@ class RenameVariablesFunction(PreprocessorFunctionBase):
         rename_d = dict()
         # rename var
         if tv.name != var.name:
-            _log.debug("Rename '%s' variable in %s to '%s'.", 
+            _log.debug("Rename '%s' variable in %s to '%s'.",
                 tv.name, var.full_name, var.name)
             rename_d[tv.name] = var.name
             tv.name = var.name
@@ -317,7 +317,7 @@ class RenameVariablesFunction(PreprocessorFunctionBase):
         for c in tv.dim_axes.values():
             dest_c = var.axes[c.axis]
             if c.name != dest_c.name:
-                _log.debug("Rename %s axis of %s from '%s' to '%s'.", 
+                _log.debug("Rename %s axis of %s from '%s' to '%s'.",
                     c.axis, var.full_name, c.name, dest_c.name)
                 rename_d[c.name] = dest_c.name
                 c.name = dest_c.name
@@ -327,7 +327,7 @@ class RenameVariablesFunction(PreprocessorFunctionBase):
         for c in tv.scalar_coords:
             if c.name in ds:
                 dest_c = var.axes[c.axis]
-                _log.debug("Rename %s scalar coordinate of %s from '%s' to '%s'.", 
+                _log.debug("Rename %s scalar coordinate of %s from '%s' to '%s'.",
                     c.axis, var.full_name, c.name, dest_c.name)
                 rename_d[c.name] = dest_c.name
                 c.name = dest_c.name
@@ -335,16 +335,16 @@ class RenameVariablesFunction(PreprocessorFunctionBase):
         return ds.rename(rename_d)
 
 class ExtractLevelFunction(PreprocessorFunctionBase):
-    """Extract a single pressure level from a DataSet. Unit conversions of 
-    pressure are handled by cfunits, but paramateric vertical coordinates are 
-    **not** handled (interpolation is not implemented here.) If the exact level 
+    """Extract a single pressure level from a DataSet. Unit conversions of
+    pressure are handled by cfunits, but paramateric vertical coordinates are
+    **not** handled (interpolation is not implemented here.) If the exact level
     is not provided by the data, KeyError is raised.
     """
     @edit_request_wrapper
     def edit_request(self, v, pod, data_mgr):
-        """Edit the POD's Varlist prior to query. If given a 
+        """Edit the POD's Varlist prior to query. If given a
         :class:`~diagnostic.VarlistEntry` v which specifies a scalar Z coordinate,
-        return a copy with that scalar_coordinate removed to be used as an 
+        return a copy with that scalar_coordinate removed to be used as an
         alternate variable for v.
         """
         if not v.translation:
@@ -378,7 +378,7 @@ class ExtractLevelFunction(PreprocessorFunctionBase):
         return new_v
 
     def process(self, var, ds):
-        """Determine if level extraction is needed, and return appropriate slice 
+        """Determine if level extraction is needed, and return appropriate slice
         of Dataset if it is.
         """
         _atol = 1.0e-3 # absolute tolerance for floating-point equality
@@ -386,22 +386,22 @@ class ExtractLevelFunction(PreprocessorFunctionBase):
         tv_name = var.name_in_model
         our_z = var.get_scalar('Z')
         if not our_z or not our_z.value:
-            _log.debug("Exit %s for %s: no level requested.", 
+            _log.debug("Exit %s for %s: no level requested.",
                 self.__class__.__name__, var.full_name)
             return ds
         if 'Z' not in ds[tv_name].cf.dim_axes_set:
             # maybe the ds we received has this level extracted already
-            ds_z = ds.cf.get_scalar('Z', tv_name) 
+            ds_z = ds.cf.get_scalar('Z', tv_name)
             if ds_z is None or isinstance(ds_z, xr_parser.PlaceholderScalarCoordinate):
                 _log.debug(("Exit %s for %s: %s %s Z level requested but value not "
-                    "provided in scalar coordinate information; assuming correct."), 
+                    "provided in scalar coordinate information; assuming correct."),
                     self.__class__.__name__, var.full_name, our_z.value, our_z.units)
                 return ds
             else:
-                # value (on var.translation) has already been checked by 
+                # value (on var.translation) has already been checked by
                 # xr_parser.DatasetParser
                 _log.debug(("Exit %s for %s: %s %s Z level requested and provided "
-                    "by dataset."), 
+                    "by dataset."),
                     self.__class__.__name__, var.full_name, our_z.value, our_z.units)
                 return ds
 
@@ -417,7 +417,7 @@ class ExtractLevelFunction(PreprocessorFunctionBase):
                 tolerance=_atol,
                 drop=False
             )
-            _log.info("Extracted %s %s level from Z axis ('%s') of %s.", 
+            _log.info("Extracted %s %s level from Z axis ('%s') of %s.",
                 ds_z_value, ds_z.units, ds_z.name, var.full_name)
             # rename translated var to reflect renaming we're going to do
             # recall POD variable name env vars are set on this attribute
@@ -436,9 +436,9 @@ class ExtractLevelFunction(PreprocessorFunctionBase):
 # ==================================================
 
 class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
-    """Base class for preprocessing data after it's been fetched, in order to 
-    put it into a format expected by PODs. The only functionality implemented 
-    here is parsing data axes and CF attributes; all other functionality is 
+    """Base class for preprocessing data after it's been fetched, in order to
+    put it into a format expected by PODs. The only functionality implemented
+    here is parsing data axes and CF attributes; all other functionality is
     provided by :class:`PreprocessorFunctionBase` functions.
     """
     _functions = util.abstract_attribute()
@@ -456,8 +456,8 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
 
     def edit_request(self, data_mgr, pod):
         """Edit POD's data request, based on the child class's functionality. If
-        the child class has a function that can transform data in format X to 
-        format Y and the POD requests X, this method should insert a 
+        the child class has a function that can transform data in format X to
+        format Y and the POD requests X, this method should insert a
         backup/fallback request for Y.
         """
         for func in self.functions:
@@ -482,7 +482,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             raise ValueError(f"{var.full_name}: Expected one file, got {path_list}.")
         _log.debug("xr.open_dataset on %s", path_list[0])
         return xr.open_dataset(
-            path_list[0], 
+            path_list[0],
             **self.open_dataset_kwargs
         )
 
@@ -509,8 +509,8 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                     if compare_ and k.lower() != 'source':
                         _log.warning("Conflict in '%s' attribute of %s: %s != %s.",
                             k, name, v, attrs[k])
-                    del attrs[k]   
-            
+                    del attrs[k]
+
         for vv in ds.variables.values():
             _clean_dict(vv)
         _clean_dict(ds)
@@ -525,12 +525,12 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 ds[t_coord.bounds].encoding['units'] = ds_T.encoding['units']
 
         for k, v in ds.variables.items():
-            # First condition: unset _FillValue attribute for all independent 
-            # variables (coordinates and their bounds) as per CF convention but 
-            # contrary to xarray default; see 
+            # First condition: unset _FillValue attribute for all independent
+            # variables (coordinates and their bounds) as per CF convention but
+            # contrary to xarray default; see
             # https://github.com/pydata/xarray/issues/1598.
             # Second condition: 'NaN' not a valid _FillValue in NCL for any
-            # variable; see 
+            # variable; see
             # https://www.ncl.ucar.edu/Support/talk_archives/2012/1689.html
             old_fillvalue = v.encoding.get('_FillValue', np.nan)
             if k != var.translation.name \
@@ -541,7 +541,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         return ds
 
     def write_dataset(self, var, ds):
-        # TODO: remove any netcdf Variables that were present in file (and ds) 
+        # TODO: remove any netcdf Variables that were present in file (and ds)
         # but not needed for request
         path_str = util.abbreviate_path(var.dest_path, self.WK_DIR, '$WK_DIR')
         _log.info("Writing to %s", path_str)
@@ -590,7 +590,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
 
 
 class SingleFilePreprocessor(MDTFPreprocessorBase):
-    """A :class:`MDTFPreprocessorBase` for preprocessing model data that is 
+    """A :class:`MDTFPreprocessorBase` for preprocessing model data that is
     provided as a single netcdf file per variable, for example the sample model
     data.
     """
@@ -598,8 +598,8 @@ class SingleFilePreprocessor(MDTFPreprocessorBase):
         return self.read_one_file(var, var.local_data)
 
 class DaskMultiFilePreprocessor(MDTFPreprocessorBase):
-    """A :class:`MDTFPreprocessorBase` that uses xarray's dask support to 
-    preprocessing model data provided as one or several netcdf files per 
+    """A :class:`MDTFPreprocessorBase` that uses xarray's dask support to
+    preprocessing model data provided as one or several netcdf files per
     variable.
     """
     _file_preproc_functions = util.abstract_attribute()
@@ -612,8 +612,8 @@ class DaskMultiFilePreprocessor(MDTFPreprocessorBase):
 
     def edit_request(self, data_mgr, pod):
         """Edit POD's data request, based on the child class's functionality. If
-        the child class has a function that can transform data in format X to 
-        format Y and the POD requests X, this method should insert a 
+        the child class has a function that can transform data in format X to
+        format Y and the POD requests X, this method should insert a
         backup/fallback request for Y.
         """
         for func in self.file_preproc_functions:
@@ -632,7 +632,7 @@ class DaskMultiFilePreprocessor(MDTFPreprocessorBase):
             return _file_preproc(ds)
         else:
             assert not var.is_static # just to be safe
-            _log.debug("xr.open_mfdataset on %d files: %s", 
+            _log.debug("xr.open_mfdataset on %d files: %s",
                 len(var.local_data), var.local_data)
             return xr.open_mfdataset(
                 var.local_data,
@@ -658,8 +658,8 @@ class SampleDataPreprocessor(SingleFilePreprocessor):
     """
     # ExtractLevelFunction needed for NCAR-CAM5.timeslice for Travis
     _functions = (
-        CropDateRangeFunction, 
-        PrecipRateToFluxFunction, ConvertUnitsFunction, 
+        CropDateRangeFunction,
+        PrecipRateToFluxFunction, ConvertUnitsFunction,
         ExtractLevelFunction, RenameVariablesFunction
     )
 
@@ -668,7 +668,7 @@ class MDTFDataPreprocessor(DaskMultiFilePreprocessor):
     """
     _file_preproc_functions = []
     _functions = (
-        CropDateRangeFunction, 
-        PrecipRateToFluxFunction, ConvertUnitsFunction, 
+        CropDateRangeFunction,
+        PrecipRateToFluxFunction, ConvertUnitsFunction,
         ExtractLevelFunction, RenameVariablesFunction
     )

--- a/src/tests/shared_test_utils.py
+++ b/src/tests/shared_test_utils.py
@@ -16,10 +16,10 @@ class DummyMDTFFramework(object):
 
 
 def setUp_config_singletons(config=None, paths=None, pods=None, unittest=True):
-    cwd = os.path.dirname(os.path.realpath(__file__)) 
+    cwd = os.path.dirname(os.path.realpath(__file__))
     code_root = os.path.dirname(os.path.dirname(cwd))
     cli_obj = cli.MDTFTopLevelArgParser(
-        code_root, 
+        code_root,
         skip_defaults=True,
         argv= f"-f {os.path.join(cwd, 'dummy_config.json')}"
     )
@@ -79,14 +79,14 @@ def get_configuration(config_file='', check_input=False, check_output=False):
     # config['paths']['OBS_ROOT_DIR'] = os.path.realpath(config['paths']['OBS_ROOT_DIR'])
     # config['paths']['MODEL_ROOT_DIR'] = os.path.realpath(config['paths']['MODEL_ROOT_DIR'])
     # config['paths']['OUTPUT_DIR'] = os.path.realpath(config['paths']['OUTPUT_DIR'])
-    
+
 
     # assert os.path.isdir(config['paths']['md5_path'])
     # if check_input:
     #     assert os.path.isdir(config['paths']['OBS_ROOT_DIR'])
     #     assert os.path.isdir(config['paths']['MODEL_ROOT_DIR'])
     # if check_output:
-    #     assert os.path.isdir(config['paths']['OUTPUT_DIR'])        
+    #     assert os.path.isdir(config['paths']['OUTPUT_DIR'])
     return config
 
 def get_test_data_configuration():
@@ -121,7 +121,7 @@ def checksum_function(file_path):
     print(os.path.split(file_path)[1])
     ext = os.path.splitext(file_path)[1]
     if ext in IMAGE_FILES:
-        # use ImageMagick 'identify' command which ignores file creation time 
+        # use ImageMagick 'identify' command which ignores file creation time
         # metadata in image header file and only hashes actual image data.
         # See https://stackoverflow.com/a/41706704
         checksum = subprocess.check_output('identify -format "%#" '+file_path, shell=True)
@@ -140,7 +140,7 @@ def checksum_files_in_subtree(dir, exclude_exts=[]):
     files = subprocess.check_output('find . -type f -not -path "*/\.*"', shell=True)
     files = files.split('\n')
     # f[2:] removes the "./" at the beginning of each entry
-    files = [f[2:] for f in files if 
+    files = [f[2:] for f in files if
         f != '' and (os.path.splitext(f)[1] not in exclude_exts)]
     for f in files:
         checksum_dict[f] = checksum_function(os.path.join(dir, f))
@@ -150,7 +150,7 @@ def checksum_files_in_subtree(dir, exclude_exts=[]):
 def generate_checksum_test(name, path, reference_dict, include_exts=[]):
     def test(self):
         self.assertIn(name, reference_dict)
-        if name not in reference_dict: 
+        if name not in reference_dict:
             self.skipTest('Skipping rest of test: {} not found.'.format(name))
         test_dict = checksum_files_in_subtree(os.path.join(path, name))
         for key in reference_dict[name]:
@@ -162,5 +162,5 @@ def generate_checksum_test(name, path, reference_dict, include_exts=[]):
                 self.assertEqual(test_dict[key], reference_dict[name][key],
                     'Failure: Hash of {} differs from reference.'.format(
                         os.path.join(path, name, key)))
-    return test    
+    return test
 

--- a/src/tests/test_cli.py
+++ b/src/tests/test_cli.py
@@ -29,9 +29,9 @@ class TestWordWrap(unittest.TestCase):
 
     def test_word_wrap(self):
         str1 = """
-            Here's a multiline test string; we'll test to see 
+            Here's a multiline test string; we'll test to see
             if the indentation is removed
-            and if it 
+            and if it
             gets word wrapped to 80 columns, etc.
         """
         str2 = ("Here's a multiline test string; we'll test to see if the "
@@ -40,10 +40,10 @@ class TestWordWrap(unittest.TestCase):
 
     def test_word_wrap_multipara(self):
         str1 = """
-            Here's a multiline test string; we'll test to see  
-            if the indentation is removed  
+            Here's a multiline test string; we'll test to see
+            if the indentation is removed
             and if it
-            
+
             gets word wrapped to 80 columns, etc.
             \n\nExplicit para break
         """
@@ -103,11 +103,11 @@ class TestMDTFArgParserHelpFormat(unittest.TestCase):
         p = _parser_from_dict({
             "usage": 'foo',
             "description": """long multiline description text, although strictly
-                speaking we covered this in TestWordWrap, but why not test it 
+                speaking we covered this in TestWordWrap, but why not test it
                 again
             """,
             "arguments": [{
-                "name": "foo", 
+                "name": "foo",
                 "help": "foo help",
                 "metavar": "<foo metavar>",
                 "default": "bar"}],
@@ -299,11 +299,11 @@ class TestParseDummyInput(unittest.TestCase):
             pass
 
     def test_parse_dummy_input(self):
-        # get dir of currently executing script: 
-        cwd = os.path.dirname(os.path.realpath(__file__)) 
+        # get dir of currently executing script:
+        cwd = os.path.dirname(os.path.realpath(__file__))
         code_root = os.path.dirname(os.path.dirname(cwd))
         cli_obj = cli.MDTFTopLevelArgParser(
-            code_root, 
+            code_root,
             skip_defaults=True,
             argv= f"-f {os.path.join(cwd, 'dummy_config.json')}"
         )

--- a/src/tests/test_cmip6.py
+++ b/src/tests/test_cmip6.py
@@ -25,7 +25,7 @@ class TestCMIP6_CVs(unittest.TestCase):
             x.lookup('NorCPM1', 'source_id', 'institution_id')
         )
         self.assertCountEqual(
-            ['NorCPM1', 'NorESM2-LMEC', 'NorESM2-HH', 'NorESM1-F', 
+            ['NorCPM1', 'NorESM2-LMEC', 'NorESM2-HH', 'NorESM1-F',
                 'NorESM2-MH', 'NorESM2-LM', 'NorESM2-MM', 'NorESM2-LME'],
             x.lookup('NCC', 'institution_id', 'source_id')
         )
@@ -43,20 +43,20 @@ class TestCMIP6_CVs(unittest.TestCase):
         )
         self.assertEqual(
             x.lookup(dt_freq('mon'), 'frequency', 'table_id'),
-            set(['EmonZ', 'AERmon', 'SImon', 'Amon', 'CFmon', 'Omon', 
-                'ImonGre', 'Emon', 'ImonAnt', 'Lmon', 'LImon', 'Oclim', 
+            set(['EmonZ', 'AERmon', 'SImon', 'Amon', 'CFmon', 'Omon',
+                'ImonGre', 'Emon', 'ImonAnt', 'Lmon', 'LImon', 'Oclim',
                 'AERmonZ'])
         )
         self.assertEqual(
             x.lookup('mon', 'table_freq', 'table_id'),
-            set(['EmonZ', 'AERmon', 'SImon', 'Amon', 'CFmon', 'Omon', 
-                'ImonGre', 'Emon', 'ImonAnt', 'Lmon', 'LImon', 'Oclim', 
+            set(['EmonZ', 'AERmon', 'SImon', 'Amon', 'CFmon', 'Omon',
+                'ImonGre', 'Emon', 'ImonAnt', 'Lmon', 'LImon', 'Oclim',
                 'AERmonZ'])
         )
 
 class TestCMIP6DateFrequency(unittest.TestCase):
     all_freqs = ['fx', 'dec', 'yr', 'yrPt', 'mon', 'monC', 'day',
-        '6hr', '6hrPt', '3hr', '3hrPt', '1hr', '1hrCM', '1hrPt', 
+        '6hr', '6hrPt', '3hr', '3hrPt', '1hr', '1hrCM', '1hrPt',
         'subhrPt']
 
     def test_string_output(self):

--- a/src/tests/test_core.py
+++ b/src/tests/test_core.py
@@ -15,8 +15,8 @@ class TestVariableTranslator(unittest.TestCase):
         setUp_config_singletons()
 
     def tearDown(self):
-        # call _reset method deleting clearing Translator for unit testing, 
-        # otherwise the second, third, .. tests will use the instance created 
+        # call _reset method deleting clearing Translator for unit testing,
+        # otherwise the second, third, .. tests will use the instance created
         # in the first test instead of being properly initialized
         tearDown_config_singletons()
 
@@ -75,14 +75,14 @@ class TestVariableTranslator(unittest.TestCase):
 
 class TestVariableTranslatorFiles(unittest.TestCase):
     def tearDown(self):
-        # call _reset method deleting clearing Translator for unit testing, 
-        # otherwise the second, third, .. tests will use the instance created 
+        # call _reset method deleting clearing Translator for unit testing,
+        # otherwise the second, third, .. tests will use the instance created
         # in the first test instead of being properly initialized
         tearDown_config_singletons()
 
     def test_variabletranslator_load_files(self):
         # run in non-unit-test mode to test loading of config files
-        cwd = os.path.dirname(os.path.realpath(__file__)) 
+        cwd = os.path.dirname(os.path.realpath(__file__))
         code_root = os.path.dirname(os.path.dirname(cwd))
         raised = False
         try:
@@ -92,10 +92,10 @@ class TestVariableTranslatorFiles(unittest.TestCase):
         self.assertFalse(raised)
         self.assertIn('CMIP', translate.conventions)
         self.assertIn('ua', translate.conventions['CMIP'].entries)
-        
+
     def test_variabletranslator_real_data(self):
         # run in non-unit-test mode to test loading of config files
-        cwd = os.path.dirname(os.path.realpath(__file__)) 
+        cwd = os.path.dirname(os.path.realpath(__file__))
         code_root = os.path.dirname(os.path.dirname(cwd))
         translate = core.VariableTranslator(code_root, unittest=False)
         self.assertEqual(translate.to_CF_name('NCAR', 'PRECT'), "precipitation_rate")
@@ -129,7 +129,7 @@ class TestPathManager(unittest.TestCase):
         paths = core.PathManager()
         self.assertRaises(AssertionError, paths.parse, d, list(d.keys()))
         # initialize successfully so that tear_down doesn't break
-        #_ = core.PathManager(unittest = True) 
+        #_ = core.PathManager(unittest = True)
 
 
 @unittest.skip("TODO: Test needs to be rewritten following v3 beta 3 release")
@@ -138,13 +138,13 @@ class TestPathManagerPodCase(unittest.TestCase):
     def setUp(self):
         # set up translation dictionary without calls to filesystem
         setUp_config_singletons(
-            config=self.case_dict, 
+            config=self.case_dict,
             paths={
                 'CODE_ROOT':'A', 'OBS_DATA_ROOT':'B', 'MODEL_DATA_ROOT':'C',
                 'WORKING_DIR':'D', 'OUTPUT_DIR':'E'
             },
             pods={ 'AA':{
-                'settings':{}, 
+                'settings':{},
                 'varlist':[{'var_name': 'pr_var', 'freq':'mon'}]
                 }
             })

--- a/src/tests/test_data_manager.py
+++ b/src/tests/test_data_manager.py
@@ -15,7 +15,7 @@ class TestDataManagerSetup(unittest.TestCase):
         'pod_list': ['C']
     }
     default_pod_CF = {
-        'settings':{}, 
+        'settings':{},
         'varlist':[{'var_name': 'pr_var', 'freq':'mon'}]
         }
     dummy_paths = {
@@ -30,8 +30,8 @@ class TestDataManagerSetup(unittest.TestCase):
     @mock.patch('src.configs.util.read_json', return_value=dummy_var_translate)
     def setUp(self, mock_read_json):
         setUp_ConfigManager(
-            config=self.default_case, 
-            paths=self.dummy_paths, 
+            config=self.default_case,
+            paths=self.dummy_paths,
             pods={'C': self.default_pod_CF}
         )
         _ = configs.VariableTranslator(unittest = True)
@@ -90,7 +90,7 @@ class TestDataManagerSetupNonCFPod(unittest.TestCase):
         'pod_list': ['C']
     }
     default_pod_not_CF = {
-        'settings': {'variable_convention':'not_CF'}, 
+        'settings': {'variable_convention':'not_CF'},
         'varlist': [{'var_name': 'PRECT', 'freq':'mon'}]
         }
     dummy_paths = {
@@ -105,8 +105,8 @@ class TestDataManagerSetupNonCFPod(unittest.TestCase):
     @mock.patch('src.configs.util.read_json', return_value=dummy_var_translate)
     def setUp(self, mock_read_json):
         setUp_ConfigManager(
-            config=self.default_case, 
-            paths=self.dummy_paths, 
+            config=self.default_case,
+            paths=self.dummy_paths,
             pods={'C': self.default_pod_not_CF}
         )
         _ = configs.VariableTranslator(unittest = True)
@@ -134,14 +134,14 @@ class TestDataManagerSetupNonCFPod(unittest.TestCase):
     @mock.patch('src.diagnostic.util.read_json', return_value = {
         'settings':{'conda_env':'B'},'varlist':[]})
     def test_parse_pod_settings_conda_env(self, mock_read_json):
-        # fill in conda environment 
+        # fill in conda environment
         pod = Diagnostic('A')
         self.assertEqual(pod.conda_env, '_MDTF-diagnostics-B')
 
 
 @unittest.skip("TODO: Test needs to be rewritten following v3 beta 3 release")
-class TestDataManagerFetchData(unittest.TestCase):    
-    @mock.patch('src.util.read_json', 
+class TestDataManagerFetchData(unittest.TestCase):
+    @mock.patch('src.util.read_json',
         return_value = {
             'convention_name':'not_CF',
             'var_names':{'pr_var': 'PRECT', 'prc_var':'PRECC'}
@@ -152,8 +152,8 @@ class TestDataManagerFetchData(unittest.TestCase):
         _ = util.PathManager(unittest = True)
 
     def tearDown(self):
-        # call _reset method deleting clearing Translator for unit testing, 
-        # otherwise the second, third, .. tests will use the instance created 
+        # call _reset method deleting clearing Translator for unit testing,
+        # otherwise the second, third, .. tests will use the instance created
         # in the first test instead of being properly initialized
         temp = util.VariableTranslator(unittest = True)
         temp._reset()

--- a/src/tests/test_diagnostic.py
+++ b/src/tests/test_diagnostic.py
@@ -12,7 +12,7 @@ from src.util.datelabel import DateFrequency
 class TestDiagnosticInit(unittest.TestCase):
     # pylint: disable=maybe-no-member
     default_pod_CF = {
-        'settings':{}, 
+        'settings':{},
         'varlist':[{'var_name': 'pr_var', 'freq':'mon'}]
         }
     dummy_paths = {
@@ -27,7 +27,7 @@ class TestDiagnosticInit(unittest.TestCase):
     @mock.patch('src.configs.util.read_json', return_value=dummy_var_translate)
     def setUp(self, mock_read_json):
         setUp_ConfigManager(
-            paths=self.dummy_paths, 
+            paths=self.dummy_paths,
             pods={'DUMMY_POD': self.default_pod_CF}
         )
         _ = configs.VariableTranslator(unittest = True)
@@ -35,7 +35,7 @@ class TestDiagnosticInit(unittest.TestCase):
     def tearDown(self):
         tearDown_ConfigManager()
 
-    # ---------------------------------------------------  
+    # ---------------------------------------------------
 
     def test_parse_pod_settings(self):
         # normal operation
@@ -65,7 +65,7 @@ class TestDiagnosticInit(unittest.TestCase):
             }]
         }
         test_ds = DataSet({
-                'name':'foo', 'freq':'mon', 
+                'name':'foo', 'freq':'mon',
                 'CF_name':'foo', 'required': True,
                 'original_name':'pr_var', 'alternates':[]
                 })
@@ -103,8 +103,8 @@ class TestDiagnosticSetUp(unittest.TestCase):
     @mock.patch('src.configs.util.read_json', return_value=dummy_var_translate)
     def setUp(self, mock_read_json):
         setUp_ConfigManager(
-            config=self.default_case, 
-            paths=self.dummy_paths, 
+            config=self.default_case,
+            paths=self.dummy_paths,
             pods={'DUMMY_POD': self.default_pod}
         )
         _ = configs.VariableTranslator(unittest = True)
@@ -112,7 +112,7 @@ class TestDiagnosticSetUp(unittest.TestCase):
     def tearDown(self):
         tearDown_ConfigManager()
 
-    # ---------------------------------------------------  
+    # ---------------------------------------------------
 
     @unittest.skip("")
     # @mock.patch.multiple(DataManager, __abstractmethods__=set())
@@ -126,14 +126,14 @@ class TestDiagnosticSetUp(unittest.TestCase):
         pod._set_pod_env_vars()
         self.assertEqual(pod.pod_env_vars['POD_HOME'], 'TEST_CODE_ROOT/diagnostics/C')
         self.assertEqual(pod.pod_env_vars['OBS_DATA'], 'TEST_OBS_DATA_ROOT/C')
-        self.assertEqual(pod.pod_env_vars['WK_DIR'], 'A')  
+        self.assertEqual(pod.pod_env_vars['WK_DIR'], 'A')
 
     @mock.patch('src.util.check_dirs')
     @mock.patch('os.path.exists', return_value = False)
     @mock.patch('os.makedirs')
     def test_setup_pod_directories_mkdir(self, mock_makedirs, mock_exists, \
-        mock_check_dirs): 
-        # create output dirs if not present    
+        mock_check_dirs):
+        # create output dirs if not present
         pod = Diagnostic('DUMMY_POD')
         pod.POD_WK_DIR = 'A/B'
         pod._setup_pod_directories()
@@ -146,17 +146,17 @@ class TestDiagnosticSetUp(unittest.TestCase):
     @mock.patch('os.path.exists', return_value = True)
     @mock.patch('os.makedirs')
     def test_setup_pod_directories_no_mkdir(self, mock_makedirs, mock_exists):
-        # don't create output dirs if already present       
+        # don't create output dirs if already present
         pod = Diagnostic('DUMMY_POD')
         pod.POD_WK_DIR = 'A'
         pod._setup_pod_directories()
-        mock_makedirs.assert_not_called()     
+        mock_makedirs.assert_not_called()
 
-    @mock.patch('os.path.exists', return_value = True) 
+    @mock.patch('os.path.exists', return_value = True)
     def test_check_pod_driver_no_driver_1(self, mock_exists):
         # fill in driver from pod name
         programs = util.get_available_programs()
-        pod = Diagnostic('DUMMY_POD')  
+        pod = Diagnostic('DUMMY_POD')
         pod._check_pod_driver()
         ext = os.path.splitext(pod.driver)[1][1:]
         self.assertTrue(ext in programs)
@@ -165,7 +165,7 @@ class TestDiagnosticSetUp(unittest.TestCase):
     @mock.patch('os.path.exists', return_value = False)
     def test_check_pod_driver_no_driver_2(self, mock_exists):
         # assertion fails if no driver found
-        pod = Diagnostic('DUMMY_POD')  
+        pod = Diagnostic('DUMMY_POD')
         self.assertRaises(PodRuntimeError, pod._check_pod_driver)
 
 @unittest.skip("TODO: Test needs to be rewritten following v3 beta 3 release")
@@ -184,7 +184,7 @@ class TestDiagnosticCheckVarlist(unittest.TestCase):
     @mock.patch('src.configs.util.read_json', return_value=dummy_var_translate)
     def setUp(self, mock_read_json):
         setUp_ConfigManager(
-            paths=self.dummy_paths, 
+            paths=self.dummy_paths,
             pods={'DUMMY_POD': self.default_pod}
         )
         _ = configs.VariableTranslator(unittest = True)
@@ -192,7 +192,7 @@ class TestDiagnosticCheckVarlist(unittest.TestCase):
     def tearDown(self):
         tearDown_ConfigManager()
 
-    # ---------------------------------------------------  
+    # ---------------------------------------------------
 
     def _populate_pod__local_data(self, pod):
         # reproduce logic in DataManager._setup_pod rather than invoke it here
@@ -223,7 +223,7 @@ class TestDiagnosticCheckVarlist(unittest.TestCase):
         'settings':{}, 'varlist':[
             {'var_name': 'pr_var', 'freq':'mon'}
         ]}
-        pod = Diagnostic('DUMMY_POD') 
+        pod = Diagnostic('DUMMY_POD')
         self._populate_pod__local_data(pod)
         (found, missing) = pod._check_for_varlist_files(pod.varlist)
         self.assertEqual(found, ['TEST_MODEL_DATA_ROOT/A/mon/A.PRECT.mon.nc'])
@@ -237,7 +237,7 @@ class TestDiagnosticCheckVarlist(unittest.TestCase):
         'settings':{}, 'varlist':[
             {'var_name': 'pr_var', 'freq':'mon', 'required': True}
         ]}
-        pod = Diagnostic('DUMMY_POD') 
+        pod = Diagnostic('DUMMY_POD')
         self._populate_pod__local_data(pod)
         (found, missing) = pod._check_for_varlist_files(pod.varlist)
         self.assertEqual(found, [])
@@ -251,7 +251,7 @@ class TestDiagnosticCheckVarlist(unittest.TestCase):
         'settings':{}, 'varlist':[
             {'var_name': 'pr_var', 'freq':'mon', 'required': False}
         ]}
-        pod = Diagnostic('DUMMY_POD') 
+        pod = Diagnostic('DUMMY_POD')
         self._populate_pod__local_data(pod)
         (found, missing) = pod._check_for_varlist_files(pod.varlist)
         self.assertEqual(found, [])
@@ -263,10 +263,10 @@ class TestDiagnosticCheckVarlist(unittest.TestCase):
         config = configs.ConfigManager(unittest=True)
         config.pods['DUMMY_POD'] = {
         'settings':{}, 'varlist':[
-            {'var_name': 'pr_var', 'freq':'mon', 
+            {'var_name': 'pr_var', 'freq':'mon',
             'required': True, 'alternates':['prc_var']}
         ]}
-        pod = Diagnostic('DUMMY_POD') 
+        pod = Diagnostic('DUMMY_POD')
         self._populate_pod__local_data(pod)
         (found, missing) = pod._check_for_varlist_files(pod.varlist)
         # name_in_model translation now done in DataManager._setup_pod
@@ -289,7 +289,7 @@ class TestDiagnosticSetUpCustomSettings(unittest.TestCase):
     @mock.patch('src.configs.util.read_json', return_value=dummy_var_translate)
     def setUp(self, mock_read_json):
         setUp_ConfigManager(
-            paths=self.dummy_paths, 
+            paths=self.dummy_paths,
             pods={'DUMMY_POD': self.default_pod}
         )
         _ = configs.VariableTranslator(unittest = True)
@@ -297,7 +297,7 @@ class TestDiagnosticSetUpCustomSettings(unittest.TestCase):
     def tearDown(self):
         tearDown_ConfigManager()
 
-    # ---------------------------------------------------  
+    # ---------------------------------------------------
 
     @mock.patch('os.path.exists', return_value = True)
     def test_set_pod_env_vars_vars(self, mock_exists):
@@ -320,7 +320,7 @@ class TestDiagnosticSetUpCustomSettings(unittest.TestCase):
         config.pods['DUMMY_POD'] = {
             'settings':{'driver':'C.ncl'}, 'varlist':[]
         }
-        pod = Diagnostic('DUMMY_POD')  
+        pod = Diagnostic('DUMMY_POD')
         pod._check_pod_driver()
         self.assertEqual(pod.driver, 'TEST_CODE_ROOT/diagnostics/A/C.ncl')
         self.assertEqual(pod.program, 'ncl')
@@ -332,7 +332,7 @@ class TestDiagnosticSetUpCustomSettings(unittest.TestCase):
         config.pods['DUMMY_POD'] = {
             'settings':{'driver':'C.foo'}, 'varlist':[]
         }
-        pod = Diagnostic('DUMMY_POD') 
+        pod = Diagnostic('DUMMY_POD')
         self.assertRaises(PodRuntimeError, pod._check_pod_driver)
 
 @unittest.skip("TODO: Test needs to be rewritten following v3 beta 3 release")
@@ -351,7 +351,7 @@ class TestDiagnosticTearDown(unittest.TestCase):
     @mock.patch('src.configs.util.read_json', return_value=dummy_var_translate)
     def setUp(self, mock_read_json):
         setUp_ConfigManager(
-            paths=self.dummy_paths, 
+            paths=self.dummy_paths,
             pods={'DUMMY_POD': self.default_pod}
         )
         _ = configs.VariableTranslator(unittest = True)
@@ -359,7 +359,7 @@ class TestDiagnosticTearDown(unittest.TestCase):
     def tearDown(self):
         tearDown_ConfigManager()
 
-    # ---------------------------------------------------  
+    # ---------------------------------------------------
 
     # expected to fail because error will be raised about missing TEMP_HTML
     # attribute, which is set when PODs are initialized by data_manager
@@ -371,7 +371,7 @@ class TestDiagnosticTearDown(unittest.TestCase):
     @mock.patch('os.remove')
     @mock.patch('src.util.append_html_template')
     def test_make_pod_html(self, mock_append_html_template, mock_remove, \
-        mock_system, mock_copy2, mock_exists): 
+        mock_system, mock_copy2, mock_exists):
         pod = Diagnostic('DUMMY_POD')
         pod.MODEL_WK_DIR = '/B'
         pod.POD_WK_DIR = '/B/DUMMY_POD'
@@ -395,8 +395,8 @@ class TestDiagnosticTearDown(unittest.TestCase):
     def test_convert_pod_figures(self, mock_subprocess, mock_glob):
         # assert we munged filenames correctly
         config = configs.ConfigManager(unittest=True)
-        pod = Diagnostic('DUMMY_POD') 
-        pod.POD_WK_DIR = 'A'  
+        pod = Diagnostic('DUMMY_POD')
+        pod.POD_WK_DIR = 'A'
         pod._convert_pod_figures(config)
         mock_system.assert_has_calls([
             mock.call('convert -C A/model/PS/B.ps A/model/B.png')

--- a/src/tests/test_environment_manager.py
+++ b/src/tests/test_environment_manager.py
@@ -22,9 +22,9 @@ class TestEnvironmentManager(unittest.TestCase):
     # @mock.patch('os.path.exists', return_value = True)
     # def test_check_pod_driver_no_program_2(self, mock_exists, mock_read_json):
     #     # assertion fail if explicitly specified program not found
-    #     pod = Diagnostic('A') 
+    #     pod = Diagnostic('A')
     #     self.assertRaises(AssertionError, pod._check_pod_driver)
-    
+
     # ---------------------------------------------------
 
     def test_run(self):

--- a/src/tests/test_mdtf.py
+++ b/src/tests/test_mdtf.py
@@ -15,8 +15,8 @@ class TestMDTFArgParsing(unittest.TestCase):
         }
 
     def tearDown(self):
-        # call _reset method deleting clearing PathManager for unit testing, 
-        # otherwise the second, third, .. tests will use the instance created 
+        # call _reset method deleting clearing PathManager for unit testing,
+        # otherwise the second, third, .. tests will use the instance created
         # in the first test instead of being properly initialized
         temp = configs.PathManager(unittest = True)
         temp._reset()
@@ -44,7 +44,7 @@ class TestMDTFArgParsing(unittest.TestCase):
         mdtf = MDTFFramework.__new__(MDTFFramework)
         mdtf.config = self.config_test.copy()
         mdtf.set_mdtf_env_vars()
-        self.assertEqual(mdtf.config['envvars']['E'], 'F')      
+        self.assertEqual(mdtf.config['envvars']['E'], 'F')
 
     @mock.patch('src.util.check_dirs')
     def test_sset_mdtf_env_vars_config_rgb(self, mock_check_dirs):

--- a/src/units.py
+++ b/src/units.py
@@ -14,9 +14,9 @@ class Units(cfunits.Units):
     pass
 
 def to_cfunits(*args):
-    """Coerce string-valued units and (quantity, unit) tuples to cfunits.Units 
-    objects. Also coerces reference time units (eg 'days since 1970-01-01') to 
-    time units ('days'). The reference date aspect isn't used in the code here 
+    """Coerce string-valued units and (quantity, unit) tuples to cfunits.Units
+    objects. Also coerces reference time units (eg 'days since 1970-01-01') to
+    time units ('days'). The reference date aspect isn't used in the code here
     and is handled by xarray parsing in the preprocessor.
     """
     def _coerce(u):
@@ -49,7 +49,7 @@ def to_equivalent_units(*args):
     return args
 
 def relative_tol(x, y):
-    """HACK to return ``max(|x-y|/x, |x-y|/y)`` for unit-ful quantities x, y. 
+    """HACK to return ``max(|x-y|/x, |x-y|/y)`` for unit-ful quantities x, y.
     Vulnerable to underflow in principle.
     """
     x, y = to_equivalent_units(x,y)
@@ -59,7 +59,7 @@ def relative_tol(x, y):
 
 def units_equivalent(*args):
     """Returns True if and only if all units in arguments are equivalent
-    (represent the same physical quantity, up to a multiplicative conversion 
+    (represent the same physical quantity, up to a multiplicative conversion
     factor.)
     """
     args = to_cfunits(*args)
@@ -89,8 +89,8 @@ def units_equal(*args, rtol=None):
         return True
 
 def conversion_factor(source_unit, dest_unit):
-    """Defined so that (conversion factor) * (quantity in source_units) = 
-    (quantity in dest_units). 
+    """Defined so that (conversion factor) * (quantity in source_units) =
+    (quantity in dest_units).
     """
     source_unit, dest_unit = to_equivalent_units(source_unit, dest_unit)
     return Units.conform(1.0, source_unit, dest_unit)
@@ -99,14 +99,14 @@ def conversion_factor(source_unit, dest_unit):
 
 def convert_scalar_coord(coord, dest_units):
     """Given scalar coordinate *coord*, return the appropriate scalar value in
-    new units *dest_units*. 
+    new units *dest_units*.
     """
     assert hasattr(coord, 'is_scalar') and coord.is_scalar
     if not units_equal(coord.units, dest_units):
         # convert units of scalar value to convention's coordinate's units
         dest_value = coord.value * conversion_factor(coord.units, dest_units)
         _log.debug("Converted %s %s %s slice of '%s' to %s %s.",
-            coord.value, coord.units, coord.axis, coord.name, 
+            coord.value, coord.units, coord.axis, coord.name,
             dest_value, dest_units)
     else:
         # identical units
@@ -133,7 +133,7 @@ def convert_dataarray(ds, da_name, dest_unit):
             "done."), da.name, std_name, dest_unit)
         return ds
 
-    _log.debug("Convert units of '%s'%s from '%s' to '%s'.", 
+    _log.debug("Convert units of '%s'%s from '%s' to '%s'.",
         da.name, std_name, src_unit, dest_unit)
     da_attrs = da.attrs.copy()
     fac = conversion_factor(src_unit, dest_unit)

--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -1,9 +1,9 @@
 # List public symbols for package import.
 
 from .basic import (
-    Singleton, abstract_attribute, MDTFABCMeta, MultiMap, 
+    Singleton, abstract_attribute, MDTFABCMeta, MultiMap,
     WormDict, ConsistentDict, WormDefaultDict, NameSpace, MDTFEnum, MDTFIntEnum,
-    sentinel_object_factory, is_iterable, to_iter, from_iter, remove_prefix, 
+    sentinel_object_factory, is_iterable, to_iter, from_iter, remove_prefix,
     remove_suffix, filter_kwargs, splice_into_list, deserialize_class
 )
 from .dataclass import (
@@ -18,16 +18,16 @@ from .datelabel import (
 )
 from .exceptions import *
 from .filesystem import (
-    abbreviate_path, resolve_path, recursive_copy, 
-    get_available_programs, check_executable, find_files, check_dirs, bump_version, 
+    abbreviate_path, resolve_path, recursive_copy,
+    get_available_programs, check_executable, find_files, check_dirs, bump_version,
     strip_comments, parse_json, read_json, find_json, write_json, pretty_print_json,
     append_html_template
-    # is_subpath, 
+    # is_subpath,
 )
 from .logs import (
     signal_logger, git_info, case_log_config
 )
 from .processes import (
-    ExceptionPropagatingThread, 
+    ExceptionPropagatingThread,
     poll_command, run_command, run_shell_command
 )

--- a/src/util/basic.py
+++ b/src/util/basic.py
@@ -18,8 +18,8 @@ class _AbstractAttributePlaceholder():
     pass
 
 def abstract_attribute(obj=None):
-    """Decorator for abstract attributes in abstract base classes by analogy 
-    with :py:func:`abc.abstract_method`. Based on 
+    """Decorator for abstract attributes in abstract base classes by analogy
+    with :py:func:`abc.abstract_method`. Based on
     `<https://stackoverflow.com/a/50381071>`__.
     """
     if obj is None:
@@ -28,9 +28,9 @@ def abstract_attribute(obj=None):
     return obj
 
 class MDTFABCMeta(abc.ABCMeta):
-    """Wrap the metaclass for abstract base classes to enable definition of 
+    """Wrap the metaclass for abstract base classes to enable definition of
     abstract attributes; raises NotImplementedError if they aren't defined in
-    child classes. Based on 
+    child classes. Based on
     `<https://stackoverflow.com/a/50381071>`__.
     """
     def __call__(cls, *args, **kwargs):
@@ -61,17 +61,17 @@ class _Singleton(type):
             cls._instances[cls] = super(_Singleton, cls).__call__(*args, **kwargs)
         return cls._instances[cls]
 
-class Singleton(_Singleton('SingletonMeta', (object,), {})): 
-    """Parent class defining the 
+class Singleton(_Singleton('SingletonMeta', (object,), {})):
+    """Parent class defining the
     `Singleton <https://en.wikipedia.org/wiki/Singleton_pattern>`_ pattern. We
     use this as safer way to pass around global state.
     """
     @classmethod
     def _reset(cls):
         """Private method of all :class:`~util.Singleton`-derived classes added
-        for use in unit testing only. Calling this method on test teardown 
-        deletes the instance, so that tests coming afterward will initialize the 
-        :class:`~util.Singleton` correctly, instead of getting the state set 
+        for use in unit testing only. Calling this method on test teardown
+        deletes the instance, so that tests coming afterward will initialize the
+        :class:`~util.Singleton` correctly, instead of getting the state set
         during previous tests.
         """
         # pylint: disable=maybe-no-member
@@ -80,12 +80,12 @@ class Singleton(_Singleton('SingletonMeta', (object,), {})):
 
 
 class MultiMap(collections.defaultdict):
-    """Extension of the :obj:`dict` class that allows doing dictionary lookups 
-    from either keys or values. 
-    
+    """Extension of the :obj:`dict` class that allows doing dictionary lookups
+    from either keys or values.
+
     Syntax for lookup from keys is unchanged, ``bd['key'] = 'val'``, while lookup
     from values is done on the `inverse` attribute and returns a set of matching
-    keys if more than one match is present: ``bd.inverse['val'] = ['key1', 'key2']``.    
+    keys if more than one match is present: ``bd.inverse['val'] = ['key1', 'key2']``.
     See `<https://stackoverflow.com/a/21894086>`__.
     """
     def __init__(self, *args, **kwargs):
@@ -102,7 +102,7 @@ class MultiMap(collections.defaultdict):
         if key not in list(self.keys()):
             raise KeyError(key)
         return from_iter(self[key])
-    
+
     def to_dict(self):
         d = {}
         for key in iter(self.keys()):
@@ -122,7 +122,7 @@ class MultiMap(collections.defaultdict):
         return from_iter(inv_lookup[val])
 
 class WormDict(collections.UserDict, dict):
-    """Dict which raises eexceptions when trying to overwrite or delete an 
+    """Dict which raises eexceptions when trying to overwrite or delete an
     existing entry. "WORM" is an acronym for "write once, read many."
     """
     def __setitem__(self, key, value):
@@ -173,7 +173,7 @@ class WormDefaultDict(WormDict):
 class NameSpace(dict):
     """ A dictionary that provides attribute-style access.
 
-    For example, `d['key'] = value` becomes `d.key = value`. All methods of 
+    For example, `d['key'] = value` becomes `d.key = value`. All methods of
     :py:obj:`dict` are supported.
 
     Note: recursive access (`d.key.subkey`, as in C-style languages) is not
@@ -291,7 +291,7 @@ class NameSpace(dict):
     def _freeze(self):
         """Return immutable representation of (current) attributes.
 
-        We do this to enable comparison of two Namespaces, which otherwise would 
+        We do this to enable comparison of two Namespaces, which otherwise would
         be done by the default method of testing if the two objects refer to the
         same location in memory.
         See `<https://stackoverflow.com/a/45170549>`__.
@@ -331,8 +331,8 @@ class _MDTFEnumMixin():
 
 class MDTFEnum(_MDTFEnumMixin, enum.Enum):
     """Customize :py:class:`~enum.Enum`. 1) Assign (integer) values automatically
-    to the members of the enumeration. 2) Provide a ``from_struct`` method to 
-    simplify instantiating an instance from a string. To avoid potential 
+    to the members of the enumeration. 2) Provide a ``from_struct`` method to
+    simplify instantiating an instance from a string. To avoid potential
     confusion with reserved keywords, we use the Python convention that members
     of the enumeration are all uppercase.
     """
@@ -346,11 +346,11 @@ class MDTFEnum(_MDTFEnumMixin, enum.Enum):
 class MDTFIntEnum(_MDTFEnumMixin, enum.IntEnum):
     """Customize :py:class:`~enum.IntEnum` analogous to :class:`MDTFEnum`.
     """
-    pass 
+    pass
 
 def sentinel_object_factory(obj_name):
     """Return a unique singleton object/class (same difference for singletons).
-    For implentation, see `python docs 
+    For implentation, see `python docs
     <https://docs.python.org/3/library/unittest.mock.html#unittest.mock.sentinel>`__.
     """
     return getattr(unittest.mock.sentinel, obj_name)
@@ -400,8 +400,8 @@ def filter_kwargs(kwarg_dict, function):
         if k in kwarg_dict and k not in ['self', 'args', 'kwargs'])
 
 def splice_into_list(list_, splice_d,  key_fn=None):
-    """Splice sub-lists in ``splice_d`` into list ``list_`` after their 
-    corresponding entries (keys of ``slice_d``). Example: 
+    """Splice sub-lists in ``splice_d`` into list ``list_`` after their
+    corresponding entries (keys of ``slice_d``). Example:
 
     .. code-block:: python
 
@@ -413,7 +413,7 @@ def splice_into_list(list_, splice_d,  key_fn=None):
         splice_d: dict of sub-lists to splice in. Keys are entries in ``list_``
             and values are the sub-lists to insert after that entry. Duplicate
             or missing entries are handled appropriately.
-        key_fn (optional): If supplied, function applied to elements of ``list_`` 
+        key_fn (optional): If supplied, function applied to elements of ``list_``
             to compare to keys of ``splice_d``.
 
     Returns: spliced ``list_`` as described above.
@@ -439,7 +439,7 @@ def splice_into_list(list_, splice_d,  key_fn=None):
 
 def deserialize_class(name):
     """Given the name of a currently defined class, return the class itself.
-    This avoids security issues with calling :py:func:`eval`. Based on 
+    This avoids security issues with calling :py:func:`eval`. Based on
     `<https://stackoverflow.com/a/11781721>`__.
 
     Args:
@@ -448,7 +448,7 @@ def deserialize_class(name):
     Returns: class with the given name, or raise ValueError.
     """
     try:
-        # for performance, search python builtin types first before going 
+        # for performance, search python builtin types first before going
         # through everything
         return getattr(__builtins__, name)
     except AttributeError:

--- a/src/util/dataclass.py
+++ b/src/util/dataclass.py
@@ -14,22 +14,22 @@ import logging
 _log = logging.getLogger(__name__)
 
 class RegexPatternBase():
-    """Dummy parent class for :class:`RegexPattern` and 
+    """Dummy parent class for :class:`RegexPattern` and
     :class:`ChainedRegexPattern`.
     """
     pass
 
 class RegexPattern(collections.UserDict, RegexPatternBase):
-    """Wraps :py:class:`re.Pattern` with more convenience methods. Extracts 
-    values of named fields from a string by parsing it with a regex with 
-    named capture groups, and stores those values in a dict. 
+    """Wraps :py:class:`re.Pattern` with more convenience methods. Extracts
+    values of named fields from a string by parsing it with a regex with
+    named capture groups, and stores those values in a dict.
     """
-    def __init__(self, regex, defaults=None, input_field=None, 
+    def __init__(self, regex, defaults=None, input_field=None,
         match_error_filter=None):
         """Constructor.
 
         Args:
-            regex: str or :py:class:`re.Pattern`: regex to use for string 
+            regex: str or :py:class:`re.Pattern`: regex to use for string
                 parsing. Should contain named match groups corresponding to the
                 fields to parse.
             defaults: dict, optional. If supplied, any fields not matched by the
@@ -37,17 +37,17 @@ class RegexPattern(collections.UserDict, RegexPatternBase):
             input_field: str, optional. If supplied, add a field to the match with
                 the supplied name which will be set equal to the contents of the
                 input string on a successful match.
-            match_error_filter: optional, bool or :class:`RegexPattern` or 
+            match_error_filter: optional, bool or :class:`RegexPattern` or
                 :class:`ChainedRegexPattern`.
                 If supplied, suppresses raising ValueErrors when match() fails.
                 If boolean or none, either always or never raise ValueError.
-                If a RegexPattern, try matching the input string that caused 
+                If a RegexPattern, try matching the input string that caused
                 the failed match against it. If it matches, do not raise an error.
 
         Attributes:
             data: dict, either empty when unmatched, or containing the contents
                 of the match. From :py:class:`collections.UserDict`.
-            fields: frozenset of fields matched by the pattern. Consists of the 
+            fields: frozenset of fields matched by the pattern. Consists of the
                 *union* of named match groups in regex, and *all* keys in defaults.
             input_string: Contains string that was input to last call of match(),
                 whether successful or not.
@@ -73,28 +73,28 @@ class RegexPattern(collections.UserDict, RegexPatternBase):
         self.input_field = input_field
         self._match_error_filter = match_error_filter
         self._update_fields()
-    
+
     def clear(self):
         """Erase an existing match.
         """
         self.data = dict()
         self.input_string = ""
         self.is_matched = False
-        
+
     def _update_fields(self):
         self.regex_fields = frozenset(self.regex.groupindex.keys())
         self.fields = self.regex_fields.union(self._defaults.keys())
         if self.input_field:
             self.fields = self.fields.union((self.input_field, ))
         self.clear()
-        
+
     def update_defaults(self, d):
         """Update the default values used for the match with the values in d.
         """
         if d:
             self._defaults.update(d)
             self._update_fields()
-                
+
     def match(self, str_, *args):
         self.clear() # to be safe
         self.input_string = str_
@@ -113,34 +113,34 @@ class RegexPattern(collections.UserDict, RegexPatternBase):
             else:
                 raise exceptions.RegexParseError(
                     f"Couldn't match {str_} against {self.regex}.")
-        else:    
+        else:
             self.data = m.groupdict(default=NOTSET)
             for k,v in self._defaults.items():
                 if self.data.get(k, NOTSET) is NOTSET:
                     self.data[k] = v
             if self.input_field:
                 self.data[self.input_field] = m.string
-            
+
             self._validate_match(m)
             if any(self.data[f] == NOTSET for f in self.fields):
                 bad_names = [f for f in self.fields if self.data[f] == NOTSET]
                 raise exceptions.RegexParseError((f"Couldn't match the "
                     f"following fields in {str_}: " + ', '.join(bad_names) ))
             self.is_matched = True
-        
+
     def _validate_match(self, match_obj):
         """Hook for post-processing of match, running after all fields are
-        assigned but before final check that all fields are set. 
+        assigned but before final check that all fields are set.
         """
         pass
-    
+
     def __str__(self):
         if not self.is_matched:
             str_ = ', '.join(self.fields)
         else:
             str_ = ', '.join([f'{k}={v}' for k,v in self.data.items()])
         return f"<{self.__class__.__name__}({str_})>"
-    
+
     def __copy__(self):
         if hasattr(self._match_error_filter, 'copy'):
             match_error_filter_copy = self._match_error_filter.copy()
@@ -170,15 +170,15 @@ class RegexPatternWithTemplate(RegexPattern):
     """Adds formatted output to RegexPattern.
 
         Args:
-            template: str, optional. Template string to use for formatting 
+            template: str, optional. Template string to use for formatting
                 contents of match in format() method. Contents of the matched
                 fields will be subsituted using the {}-syntax of python string
                 formatting.
             Other arguments the same
     """
-    def __init__(self, regex, defaults=None, input_field=None, 
+    def __init__(self, regex, defaults=None, input_field=None,
         match_error_filter=None, template=None):
-        super(RegexPatternWithTemplate, self).__init__(regex, defaults=defaults, 
+        super(RegexPatternWithTemplate, self).__init__(regex, defaults=defaults,
             input_field=input_field, match_error_filter=match_error_filter)
         self.template = template
         for f in self.fields:
@@ -218,9 +218,9 @@ class RegexPatternWithTemplate(RegexPattern):
         )
         obj.data = copy.deepcopy(self.data, memo)
         return obj
-    
+
 class ChainedRegexPattern(RegexPatternBase):
-    """Class which takes an 'or' of multiple RegexPatterns. Matches are 
+    """Class which takes an 'or' of multiple RegexPatterns. Matches are
     attempted on the supplied RegexPatterns in order, with the first one that
     succeeds determining the returned answer. Public methods work the same as
     on RegexPattern.
@@ -245,40 +245,40 @@ class ChainedRegexPattern(RegexPatternBase):
                 pat.update_defaults(defaults)
             if input_field:
                 pat.input_field = input_field
-            pat._match_error_filter = None   
+            pat._match_error_filter = None
             pat._update_fields()
         self._update_fields()
 
     @property
     def is_matched(self):
         return (self._match >= 0)
-    
+
     @property
     def data(self):
         if self.is_matched:
             return self._patterns[self._match].data
         else:
             return dict()
-        
+
     def clear(self):
         for pat in self._patterns:
             pat.clear()
         self._match = -1
         self.input_string = ""
-    
+
     def _update_fields(self):
         self.fields = self._patterns[0].fields
         for pat in self._patterns:
             if pat.fields != self.fields:
                 raise ValueError("Incompatible fields.")
         self.clear()
-    
+
     def update_defaults(self, d):
         if d:
             for pat in self._patterns:
                 pat.update_defaults(d)
         self._update_fields()
-                
+
     def match(self, str_, *args):
         self.clear()
         self.input_string = str_
@@ -303,30 +303,30 @@ class ChainedRegexPattern(RegexPatternBase):
             else:
                 raise exceptions.RegexParseError((f"Couldn't match {str_} "
                     f"against any pattern in {self.__class__.__name__}."))
-    
+
     def __str__(self):
         if not self.is_matched:
             str_ = ', '.join(self.fields)
         else:
             str_ = ', '.join([f'{k}={v}' for k,v in self.data.items()])
         return f"<{self.__class__.__name__}({str_})>"
-    
+
     def format(self):
         if not self.is_matched:
             raise ValueError('No match')
         return self._patterns[self._match].format()
-    
+
     def __copy__(self):
         new_pats = (pat.copy() for pat in self._patterns)
         return self.__class__(
-            *new_pats, 
+            *new_pats,
             match_error_filter=self._match_error_filter.copy()
         )
 
     def __deepcopy__(self, memo):
         new_pats = (copy.deepcopy(pat, memo) for pat in self._patterns)
         return self.__class__(
-            *new_pats, 
+            *new_pats,
             match_error_filter=copy.deepcopy(self._match_error_filter, memo)
         )
 
@@ -334,25 +334,25 @@ class ChainedRegexPattern(RegexPatternBase):
 
 NOTSET = basic.sentinel_object_factory('NotSet')
 NOTSET.__doc__ = """
-Sentinel object to detect uninitialized values, in cases where ``None`` is a 
-valid value. 
+Sentinel object to detect uninitialized values, in cases where ``None`` is a
+valid value.
 """
 
 MANDATORY = basic.sentinel_object_factory('Mandatory')
 MANDATORY.__doc__ = """
-Sentinel object to mark :func:`mdtf_dataclass` fields that do not take a default 
+Sentinel object to mark :func:`mdtf_dataclass` fields that do not take a default
 value. This is a workaround to avoid errors with non-default fields coming after
-default fields in the dataclass-generated ``__init__`` method under 
+default fields in the dataclass-generated ``__init__`` method under
 `inheritance <https://docs.python.org/3/library/dataclasses.html#inheritance>`__:
 we use the second solution described in `<https://stackoverflow.com/a/53085935>`__.
 """
 
 def _mdtf_dataclass_get_field_types(obj, f):
     """Common functionality for :func:`_mdtf_dataclass_type_coercion` and
-    :func:`_mdtf_dataclass_type_check`. Given a :py:class:`datacalsses.Field` 
+    :func:`_mdtf_dataclass_type_check`. Given a :py:class:`datacalsses.Field`
     object *f*, return either a tuple of the type its value should be coerced to
     and a tuple of the valid types its value can have, or (None, None) to signal
-    a case we don't handle. 
+    a case we don't handle.
     """
     if not f.init:
         # ignore fields that aren't handled at init
@@ -387,7 +387,7 @@ def _mdtf_dataclass_get_field_types(obj, f):
     else:
         new_type = f.type
         valid_types = [new_type]
-    # Get types of field's default value, if present. Dataclass doesn't 
+    # Get types of field's default value, if present. Dataclass doesn't
     # require defaults to be same type as what's given for field.
     if not isinstance(f.default, dataclasses._MISSING_TYPE):
         valid_types.append(type(f.default))
@@ -396,12 +396,12 @@ def _mdtf_dataclass_get_field_types(obj, f):
     return (new_type, valid_types)
 
 def _mdtf_dataclass_type_coercion(self):
-    """Do type checking on all dataclass fields after the auto-generated 
+    """Do type checking on all dataclass fields after the auto-generated
     ``__init__`` method, but before any ``__post_init__`` method.
 
     .. warning::
-       Type checking logic used is specific to the ``typing`` module in python 
-       3.7. It may or may not work on newer pythons, and definitely will not 
+       Type checking logic used is specific to the ``typing`` module in python
+       3.7. It may or may not work on newer pythons, and definitely will not
        work with 3.5 or 3.6. See `<https://stackoverflow.com/a/52664522>`__.
     """
     for f in dataclasses.fields(self):
@@ -422,7 +422,7 @@ def _mdtf_dataclass_type_coercion(self):
                     new_value = new_type(value)
                 # https://stackoverflow.com/a/54119384 for implementation
                 object.__setattr__(self, f.name, new_value)
-        except (TypeError, ValueError, dataclasses.FrozenInstanceError) as exc: 
+        except (TypeError, ValueError, dataclasses.FrozenInstanceError) as exc:
             raise exceptions.DataclassParseError((f"{self.__class__.__name__}: "
                 f"Couldn't coerce value {repr(value)} for field {f.name} from "
                 f"type {type(value)} to type {new_type}.")) from exc
@@ -431,12 +431,12 @@ def _mdtf_dataclass_type_coercion(self):
             raise exc
 
 def _mdtf_dataclass_type_check(self):
-    """Do type checking on all dataclass fields after ``__init__`` and 
+    """Do type checking on all dataclass fields after ``__init__`` and
     ``__post_init__`` methods.
 
     .. warning::
-       Type checking logic used is specific to the ``typing`` module in python 
-       3.7. It may or may not work on newer pythons, and definitely will not 
+       Type checking logic used is specific to the ``typing`` module in python
+       3.7. It may or may not work on newer pythons, and definitely will not
        work with 3.5 or 3.6. See `<https://stackoverflow.com/a/52664522>`__.
     """
     for f in dataclasses.fields(self):
@@ -453,7 +453,7 @@ def _mdtf_dataclass_type_check(self):
                 f"Expected {f.name} to be {f.type}, got {type(value)} "
                 f"({repr(value)})."))
 
-DEFAULT_MDTF_DATACLASS_KWARGS = {'init': True, 'repr': True, 'eq': True, 
+DEFAULT_MDTF_DATACLASS_KWARGS = {'init': True, 'repr': True, 'eq': True,
     'order': False, 'unsafe_hash': False, 'frozen': False}
 
 # declaration to allow calling with and without args: python cookbook 9.6
@@ -468,20 +468,20 @@ def mdtf_dataclass(cls=None, **deco_kwargs):
     following tasks are performed:
 
     1. Verify that mandatory fields have values specified. We have to work around
-       the usual :py:func:`~dataclasses.dataclass` way of doing this, because it 
-       leads to errors in the signature of the dataclass-generated ``__init__`` 
-       method under inheritance (mandatory fields can't come after optional 
+       the usual :py:func:`~dataclasses.dataclass` way of doing this, because it
+       leads to errors in the signature of the dataclass-generated ``__init__``
+       method under inheritance (mandatory fields can't come after optional
        fields.) Mandatory fields must be designated by setting their default to
-       ``MANDATORY``, and a DataclassParseError is raised here if mandatory fields 
+       ``MANDATORY``, and a DataclassParseError is raised here if mandatory fields
        are uninitialized.
 
-    2. Check each field's value to see if it's consistent with known type info. 
+    2. Check each field's value to see if it's consistent with known type info.
        If not, attempt to coerce it to that type, using a ``from_struct`` method if
        it exists. Raise DataclassParseError if this fails.
 
     .. warning::
-       Unlike :py:func:`~dataclasses.dataclass`, all fields **must** have a 
-       *default* or *default_factory* defined. Fields which are mandatory must 
+       Unlike :py:func:`~dataclasses.dataclass`, all fields **must** have a
+       *default* or *default_factory* defined. Fields which are mandatory must
        have their default value set to the sentinel object ``MANDATORY``.
     """
     dc_kwargs = DEFAULT_MDTF_DATACLASS_KWARGS.copy()
@@ -504,9 +504,9 @@ def mdtf_dataclass(cls=None, **deco_kwargs):
     _old_post_init = cls.__post_init__
     @functools.wraps(_old_post_init)
     def _new_post_init(self, *args, **kwargs):
-        _mdtf_dataclass_type_coercion(self)      
+        _mdtf_dataclass_type_coercion(self)
         _old_post_init(self, *args, **kwargs)
-        _mdtf_dataclass_type_check(self)     
+        _mdtf_dataclass_type_check(self)
     type.__setattr__(cls, '__post_init__', _new_post_init)
 
     return cls
@@ -553,23 +553,23 @@ def _regex_dataclass_preprocess_kwargs(self, kwargs):
     return (new_kw, post_init)
 
 def regex_dataclass(pattern, **deco_kwargs):
-    """Decorator for a dataclass that adds a from_string classmethod which 
-    creates instances of that dataclass by parsing an input string with a 
+    """Decorator for a dataclass that adds a from_string classmethod which
+    creates instances of that dataclass by parsing an input string with a
     :class:`RegexPattern` or :class:`ChainedRegexPattern`. The values of all
-    fields returned by the match() method of the pattern are passed to the 
+    fields returned by the match() method of the pattern are passed to the
     __init__ method of the dataclass as kwargs.
 
-    Additionally, if the type of one or more fields is set to a class that's 
-    also been decorated with regex_dataclass, the parsing logic for that field's 
+    Additionally, if the type of one or more fields is set to a class that's
+    also been decorated with regex_dataclass, the parsing logic for that field's
     regex_dataclass will be invoked on that field's value (ie, a string obtained
     by regex matching in *this* regex_dataclass), and the parsed values of those
-    fields will be supplied to this regex_dataclass constructor. This is our 
+    fields will be supplied to this regex_dataclass constructor. This is our
     implementation of composition for regex_dataclasses.
 
     .. note::
-       Unlike :func:`mdtf_dataclass`, type coercion is done *after* 
-       ``__post_init__`` for these dataclasses. This is necessary due to 
-       composition: if a regex_dataclass is being instantiated as a field of 
+       Unlike :func:`mdtf_dataclass`, type coercion is done *after*
+       ``__post_init__`` for these dataclasses. This is necessary due to
+       composition: if a regex_dataclass is being instantiated as a field of
        another regex_dataclass, all values being passed to it will be strings
        (the regex fields), and type coercion is the job of ``__post_init__``.
     """
@@ -578,7 +578,7 @@ def regex_dataclass(pattern, **deco_kwargs):
 
     def _dataclass_decorator(cls):
         if '__post_init__' not in cls.__dict__:
-            # Prevent class from inheriting __post_init__ from parents if it 
+            # Prevent class from inheriting __post_init__ from parents if it
             # doesn't overload it (which is why we use __dict__ and not
             # hasattr().) __post_init__ of all parents will have been called when
             # the parent classes are instantiated by _regex_dataclass_preprocess_kwargs.
@@ -612,8 +612,8 @@ def regex_dataclass(pattern, **deco_kwargs):
             else:
                 _old_init(self, first_arg, *args, **new_kw)
 
-            _mdtf_dataclass_type_coercion(self)      
-            _mdtf_dataclass_type_check(self)     
+            _mdtf_dataclass_type_coercion(self)
+            _mdtf_dataclass_type_check(self)
         type.__setattr__(cls, '__init__', _new_init)
 
         def _from_string(cls_, str_, *args):
@@ -627,7 +627,7 @@ def regex_dataclass(pattern, **deco_kwargs):
     return _dataclass_decorator
 
 def dataclass_factory(dataclass_decorator, class_name, *parents, **kwargs):
-    """Function that returns a dataclass (ie, a decorated class) whose fields 
+    """Function that returns a dataclass (ie, a decorated class) whose fields
     are the union of the fields specified in its parent classes.
 
     Args:
@@ -637,7 +637,7 @@ def dataclass_factory(dataclass_decorator, class_name, *parents, **kwargs):
             the collection determines the MRO.
         kwargs: optional; arguments to pass to dataclass_decorator when it's
             applied to produce the returned class.
-    """ 
+    """
     def _to_dataclass(self, cls_, **kwargs_):
         f"""Method to create an instance of one of the parent classes of
         {class_name} by copying over the relevant subset of fields.
@@ -669,18 +669,18 @@ def dataclass_factory(dataclass_decorator, class_name, *parents, **kwargs):
 # ----------------------------------------------------
 
 def filter_dataclass(d, dc, init=False):
-    """Return a dict of the subset of fields or entries in d that correspond to 
+    """Return a dict of the subset of fields or entries in d that correspond to
     the fields in dataclass dc.
 
     Args:
         d: (dict, dataclass or dataclass instance):
-        dc: (dataclass or dataclass instance): 
+        dc: (dataclass or dataclass instance):
         init: bool or 'all', default False:
 
-            - If False: Include only the fields of dc (as returned by 
+            - If False: Include only the fields of dc (as returned by
                 :py:func:`dataclasses.fields`.)
             - If True: Include only the arguments to dc's constructor (ie, include
-                any `init-only fields 
+                any `init-only fields
                 <https://docs.python.org/3/library/dataclasses.html#init-only-variables>`__
                 and exclude any of dc's fields with init=False.
             - If 'all': Include the union of the above two options.
@@ -701,15 +701,15 @@ def filter_dataclass(d, dc, init=False):
             if (f.name in d and f.init)}
     if init or (init == 'all'):
         init_fields = filter(
-            (lambda f: f.type == dataclasses.InitVar), 
+            (lambda f: f.type == dataclasses.InitVar),
             dc.__dataclass_fields__.values()
         )
         ans.update({f.name: d[f.name] for f in init_fields if f.name in d})
     return ans
-    
+
 def coerce_to_dataclass(d, dc, **kwargs):
     """Given a dataclass dc (may be the class or an instance of it), and a dict,
-    dataclass or dataclass instance d, return an instance of dc's class with 
+    dataclass or dataclass instance d, return an instance of dc's class with
     field values initialized from those in d, along with any extra values
     passed in kwargs.
     """

--- a/src/util/datelabel.py
+++ b/src/util/datelabel.py
@@ -1,4 +1,4 @@
-"""Classes and utility methods for dealing with dates as expressed in filenames 
+"""Classes and utility methods for dealing with dates as expressed in filenames
 and paths. Intended use case is, eg, determining if a file contains data for a
 given year from the filename, without having to open it and parse the header.
 
@@ -6,11 +6,11 @@ Note:
     These classes should *not* be used for calendar math! We currently implement
     and test comparison logic only, not anything more (eg addition, subtraction).
 
-Note: 
+Note:
     These classes are based on the datetime standard library, and as such assume
     a proleptic Gregorian calendar for *all* dates.
 
-Note: 
+Note:
     Timezone support is not currently implemented.
 """
 import abc
@@ -44,15 +44,15 @@ class AtomicInterval(object):
 
     def __init__(self, left, lower, upper, right):
         """Create an atomic interval.
-        If a bound is set to infinity (regardless of its sign), the 
+        If a bound is set to infinity (regardless of its sign), the
         corresponding boundary will be exclusive.
 
         Args:
-            left: Boolean indicating if left boundary is inclusive (True) or 
+            left: Boolean indicating if left boundary is inclusive (True) or
                 exclusive (False).
             lower: value of the lower bound.
             upper: value of the upper bound.
-            right: Boolean indicating if right boundary is inclusive (True) 
+            right: Boolean indicating if right boundary is inclusive (True)
                 or exclusive (False).
         """
         self._left = bool(left)
@@ -67,7 +67,7 @@ class AtomicInterval(object):
 
     @property
     def left(self):
-        """Boolean indicating whether the left boundary is inclusive (True) or 
+        """Boolean indicating whether the left boundary is inclusive (True) or
         exclusive (False).
         """
         return self._left
@@ -86,7 +86,7 @@ class AtomicInterval(object):
 
     @property
     def right(self):
-        """Boolean indicating whether the right boundary is inclusive (True) or 
+        """Boolean indicating whether the right boundary is inclusive (True) or
         exclusive (False).
         """
         return self._right
@@ -103,8 +103,8 @@ class AtomicInterval(object):
 
     def replace(self, left=None, lower=None, upper=None, right=None, ignore_inf=True):
         """Create a new interval based on the current one and the provided values.
-        Callable can be passed instead of values. In that case, it is called 
-        with the current corresponding value except if ignore_inf if set 
+        Callable can be passed instead of values. In that case, it is called
+        with the current corresponding value except if ignore_inf if set
         (default) and the corresponding bound is an infinity.
 
         Args:
@@ -112,7 +112,7 @@ class AtomicInterval(object):
             lower: (a function of) value of the lower bound.
             upper: (a function of) value of the upper bound.
             right: (a function of) right boundary.
-            ignore_inf: ignore infinities if functions are provided 
+            ignore_inf: ignore infinities if functions are provided
                 (default is True).
 
         Returns: an Interval instance
@@ -141,8 +141,8 @@ class AtomicInterval(object):
 
     def overlaps(self, other, adjacent=False):
         """Test if intervals have any overlapping value.
-        If 'adjacent' is set to True (default is False), then it returns True 
-        for adjacent intervals as well (e.g., [1, 2) and [2, 3], but not 
+        If 'adjacent' is set to True (default is False), then it returns True
+        for adjacent intervals as well (e.g., [1, 2) and [2, 3], but not
         [1, 2) and (2, 3]).
         :param other: an atomic interval.
         :param adjacent: set to True to accept adjacent intervals as well.
@@ -174,8 +174,8 @@ class AtomicInterval(object):
         return self & other
 
     def union(self, other):
-        """Return the union of two intervals. If the union cannot be represented 
-        using a single atomic interval, return an Interval instance (which 
+        """Return the union of two intervals. If the union cannot be represented
+        using a single atomic interval, return an Interval instance (which
         corresponds to an union of atomic intervals).
         :param other: an interval.
         :return: the union of the intervals.
@@ -331,7 +331,7 @@ class AtomicInterval(object):
     def adjoins_left(self, other):
         # self < other
         return self._right != other._left and self._upper == other._lower
-    
+
     def adjoins_right(self, other):
         # other < self
         return self._left != other._right and self._lower == other._upper
@@ -352,13 +352,13 @@ class AtomicInterval(object):
             if not ints[i].adjoins_left(ints[i+1]):
                 raise ValueError(("Intervals {} and {} not contiguous and "
                     "nonoverlapping.").format(ints[i], ints[i+1]))
-        return AtomicInterval(ints[0].left, ints[0].lower, 
+        return AtomicInterval(ints[0].left, ints[0].lower,
             ints[-1].upper, ints[-1].right)
 
 # ===============================================================
 
 class DatePrecision(enum.IntEnum):
-    """:py:class:`~enum.IntEnum` to encode the recognized levels of precision 
+    """:py:class:`~enum.IntEnum` to encode the recognized levels of precision
     for date intervals. For example, Date('200012') has DatePrecision.MONTH since
     the length of the corresponding interval is a month.
     """
@@ -376,13 +376,13 @@ class _DateMixin(object):
     @staticmethod
     def date_format(dt, precision=None):
         """Print date in YYYYMMDDHHMMSS format, with length being set automatically
-        from precision. 
-        
+        from precision.
+
         Note:
             strftime() is broken for dates prior to 1900 in python < 3.3, see
-            `<https://bugs.python.org/issue1777412>`__ and 
+            `<https://bugs.python.org/issue1777412>`__ and
             `<https://stackoverflow.com/q/10263956>`__.
-            For this reason, the workaround implemented here should be used 
+            For this reason, the workaround implemented here should be used
             instead.
         """
         tup_ = dt.timetuple()
@@ -430,7 +430,7 @@ class _DateMixin(object):
                 return datetime.datetime.min
         if precision == DatePrecision.YEAR:
             # nb: can't handle this with timedeltas
-            return dt.replace(year=(dt.year + delta)) 
+            return dt.replace(year=(dt.year + delta))
         elif precision == DatePrecision.DAY:
             td = datetime.timedelta(days = delta)
         elif precision == DatePrecision.HOUR:
@@ -446,11 +446,11 @@ class _DateMixin(object):
 
 
 class DateRange(AtomicInterval, _DateMixin):
-    """Class representing a range of variable-precision dates. 
+    """Class representing a range of variable-precision dates.
 
     Note:
-        This is defined as a *closed* interval (containing both endpoints). 
-        Eg, DateRange('1990-1999') starts at 0:00 on 1 Jan 1990 and 
+        This is defined as a *closed* interval (containing both endpoints).
+        Eg, DateRange('1990-1999') starts at 0:00 on 1 Jan 1990 and
         ends at 23:59 on 31 Dec 1999.
     """
     _range_sep = '-'
@@ -473,7 +473,7 @@ class DateRange(AtomicInterval, _DateMixin):
             dt0, prec0 = self._coerce_to_datetime(end, is_lower=True)
             dt1, prec1 = self._coerce_to_datetime(start, is_lower=False)
         # call AtomicInterval's init
-        super(DateRange, self).__init__(self.CLOSED, dt0, dt1, self.OPEN)   
+        super(DateRange, self).__init__(self.CLOSED, dt0, dt1, self.OPEN)
         if precision is not None:
             if not isinstance(precision, DatePrecision):
                 precision = (DatePrecision)
@@ -514,7 +514,7 @@ class DateRange(AtomicInterval, _DateMixin):
         if isinstance(dt, datetime.date):
             # date specifies time to within day
             return (
-                datetime.datetime.combine(dt, datetime.datetime.min.time()), 
+                datetime.datetime.combine(dt, datetime.datetime.min.time()),
                 DatePrecision.DAY
             )
         else:
@@ -535,7 +535,7 @@ class DateRange(AtomicInterval, _DateMixin):
             try:
                 if precision is not None:
                     return cls(item, precision=precision)
-                else: 
+                else:
                     return cls(item)
             except Exception:
                 raise TypeError((f"Comparison not supported between {cls.__name__} "
@@ -562,7 +562,7 @@ class DateRange(AtomicInterval, _DateMixin):
         # input is the start of the interval (set by precision)
         assert self.precision
         return Date(
-            self.decrement(self.end_datetime, self.precision + 1), 
+            self.decrement(self.end_datetime, self.precision + 1),
             precision=self.precision
         )
 
@@ -624,7 +624,7 @@ class DateRange(AtomicInterval, _DateMixin):
     def overlaps(self, item):
         item = self._coerce_to_self(item)
         return super(DateRange, self).overlaps(item, adjacent=False)
-    
+
     def intersection(self, item, precision=None):
         item = self._coerce_to_self(item)
         if not self.overlaps(item):
@@ -642,7 +642,7 @@ class DateRange(AtomicInterval, _DateMixin):
         _meth = getattr(super(DateRange, self), func_name)
         return _meth(_other)
 
-    def __lt__(self, other): 
+    def __lt__(self, other):
         return self._date_range_compare_common(other, '__lt__')
     def __le__(self, other):
         return self._date_range_compare_common(other, '__le__')
@@ -666,9 +666,9 @@ class DateRange(AtomicInterval, _DateMixin):
 class Date(DateRange):
     """Define a date with variable level precision.
 
-    Note: 
-        Date objects are mapped to datetimes representing the start of the 
-        interval implied by their precision, eg. DateTime('2000-05') maps to 
+    Note:
+        Date objects are mapped to datetimes representing the start of the
+        interval implied by their precision, eg. DateTime('2000-05') maps to
         0:00 on 1 May 2000.
     """
 
@@ -710,7 +710,7 @@ class Date(DateRange):
     @classmethod
     def _parse_datetime(cls, dt):
         # new obj from coercing a datetime.date or datetime.datetime.
-        # A bit hacky, but no other portable way to copy the input datetime 
+        # A bit hacky, but no other portable way to copy the input datetime
         # using one of its class methods in py2.7.
         ans = []
         for attr in cls._datetime_attrs:
@@ -730,7 +730,7 @@ class Date(DateRange):
         for i in list(range(4, len(s), 2)):
             ans.append(int(s[i:(i+2)]))
         return tuple(ans)
-    
+
     def format(self, precision=None):
         if precision:
             return self.date_format(self.lower, precision)
@@ -761,8 +761,8 @@ class Date(DateRange):
             self.lower.timetuple()[:self.precision],
             other.lower.timetuple()[:self.precision]
         )
-   
-    def __lt__(self, other): 
+
+    def __lt__(self, other):
         return self._tuple_compare(other, op.lt)
 
     def __gt__(self, other):
@@ -776,7 +776,7 @@ class Date(DateRange):
 
     def __eq__(self, other):
         """Overload datetime.datetime's __eq__. Require precision to match as
-        well as date, but *only up to stated precision*, eg Date(2019,5) will == 
+        well as date, but *only up to stated precision*, eg Date(2019,5) will ==
         datetime.datetime(2019,05,18).
         """
         try:
@@ -791,7 +791,7 @@ class Date(DateRange):
         return hash((self.__class__, self.lower, self.upper, self.precision))
 
 class StaticTimeDependenceBase(object):
-    """Dummy class to label sentinel objects for use in describing static data 
+    """Dummy class to label sentinel objects for use in describing static data
     with no time dependence.
     """
     @property
@@ -809,7 +809,7 @@ class StaticTimeDependenceBase(object):
         return "<N/A>"
     isoformat = format
     __str__ = format
-    
+
     @staticmethod
     def date_format(dt, precision=None):
         return "<N/A>"
@@ -823,7 +823,7 @@ class _FXDateMin(StaticTimeDependenceBase, Date):
         self.precision = DatePrecision.STATIC
 
     def __repr__(self):
-        return "_FXDate()" 
+        return "_FXDate()"
 
     @property
     def start(self):
@@ -843,7 +843,7 @@ class _FXDateMax(StaticTimeDependenceBase, Date):
         self.precision = DatePrecision.STATIC
 
     def __repr__(self):
-        return "_FXDateMax()" 
+        return "_FXDateMax()"
 
     @property
     def start(self):
@@ -855,7 +855,7 @@ class _FXDateMax(StaticTimeDependenceBase, Date):
 FXDateMax = _FXDateMax()
 
 class _FXDateRange(StaticTimeDependenceBase, DateRange):
-    """Singleton placeholder/sentinel object for use in describing static data 
+    """Singleton placeholder/sentinel object for use in describing static data
     with no time dependence.
     """
     def __init__(self):
@@ -880,7 +880,7 @@ class DateFrequency(datetime.timedelta):
 
     .. warning::
        Period lengths are *not* defined accurately, eg. a year is taken as
-       365 days and a month is taken as 30 days. 
+       365 days and a month is taken as 30 days.
     """
     # define __new__, not __init__, because timedelta is immutable
     def __new__(cls, quantity, unit=None):
@@ -907,7 +907,7 @@ class DateFrequency(datetime.timedelta):
     @classmethod
     def from_struct(cls, str_):
         """Workaround for object creation, using the method mdtf_dataclass is
-        looking for. 
+        looking for.
         """
         return cls.__new__(cls, str_, None)
 
@@ -923,15 +923,15 @@ class DateFrequency(datetime.timedelta):
                 s = match.group('unit')
             else:
                 q = 1
-        
+
         if s in ['fx', 'static']:
             q = 0
             s = 'fx'
         elif s in ['yearly', 'year', 'years', 'yr', 'y', 'annually', 'annual', 'ann']:
             s = 'yr'
-        elif s in ['seasonally', 'seasonal', 'seasons', 'season', 'se']:      
+        elif s in ['seasonally', 'seasonal', 'seasons', 'season', 'se']:
             s = 'season'
-        elif s in ['monthly', 'month', 'months', 'mon', 'mo']:      
+        elif s in ['monthly', 'month', 'months', 'mon', 'mo']:
             s = 'mo'
         elif s in ['weekly', 'weeks', 'week', 'wk', 'w']:
             s = 'wk'
@@ -950,7 +950,7 @@ class DateFrequency(datetime.timedelta):
         if s == 'fx':
             # internally set to maximum representable timedelta, for purposes of comparison
             tmp = datetime.timedelta.max
-            return {'days': tmp.days, 'seconds': tmp.seconds, 
+            return {'days': tmp.days, 'seconds': tmp.seconds,
                 'microseconds': tmp.microseconds
             }
         elif s == 'yr':
@@ -1009,7 +1009,7 @@ class DateFrequency(datetime.timedelta):
         return self.__class__.__new__(self.__class__, self.quantity, unit=self.unit)
 
     def __deepcopy__(self, memo):
-        return self.__class__.__new__(self.__class__, 
+        return self.__class__.__new__(self.__class__,
             copy.deepcopy(self.quantity, memo), unit=copy.deepcopy(self.unit, memo)
         )
 
@@ -1017,7 +1017,7 @@ class DateFrequency(datetime.timedelta):
         return hash((self.__class__, self.quantity, self.unit))
 
 class _FXDateFrequency(DateFrequency, StaticTimeDependenceBase):
-    """Singleton placeholder/sentinel object for use in describing static data 
+    """Singleton placeholder/sentinel object for use in describing static data
     with no time dependence.
     """
     # define __new__, not __init__, because timedelta is immutable
@@ -1052,8 +1052,8 @@ class AbstractDateFrequency(abc.ABC):
     pass
 
 
-# Use the "register" method, instead of inheritance, to identify the 
-# DM*Dimension classes as implementations of AbstractDMDimension, because 
+# Use the "register" method, instead of inheritance, to identify the
+# DM*Dimension classes as implementations of AbstractDMDimension, because
 # Python dataclass fields aren't recognized as implementing an abc.abstractmethod.
 AbstractDateRange.register(DateRange)
 AbstractDateRange.register(_FXDateRange)

--- a/src/util/exceptions.py
+++ b/src/util/exceptions.py
@@ -1,4 +1,4 @@
-"""All framework-specific exceptions are placed in a single module to simplify 
+"""All framework-specific exceptions are placed in a single module to simplify
 imports.
 """
 import os
@@ -32,7 +32,7 @@ class ExceptionQueue(object):
 
 def exit_on_exception(exc, msg=None):
     """Prints information about a fatal exception to the console beofre exiting.
-    Use case is in user-facing subcommands (``mdtf install`` etc.), since we 
+    Use case is in user-facing subcommands (``mdtf install`` etc.), since we
     have more sophisticated logging in the framework itself.
     Args:
         exc: :py:class:`Exception` object
@@ -85,26 +85,26 @@ class WormKeyError(KeyError, MDTFBaseException):
     pass
 
 class DataclassParseError(ValueError, MDTFBaseException):
-    """Raised when parsing input data fails on a 
+    """Raised when parsing input data fails on a
     :func:`~src.util.dataclass.mdtf_dataclass` or :func:`~src.util.dataclass.regex_dataclass`.
     """
     pass
 
 class RegexParseError(ValueError, MDTFBaseException):
-    """Raised when parsing input data fails on a 
+    """Raised when parsing input data fails on a
     :func:`~src.util.dataclass.RegexPattern`.
     """
     pass
 
 class RegexSuppressedError(ValueError, MDTFBaseException):
     """Raised when parsing input data fails on a
-    :func:`~src.util.dataclass.RegexPattern`, but we've decided to supress 
+    :func:`~src.util.dataclass.RegexPattern`, but we've decided to supress
     error based on the associated RegexPattern's match_error_filter attribute.
     """
     pass
 
 class UnitsError(ValueError, MDTFBaseException):
-    """Raised when trying to convert between quantities with physically 
+    """Raised when trying to convert between quantities with physically
     inequivalent units.
     """
     pass
@@ -118,7 +118,7 @@ class ConventionError(MDTFBaseException):
         return f"Error in the definition of convention '{self.conv_name}'."
 
 class MixedDatePrecisionException(MDTFBaseException):
-    """Exception raised when we attempt to operate on :class:`Date` or 
+    """Exception raised when we attempt to operate on :class:`Date` or
     :class:`DateRange` objects with differing levels of precision, which shouldn't
     happen with data sampled at a single frequency.
     """
@@ -131,9 +131,9 @@ class MixedDatePrecisionException(MDTFBaseException):
             "placeholder: {}.").format(self.func_name, self.msg)
 
 class FXDateException(MDTFBaseException):
-    """Exception raised when :class:`FXDate` or :class:`FXDateRange` classes, 
-    which are placeholder/sentinel classes used to indicate static data with no 
-    time dependence, are accessed like real :class:`Date` or :class:`DateRange` 
+    """Exception raised when :class:`FXDate` or :class:`FXDateRange` classes,
+    which are placeholder/sentinel classes used to indicate static data with no
+    time dependence, are accessed like real :class:`Date` or :class:`DateRange`
     objects.
     """
     def __init__(self, func_name='', msg=''):
@@ -145,7 +145,7 @@ class FXDateException(MDTFBaseException):
             "placeholder: {}.").format(self.func_name, self.msg)
 
 class DataExceptionBase(MDTFBaseException):
-    """Base class and common formatting code for exceptions raised in data 
+    """Base class and common formatting code for exceptions raised in data
     query/fetch.
     """
     _error_str = ""
@@ -175,8 +175,8 @@ class DataExceptionBase(MDTFBaseException):
         return f"{self.__class__.__name__}({str(self)})"
 
 class DataQueryError(DataExceptionBase):
-    """Exception signaling a failure to find requested data in the remote location. 
-    
+    """Exception signaling a failure to find requested data in the remote location.
+
     Raised by :meth:`~data_manager.DataManager.queryData` to signal failure of a
     data query. Should be caught properly in :meth:`~data_manager.DataManager.planData`
     or :meth:`~data_manager.DataManager.fetchData`.
@@ -195,7 +195,7 @@ class DataFetchError(DataExceptionBase):
     _error_str = "Data fetch error"
 
 class DataPreprocessError(DataExceptionBase):
-    """Exception signaling an error in preprocessing data after it's been 
+    """Exception signaling an error in preprocessing data after it's been
     fetched, but before any PODs run.
     """
     _error_str = "Data preprocessing error"
@@ -243,12 +243,12 @@ class PodConfigError(PodExceptionBase):
     _error_str = "Couldn't parse the settings.jsonc file"
 
 class PodDataError(PodExceptionBase):
-    """Exception raised if POD doesn't have required data to run. 
+    """Exception raised if POD doesn't have required data to run.
     """
     _error_str = "Requested data not available"
 
 class PodRuntimeError(PodExceptionBase):
-    """Exception raised if POD doesn't have required resources to run. 
+    """Exception raised if POD doesn't have required resources to run.
     """
     _error_str = "Error in setting the runtime environment"
 

--- a/src/util/filesystem.py
+++ b/src/util/filesystem.py
@@ -17,7 +17,7 @@ import logging
 _log = logging.getLogger(__name__)
 
 def abbreviate_path(path, old_base, new_base=None):
-    """Express path as a path relative to old_base, optionally prepending 
+    """Express path as a path relative to old_base, optionally prepending
     new_base.
     """
     ps = tuple(os.path.abspath(p) for p in (path, old_base))
@@ -34,7 +34,7 @@ def resolve_path(path, root_path="", env=None):
         root_path (:obj:`str`, optional): root path to resolve `path` with. If
             not given, resolves relative to `cwd`.
 
-    Returns: Absolute version of `path`, relative to `root_path` if given, 
+    Returns: Absolute version of `path`, relative to `root_path` if given,
         otherwise relative to `os.getcwd`.
     """
     def _expandvars(path, env_dict):
@@ -45,8 +45,8 @@ def resolve_path(path, root_path="", env=None):
         escaped characters and not changing unrecognized variables.
         """
         return re.sub(
-            r'\$(\w+|\{([^}]*)\})', 
-            lambda m: env_dict.get(m.group(2) or m.group(1), m.group(0)), 
+            r'\$(\w+|\{([^}]*)\})',
+            lambda m: env_dict.get(m.group(2) or m.group(1), m.group(0)),
             path
         )
 
@@ -66,14 +66,14 @@ def resolve_path(path, root_path="", env=None):
     assert os.path.isabs(root_path)
     return os.path.normpath(os.path.join(root_path, path))
 
-def recursive_copy(src_files, src_root, dest_root, copy_function=None, 
+def recursive_copy(src_files, src_root, dest_root, copy_function=None,
     overwrite=False):
     """Copy src_files to dest_root, preserving relative subdirectory structure.
 
     Copies a subset of files in a directory subtree rooted at src_root to an
     identical subtree structure rooted at dest_root, creating any subdirectories
-    as needed. For example, `recursive_copy('/A/B/C.txt', '/A', '/D')` will 
-    first create the destination subdirectory `/D/B` and copy '/A/B/C.txt` to 
+    as needed. For example, `recursive_copy('/A/B/C.txt', '/A', '/D')` will
+    first create the destination subdirectory `/D/B` and copy '/A/B/C.txt` to
     `/D/B/C.txt`.
 
     Args:
@@ -81,8 +81,8 @@ def recursive_copy(src_files, src_root, dest_root, copy_function=None,
         src_root: Root subtree of all files in src_files. Raises a ValueError
             if all files in src_files are not contained in the src_root directory.
         dest_root: Destination directory in which to create the copied subtree.
-        copy_function: Function to use to copy individual files. Must take two 
-            arguments, the source and destination paths, respectively. Defaults 
+        copy_function: Function to use to copy individual files. Must take two
+            arguments, the source and destination paths, respectively. Defaults
             to :py:meth:`shutil.copy2`.
         overwrite: Boolean, deafult False. If False, raise an OSError if
             any destination files already exist, otherwise silently overwrite.
@@ -106,7 +106,7 @@ def recursive_copy(src_files, src_root, dest_root, copy_function=None,
 
 def get_available_programs():
     return {'py': 'python', 'ncl': 'ncl', 'R': 'Rscript'}
-    #return {'py': sys.executable, 'ncl': 'ncl'}  
+    #return {'py': sys.executable, 'ncl': 'ncl'}
 
 def check_executable(exec_name):
     """Tests if <exec_name> is found on the current $PATH.
@@ -123,12 +123,12 @@ def find_files(src_dirs, filename_globs, n_files=None):
     of ``filename_globs``. Wraps :py:class:`glob.glob`.
 
     Args:
-        src_dirs: Directory, or a list of directories, to search for files in. The 
+        src_dirs: Directory, or a list of directories, to search for files in. The
             function will also search all subdirectories.
-        filename_globs: Glob, or a list of globs, for filenames to match. This 
+        filename_globs: Glob, or a list of globs, for filenames to match. This
             is a shell globbing pattern, not a full regex.
-        n_files (int, optional): If supplied, raise 
-            :class:`~framework.util.exceptions.MDTFFileNotFoundError` if the 
+        n_files (int, optional): If supplied, raise
+            :class:`~framework.util.exceptions.MDTFFileNotFoundError` if the
             number of files found is not equal to this number.
 
     Returns: :py:obj:`list` of paths to files matching any of the criteria.
@@ -148,13 +148,13 @@ def find_files(src_dirs, filename_globs, n_files=None):
 
 def check_dirs(*dirs, create=False):
     """Check existence of directories. No action is taken for directories that
-    already exist; nonexistent directories either raise a 
+    already exist; nonexistent directories either raise a
     :class:`~util.MDTFFileNotFoundError` or cause the creation of that directory.
 
     Args:
         dirs: iterable of absolute paths to check.
-        create: (bool, default False): if True, nonexistent directories are 
-            created. 
+        create: (bool, default False): if True, nonexistent directories are
+            created.
     """
     for dir_ in dirs:
         try:
@@ -239,7 +239,7 @@ def strip_comments(str_, delimiter=None):
     # would be better to use shlex, but that doesn't support multi-character
     # comment delimiters like '//'
     ESCAPED_QUOTE_PLACEHOLDER = '\v' # no one uses vertical tab
-    
+
     if not delimiter:
         return str_
     lines = str_.splitlines()
@@ -250,7 +250,7 @@ def strip_comments(str_, delimiter=None):
             continue
         # handle delimiters midway through a line:
         # If delimiter appears quoted in a string, don't want to treat it as
-        # a comment. So for each occurrence of delimiter, count number of 
+        # a comment. So for each occurrence of delimiter, count number of
         # "s to its left and only truncate when that's an even number.
         # First we get rid of \-escaped single "s.
         replaced_line = lines[i].replace('\\\"', ESCAPED_QUOTE_PLACEHOLDER)
@@ -272,25 +272,25 @@ def strip_comments(str_, delimiter=None):
 
 def parse_json(str_):
     def _pos_from_lc(lineno, colno, str_):
-        # fix line number, since we stripped commented-out lines. JSONDecodeError 
+        # fix line number, since we stripped commented-out lines. JSONDecodeError
         # computes line/col no. in error message from character position in string.
         lines = str_.splitlines()
         return (colno - 1) + sum( (len(line) + 1) for line in lines[:lineno])
 
     (strip_str, line_nos) = strip_comments(str_, delimiter= '//')
     try:
-        parsed_json = json.loads(strip_str, 
+        parsed_json = json.loads(strip_str,
             object_pairs_hook=collections.OrderedDict)
     except json.JSONDecodeError as exc:
-        # fix reported line number, since we stripped commented-out lines. 
+        # fix reported line number, since we stripped commented-out lines.
         assert exc.lineno <= len(line_nos)
         raise json.JSONDecodeError(
-            msg=exc.msg, doc=str_, 
+            msg=exc.msg, doc=str_,
             pos=_pos_from_lc(line_nos[exc.lineno-1], exc.colno, str_)
         )
     except UnicodeDecodeError as exc:
         raise json.JSONDecodeError(
-            msg=f"parse_json received UnicodeDecodeError:\n{exc}", 
+            msg=f"parse_json received UnicodeDecodeError:\n{exc}",
             doc=strip_str, pos=0
         )
     return parsed_json
@@ -299,7 +299,7 @@ def read_json(file_path):
     _log.debug('Reading file %s', file_path)
     if not os.path.isfile(file_path):
         raise exceptions.MDTFFileNotFoundError(file_path)
-    try:    
+    try:
         with io.open(file_path, 'r', encoding='utf-8') as file_:
             str_ = file_.read()
     except Exception as exc:
@@ -309,7 +309,7 @@ def read_json(file_path):
     return parse_json(str_)
 
 def find_json(dir_, file_name, exit_if_missing=True):
-    """Wrap :func:`read_json` with more elaborate error handling. find_files() 
+    """Wrap :func:`read_json` with more elaborate error handling. find_files()
     will find a file named file_name at any level within dir\_.
     """
     try:
@@ -333,7 +333,7 @@ def write_json(struct, file_path, sort_keys=False):
     """
     _log.debug('Writing file %s', file_path)
     try:
-        str_ = json.dumps(struct, 
+        str_ = json.dumps(struct,
             sort_keys=sort_keys, indent=2, separators=(',', ': '))
         with io.open(file_path, 'w', encoding='utf-8') as file_:
             file_.write(str_)
@@ -342,7 +342,7 @@ def write_json(struct, file_path, sort_keys=False):
         exit(1)
 
 def pretty_print_json(struct, sort_keys=False):
-    """Convert struct to a pseudo-YAML string for human-readable debugging 
+    """Convert struct to a pseudo-YAML string for human-readable debugging
     purposes only. Output is not valid JSON (or YAML).
     """
     str_ = json.dumps(struct, sort_keys=sort_keys, indent=2)
@@ -351,18 +351,18 @@ def pretty_print_json(struct, sort_keys=False):
     # remove isolated double quotes, but keep ""
     str_ = re.sub(r'(?<!\")\"(?!\")', "", str_)
     # remove lines containing only whitespace
-    return os.linesep.join([s for s in str_.splitlines() if s.strip()]) 
+    return os.linesep.join([s for s in str_.splitlines() if s.strip()])
 
 # ---------------------------------------------------------
 # HTML TEMPLATING
 # ---------------------------------------------------------
 
 class _DoubleBraceTemplate(string.Template):
-    """Private class used by :func:`~util.append_html_template` to do 
+    """Private class used by :func:`~util.append_html_template` to do
     string templating with double curly brackets as delimiters, since single
     brackets are also used in css.
 
-    See `<https://docs.python.org/3.7/library/string.html#string.Template>`_ and 
+    See `<https://docs.python.org/3.7/library/string.html#string.Template>`_ and
     `<https://stackoverflow.com/a/34362892>`__.
     """
     flags = re.VERBOSE # matching is case-sensitive, unlike default
@@ -374,7 +374,7 @@ class _DoubleBraceTemplate(string.Template):
         (?P<escaped>\{\{)|
         # case 2) text is the name of an env var, possibly followed by whitespace,
         # followed by closing double bracket. Match POSIX env var names,
-        # case-sensitive (see https://stackoverflow.com/a/2821183), with the 
+        # case-sensitive (see https://stackoverflow.com/a/2821183), with the
         # addition that hyphens are allowed.
         # Can't tell from docs what the distinction between <named> and <braced> is.
         \s*(?P<named>[a-zA-Z_][a-zA-Z0-9_-]*)\s*\}\}|
@@ -384,11 +384,11 @@ class _DoubleBraceTemplate(string.Template):
         )
     """
 
-def append_html_template(template_file, target_file, template_dict={}, 
+def append_html_template(template_file, target_file, template_dict={},
     create=True, append=True):
     """Perform substitutions on template_file and write result to target_file.
 
-    Variable substitutions are done with custom 
+    Variable substitutions are done with custom
     `templating <https://docs.python.org/3.7/library/string.html#template-strings>`__,
     replacing *double* curly bracket-delimited keys with their values in template_dict.
     For example, if template_dict is {'A': 'foo'}, all occurrences of the string
@@ -398,17 +398,17 @@ def append_html_template(template_file, target_file, template_dict={},
     Double-curly-bracketed strings that don't correspond to keys in template_dict are
     ignored (instead of raising a KeyError.)
 
-    Double curly brackets are chosen as the delimiter to match the default 
+    Double curly brackets are chosen as the delimiter to match the default
     syntax of, eg, django and jinja2. Using single curly braces leads to conflicts
     with CSS syntax.
 
     Args:
         template_file: Path to template file.
-        target_file: Destination path for result. 
+        target_file: Destination path for result.
         template_dict: :py:obj:`dict` of variable name-value pairs. Both names
             and values must be strings.
         create: Boolean, default True. If true, create target_file if it doesn't
-            exist, otherwise raise an OSError. 
+            exist, otherwise raise an OSError.
         append: Boolean, default True. If target_file exists and this is true,
             append the substituted contents of template_file to it. If false,
             overwrite target_file with the substituted contents of template_file.

--- a/src/util/logs.py
+++ b/src/util/logs.py
@@ -19,16 +19,16 @@ class MDTFConsoleHandler(logging.StreamHandler):
 
 class MultiFlushMemoryHandler(logging.handlers.MemoryHandler):
     """Subclass :py:class:`logging.handlers.MemoryHandler` to enable flushing
-    the contents of its log buffer to multiple targets. We do this to solve the 
-    chicken-and-egg problem of logging any events that happen before the log 
-    outputs are configured: those events are captured by an instance of this 
+    the contents of its log buffer to multiple targets. We do this to solve the
+    chicken-and-egg problem of logging any events that happen before the log
+    outputs are configured: those events are captured by an instance of this
     handler and then transfer()'ed to other handlers once they're set up.
     See `<https://stackoverflow.com/a/12896092>`__.
     """
 
     def transfer(self, target_handler):
         """Transfer contents of buffer to target_handler.
-        
+
         Args:
             target_handler (:py:class:`logging.Handler`): log handler to transfer
                 contents of buffer to.
@@ -45,13 +45,13 @@ class MultiFlushMemoryHandler(logging.handlers.MemoryHandler):
             self.release()
 
     def transfer_to_non_console(self, logger):
-        """Transfer contents of buffer to all non-console-based handlers attached 
+        """Transfer contents of buffer to all non-console-based handlers attached
         to *logger* (handlers that aren't :py:class:`MDTFConsoleHandler`.)
 
         If no handlers are attached to the logger, a warning is printed and the
         buffer is transferred to the :py:class:`logging.lastResort` handler, i.e.
         printed to stderr.
-        
+
         Args:
             logger (:py:class:`logging.Logger`): logger to transfer
                 contents of buffer to.
@@ -96,16 +96,16 @@ class MDTFHeaderFileHandler(HeaderFileHandler):
                 # f"sys.executable: '{sys.executable}'\n"
                 f"sys.version: '{sys.version}'\n"
                 # f"sys.path: {sys.path}\nsys.argv: {sys.argv}\n"
-            ) 
+            )
             return str_ + (80 * '-') + '\n\n'
         except Exception:
             err_str = "Couldn't gather log file header information."
             _log.exception(err_str)
             return "ERROR: " + err_str + "\n"
-    
+
 
 class HangingIndentFormatter(logging.Formatter):
-    """:py:class:`logging.Formatter` that applies a hanging indent, making it 
+    """:py:class:`logging.Formatter` that applies a hanging indent, making it
     easier to tell where one entry stops and the next starts.
     """
     # https://blog.belgoat.com/python-textwrap-wrap-your-text-to-terminal-size/
@@ -133,9 +133,9 @@ class HangingIndentFormatter(logging.Formatter):
 
         Args:
             str_ (str): String to be indented.
-            initial_indent (str): string to insert as the indent for the first 
+            initial_indent (str): string to insert as the indent for the first
                 line.
-            subsequent_indent (str): string to insert as the indent for all 
+            subsequent_indent (str): string to insert as the indent for all
                 subsequent lines.
 
         Returns:
@@ -159,7 +159,7 @@ class HangingIndentFormatter(logging.Formatter):
         Returns:
             String representation of the log entry.
 
-        This essentially repeats the method's `implementation 
+        This essentially repeats the method's `implementation
         <https://github.com/python/cpython/blob/4e02981de0952f54bf87967f8e10d169d6946b40/Lib/logging/__init__.py#L595-L625>`__
         in the python standard library. See comments there and the logging module
         `documentation <https://docs.python.org/3.7/library/logging.html>`__.
@@ -176,12 +176,12 @@ class HangingIndentFormatter(logging.Formatter):
         if record.exc_info and not record.exc_text:
             record.exc_text = self.formatException(record.exc_info)
         if record.exc_text:
-            # text from formatting the exception. NOTE that this includes the 
+            # text from formatting the exception. NOTE that this includes the
             # stack trace without populating stack_info or calling formatStack.
             if not s.endswith('\n'):
                 s = s + '\n'
             s = s + self._hanging_indent(
-                record.exc_text, 
+                record.exc_text,
                 self.indent, self.stack_indent
             )
         if record.stack_info:
@@ -202,7 +202,7 @@ class GeqLevelFilter(logging.Filter):
     """:py:class:`logging.Filter` to include only log messages with a severity of
     level or worse. This is normally done by setting the level attribute on a
     :py:class:`logging.Handler`, but we need to add a filter when transferring
-    records from another logger, as shown in 
+    records from another logger, as shown in
     `<https://stackoverflow.com/a/24324246>`__."""
     def __init__(self, name="", level=None):
         super(GeqLevelFilter, self).__init__(name=name)
@@ -219,7 +219,7 @@ class GeqLevelFilter(logging.Filter):
         return record.levelno >= self.levelno
 
 class LtLevelFilter(logging.Filter):
-    """:py:class:`logging.Filter` to include only log messages with a severity 
+    """:py:class:`logging.Filter` to include only log messages with a severity
     less than level.
     """
     def __init__(self, name="", level=None):
@@ -237,7 +237,7 @@ class LtLevelFilter(logging.Filter):
         return record.levelno < self.levelno
 
 class EqLevelFilter(logging.Filter):
-    """:py:class:`logging.Filter` to include only log messages with a severity 
+    """:py:class:`logging.Filter` to include only log messages with a severity
     equal to level.
     """
     def __init__(self, name="", level=None):
@@ -256,10 +256,10 @@ class EqLevelFilter(logging.Filter):
 
 
 def git_info():
-    """Get the current git branch, hash, and list of uncommitted files, if 
+    """Get the current git branch, hash, and list of uncommitted files, if
     available.
 
-    Called by :meth:`DebugHeaderFileHandler._debug_header`. Based on NumPy's 
+    Called by :meth:`DebugHeaderFileHandler._debug_header`. Based on NumPy's
     implementation: `<https://stackoverflow.com/a/40170206>`__.
     """
     def _minimal_ext_cmd(cmd):
@@ -283,7 +283,7 @@ def git_info():
         git_dirty = _minimal_ext_cmd(['git', 'diff', '--no-ext-diff', '--name-only'])
     except OSError:
         pass
-        
+
     if git_dirty:
         git_dirty = git_dirty.splitlines()
     elif git_hash:
@@ -300,7 +300,7 @@ def git_info():
 
 def signal_logger(caller_name, signum=None, frame=None, log=_log):
     """Lookup signal name from number and write to log.
-    
+
     Taken from `<https://stackoverflow.com/a/2549950>`__.
 
     Args:
@@ -320,7 +320,7 @@ def signal_logger(caller_name, signum=None, frame=None, log=_log):
         log.info("%s caught unknown signal.", caller_name)
 
 def _set_excepthook(root_logger):
-    """Ensure all uncaught exceptions, other than user KeyboardInterrupt, are 
+    """Ensure all uncaught exceptions, other than user KeyboardInterrupt, are
     logged to the root logger.
 
     See `<https://docs.python.org/3/library/sys.html#sys.excepthook>`__.
@@ -331,17 +331,17 @@ def _set_excepthook(root_logger):
             sys.__excepthook__(exc_type, exc_value, exc_traceback)
             return
         root_logger.critical(
-            (70*'*') + "\nUncaught exception:\n", # banner so it stands out 
+            (70*'*') + "\nUncaught exception:\n", # banner so it stands out
             exc_info=(exc_type, exc_value, exc_traceback)
         )
-    
+
     sys.excepthook = uncaught_exception_handler
 
 def _configure_logging_dict(log_d, log_args):
-    """Convert CLI flags (``--verbose``/``--quiet``) into log levels. Configure 
+    """Convert CLI flags (``--verbose``/``--quiet``) into log levels. Configure
     log level and filters on console handlers in a logging config dictionary.
     """
-    # smaller number = more verbose  
+    # smaller number = more verbose
     level = getattr(log_args, 'quiet', 0) - getattr(log_args, 'verbose', 0)
     if level <= 1:
         stderr_level = logging.WARNING
@@ -373,13 +373,13 @@ def _configure_logging_dict(log_d, log_args):
     return log_d
 
 def _set_log_file_paths(d, new_paths):
-    """Assign paths to log files. Paths are assumed to be well-formed and in 
+    """Assign paths to log files. Paths are assumed to be well-formed and in
     writeable locations.
 
     Args:
         d (dict): Nested dict read from the log configuration file.
-        new_paths (dict): Dict of new log file names to assign. Keys are the 
-            names of :py:class:`logging.Handler` handlers in the config file, and 
+        new_paths (dict): Dict of new log file names to assign. Keys are the
+            names of :py:class:`logging.Handler` handlers in the config file, and
             values are the new paths.
     """
     if not new_paths:
@@ -395,7 +395,7 @@ def _set_log_file_paths(d, new_paths):
             new_paths)
 
 def case_log_config(config_mgr, **new_paths):
-    """Wrapper to handle logger configuration from a file and transferring the 
+    """Wrapper to handle logger configuration from a file and transferring the
     temporary log cache to the newly-configured loggers.
 
     Args:
@@ -403,8 +403,8 @@ def case_log_config(config_mgr, **new_paths):
             which the temporary log cache was attached.
         cli_obj ( :class:`~src.cli.MDTFTopLevelArgParser` ): CLI parser object
             containing parsed command-line values.
-        new_paths (dict): Dict of new log file names to assign. Keys are the 
-            names of :py:class:`logging.Handler` handlers in the config file, and 
+        new_paths (dict): Dict of new log file names to assign. Keys are the
+            names of :py:class:`logging.Handler` handlers in the config file, and
             values are the new paths.
     """
     if config_mgr.log_config is None:
@@ -438,7 +438,7 @@ def case_log_config(config_mgr, **new_paths):
 
 def initial_log_config():
     """Configure the root logger for logging to console and to a cache provided
-    by :class:`MultiFlushMemoryHandler`. For debugging purposes 
+    by :class:`MultiFlushMemoryHandler`. For debugging purposes
     we want to get console output set up before we've read in the real log config
     files (which requires doing a full parse of the user input).
     """
@@ -448,9 +448,9 @@ def initial_log_config():
     _set_excepthook(root_logger)
     log_d = {
         "version": 1,
-        "disable_existing_loggers":  True,        
+        "disable_existing_loggers":  True,
         "root": {
-            "level": "NOTSET", 
+            "level": "NOTSET",
             "handlers": ["debug", "stdout", "stderr", "cache"]
         },
         "handlers": {

--- a/src/util/processes.py
+++ b/src/util/processes.py
@@ -13,7 +13,7 @@ _log = logging.getLogger(__name__)
 
 class ExceptionPropagatingThread(threading.Thread):
     """Class to propagate exceptions raised in a child thread back to the caller
-    thread when the child is join()ed. 
+    thread when the child is join()ed.
     Adapted from `<https://stackoverflow.com/a/31614591>`__.
     """
     def run(self):
@@ -33,17 +33,17 @@ class ExceptionPropagatingThread(threading.Thread):
 
 def poll_command(command, shell=False, env=None):
     """Runs a shell command and prints stdout in real-time.
-    
+
     Optional ability to pass a different environment to the subprocess. See
-    documentation for the Python2 `subprocess 
+    documentation for the Python2 `subprocess
     <https://docs.python.org/2/library/subprocess.html>`_ module.
 
     Args:
-        command: list of command + arguments, or the same as a single string. 
+        command: list of command + arguments, or the same as a single string.
             See `subprocess` syntax. Note this interacts with the `shell` setting.
-        shell (:py:obj:`bool`, optional): shell flag, passed to Popen, 
+        shell (:py:obj:`bool`, optional): shell flag, passed to Popen,
             default `False`.
-        env (:py:obj:`dict`, optional): environment variables to set, passed to 
+        env (:py:obj:`dict`, optional): environment variables to set, passed to
             Popen, default `None`.
     """
     process = subprocess.Popen(
@@ -64,24 +64,24 @@ def run_command(command, env=None, cwd=None, timeout=0, dry_run=False):
 
     Note:
         We hope to save some process overhead by not running the command in a
-        shell, but this means the command can't use piping, quoting, environment 
+        shell, but this means the command can't use piping, quoting, environment
         variables, or filename globbing etc.
 
-    See documentation for the Python2 `subprocess 
+    See documentation for the Python2 `subprocess
     <https://docs.python.org/2/library/subprocess.html>`_ module.
 
     Args:
         command (list of :py:obj:`str`): List of commands to execute
-        env (:py:obj:`dict`, optional): environment variables to set, passed to 
+        env (:py:obj:`dict`, optional): environment variables to set, passed to
             `Popen`, default `None`.
         cwd (:py:obj:`str`, optional): child processes' working directory, passed
             to `Popen`. Default is `None`, which uses parent processes' directory.
         timeout (:py:obj:`int`, optional): Optionally, kill the command's subprocess
-            and raise a MDTFCalledProcessError if the command doesn't finish in 
+            and raise a MDTFCalledProcessError if the command doesn't finish in
             `timeout` seconds.
 
     Returns:
-        :py:obj:`list` of :py:obj:`str` containing output that was written to stdout  
+        :py:obj:`list` of :py:obj:`str` containing output that was written to stdout
         by each command. Note: this is split on newlines after the fact.
 
     Raises:
@@ -136,19 +136,19 @@ def run_command(command, env=None, cwd=None, timeout=0, dry_run=False):
 def run_shell_command(command, env=None, cwd=None, dry_run=False):
     """Subprocess wrapper to facilitate running shell commands.
 
-    See documentation for the Python2 `subprocess 
+    See documentation for the Python2 `subprocess
     <https://docs.python.org/2/library/subprocess.html>`_ module.
 
     Args:
         commands (list of :py:obj:`str`): List of commands to execute
-        env (:py:obj:`dict`, optional): environment variables to set, passed to 
+        env (:py:obj:`dict`, optional): environment variables to set, passed to
             `Popen`, default `None`.
         cwd (:py:obj:`str`, optional): child processes' working directory, passed
             to `Popen`. Default is `None`, which uses parent processes' directory.
 
     Returns:
-        :py:obj:`list` of :py:obj:`str` containing output that was written to stdout  
-        by each command. Note: this is split on newlines after the fact, so if 
+        :py:obj:`list` of :py:obj:`str` containing output that was written to stdout
+        by each command. Note: this is split on newlines after the fact, so if
         commands give != 1 lines of output this will not map to the list of commands
         given.
 

--- a/src/util/tests/test_basic.py
+++ b/src/util/tests/test_basic.py
@@ -7,13 +7,13 @@ class TestMDTFABCMeta(unittest.TestCase):
     def test_abstract_attribute(self):
         class Foo(metaclass=util.MDTFABCMeta):
             class_attr = util.abstract_attribute()
-    
+
             def foo(self, x):
                 return self.class_attr + x
-    
+
         class GoodChildClass(Foo):
             class_attr = 5
-            
+
         raised_exc = False
         try:
             b = GoodChildClass()
@@ -61,7 +61,7 @@ class TestMultiMap(unittest.TestCase):
     def test_multimap_setitem(self):
         # test key addition and handling of duplicate values
         temp = util.MultiMap({'a':1, 'b':2})
-        temp['c'] = 1           
+        temp['c'] = 1
         temp_inv = temp.inverse()
         self.assertIn(1, temp_inv)
         self.assertCountEqual(temp_inv[1], set(['a','c']))
@@ -279,7 +279,7 @@ class TestSpliceIntoList(unittest.TestCase):
         list_ = ['a','b','c']
         ans = util.splice_into_list(list_, {'b':['b1']})
         self.assertEqual(ans, ['a', 'b', 'b1', 'c'])
-    
+
     def test_splice_into_list_end(self):
         list_ = ['a','b','c']
         ans = util.splice_into_list(list_, {'c':['c1']})
@@ -295,7 +295,7 @@ class TestSpliceIntoList(unittest.TestCase):
         key_fn = (lambda s: s[0])
         splice_d = {'a':['a1'], 'b':['b1'], 'd':['d1'],'g':['g1']}
         ans = util.splice_into_list(list_, splice_d, key_fn)
-        self.assertEqual(ans, 
+        self.assertEqual(ans,
             ['aaa', 'a1', 'bXX', 'b1', 'bYY', 'b1', 'c', 'dXX', 'd1', 'bZZ', 'b1']
         )
 
@@ -303,7 +303,7 @@ class TestSpliceIntoList(unittest.TestCase):
         list_ = ['a','b','b','c','d','b']
         splice_d = {'a':['a1','a2'], 'b':['b1'], 'd':['d1'],'g':['g1']}
         ans = util.splice_into_list(list_, splice_d)
-        self.assertEqual(ans, 
+        self.assertEqual(ans,
             ['a', 'a1', 'a2', 'b', 'b1', 'b', 'b1', 'c', 'd', 'd1', 'b', 'b1']
         )
 

--- a/src/util/tests/test_dataclass.py
+++ b/src/util/tests/test_dataclass.py
@@ -49,7 +49,7 @@ class TestRegexDataclassInheritance(unittest.TestCase):
                     self.spatial_avg = 'global_mean'
                 else:
                     self.spatial_avg = None
-                    
+
         drs_directory_regex = util.RegexPattern(r"""
                 /?(CMIP6/)?(?P<activity_id>\w+)/(?P<grid_label>\w+)/
             """, input_field="directory"
@@ -89,7 +89,7 @@ class TestRegexDataclassInheritance(unittest.TestCase):
                     self.spatial_avg = 'global_mean'
                 else:
                     self.spatial_avg = None
-                    
+
         parent2_regex = util.RegexPattern(r"""
                 x(?P<grid_number>\d?)x(?P<spatial_avg>\w+)x
             """, input_field="parent2"
@@ -103,7 +103,7 @@ class TestRegexDataclassInheritance(unittest.TestCase):
             def __post_init__(self):
                 if self.spatial_avg:
                     self.spatial_avg += '_mean'
-                    
+
         child_regex = util.RegexPattern(r"""
                 (?P<activity_id>\w+)/(?P<grid_label>\w+)/(?P<redundant_label>\w+)/
             """, input_field="directory"
@@ -119,9 +119,9 @@ class TestRegexDataclassInheritance(unittest.TestCase):
         foo = Child('bazinga/gm6/x6xglobalx/')
         self.assertDictEqual(
             dataclasses.asdict(foo),
-            {'parent2': 'x6xglobalx', 'grid_number': 6, 'spatial_avg': 'global_mean', 
-            'parent1': 'gm6', 'directory': 'bazinga/gm6/x6xglobalx/', 
-            'activity_id': 'bazinga', 'grid_label': 'gm6', 
+            {'parent2': 'x6xglobalx', 'grid_number': 6, 'spatial_avg': 'global_mean',
+            'parent1': 'gm6', 'directory': 'bazinga/gm6/x6xglobalx/',
+            'activity_id': 'bazinga', 'grid_label': 'gm6',
             'redundant_label': 'x6xglobalx'}
         )
         # conflict in assignment to fields of same name in parent dataclasses
@@ -147,7 +147,7 @@ class TestMDTFDataclass(unittest.TestCase):
         @util.mdtf_dataclass
         class Dummy(object):
             b: int = None
-        
+
             def __post_init__(self):
                 self.b += 5
 
@@ -160,7 +160,7 @@ class TestMDTFDataclass(unittest.TestCase):
         @util.mdtf_dataclass
         class Dummy(object):
             a: str = None
-        
+
             def __post_init__(self):
                 self.a = 5
 
@@ -171,7 +171,7 @@ class TestMDTFDataclass(unittest.TestCase):
         @util.mdtf_dataclass
         class Dummy(object):
             a: str = None
-        
+
             def __post_init__(self):
                 self.a = util.MANDATORY
 
@@ -211,7 +211,7 @@ class TestMDTFDataclass(unittest.TestCase):
             a: str = util.MANDATORY
 
         @util.mdtf_dataclass
-        class Dummy2(object):    
+        class Dummy2(object):
             b: int = util.NOTSET
 
         @util.mdtf_dataclass

--- a/src/util/tests/test_datelabel.py
+++ b/src/util/tests/test_datelabel.py
@@ -68,7 +68,7 @@ class TestDate(unittest.TestCase):
         self.assertTrue(dt(2019,9) >= datetime.date(2018,12,25))
 
     def test_minmax(self):
-        test = [dt(2019,2), dt(2019,9), dt(2018), 
+        test = [dt(2019,2), dt(2019,9), dt(2018),
             dt(2019), dt(2019,1,1,12)]
         self.assertEqual(max(test), dt(2019,9))
         self.assertEqual(min(test), dt(2018))
@@ -102,22 +102,22 @@ class TestDate(unittest.TestCase):
 
 class TestDateRange(unittest.TestCase):
     def test_string_parsing(self):
-        self.assertEqual(dt_range('2010-2019'), 
+        self.assertEqual(dt_range('2010-2019'),
             dt_range(dt(2010), dt(2019)))
-        self.assertEqual(dt_range('20100201-20190918'), 
+        self.assertEqual(dt_range('20100201-20190918'),
             dt_range(dt(2010,2,1), dt(2019,9,18)))
 
     def test_input_string_parsing(self):
-        self.assertEqual(dt_range(2010, 2019), 
+        self.assertEqual(dt_range(2010, 2019),
             dt_range(dt(2010), dt(2019)))
-        self.assertEqual(dt_range('20100201', '20190918'), 
+        self.assertEqual(dt_range('20100201', '20190918'),
             dt_range(dt(2010,2,1), dt(2019,9,18)))
 
     def test_input_list_parsing(self):
         self.assertEqual(
-            dt_range.from_date_span(dt(2015), dt(2010), dt(2019), dt(2017)), 
+            dt_range.from_date_span(dt(2015), dt(2010), dt(2019), dt(2017)),
             dt_range(2010, 2019))
-        self.assertEqual(dt_range(['20100201', '20190918']), 
+        self.assertEqual(dt_range(['20100201', '20190918']),
             dt_range('20100201', '20190918'))
 
     def test_input_range_parsing(self):
@@ -234,7 +234,7 @@ class TestDateRange(unittest.TestCase):
             self.assertTrue(d[0].overlaps(rng1) == d[2])
             self.assertTrue(d[0].contains(rng1) == d[3])
             self.assertTrue(rng1.contains(d[0]) == d[4])
-    
+
     def test_more_intersection(self):
         # mixed precision
         rng1 = dt_range('1980-1990')
@@ -356,14 +356,14 @@ class TestDateFrequency(unittest.TestCase):
         self.assertEqual(dt_freq.from_struct('daily'), dt_freq(1, 'dy'))
         self.assertEqual(dt_freq.from_struct('120hr'), dt_freq(120, 'hr'))
         self.assertEqual(dt_freq.from_struct('2 weeks'), dt_freq(2, 'wk'))
-    
+
     def test_comparisons_same_unit(self):
         self.assertTrue(dt_freq(1,'hr') < dt_freq(2,'hr'))
         self.assertTrue(dt_freq(5,'yr') > dt_freq(2,'yr'))
         self.assertTrue(dt_freq(1,'se') <= dt_freq(1,'se'))
         self.assertTrue(dt_freq(2,'mo') >= dt_freq(2,'mo'))
         self.assertTrue(dt_freq(1,'hr') <= dt_freq(2,'hr'))
-    
+
     def test_comparisons_different_unit(self):
         self.assertTrue(dt_freq(3,'hr') < dt_freq(2,'dy'))
         self.assertTrue(dt_freq(2,'yr') > dt_freq(6,'mo'))

--- a/src/util/tests/test_filesystem.py
+++ b/src/util/tests/test_filesystem.py
@@ -8,14 +8,14 @@ class TestCheckDirs(unittest.TestCase):
     @mock.patch('os.path.isdir', return_value = True)
     @mock.patch('os.makedirs')
     def test_check_dirs_found(self, mock_makedirs, mock_isdir):
-        # exit function normally if all directories found 
+        # exit function normally if all directories found
         try:
             util.check_dirs('DUMMY/PATH/NAME', create=False)
             util.check_dirs('DUMMY/PATH/NAME', create=True)
         except (Exception, SystemExit):
             self.fail()
         mock_makedirs.assert_not_called()
- 
+
     @mock.patch('os.path.isdir', return_value = False)
     @mock.patch('os.makedirs')
     def test_check_dirs_not_found(self, mock_makedirs, mock_isdir):
@@ -26,8 +26,8 @@ class TestCheckDirs(unittest.TestCase):
 
     @mock.patch('os.path.isdir', return_value = False)
     @mock.patch('os.makedirs')
-    def test_check_dirs_not_found_created(self, mock_makedirs, mock_isdir):      
-        # don't exit() and call os.makedirs if in create_if_nec          
+    def test_check_dirs_not_found_created(self, mock_makedirs, mock_isdir):
+        # don't exit() and call os.makedirs if in create_if_nec
         try:
             util.check_dirs('DUMMY/PATH/NAME', create=True)
         except (Exception, SystemExit):
@@ -38,7 +38,7 @@ class TestBumpVersion(unittest.TestCase):
     @mock.patch('os.path.exists', return_value=False)
     def test_bump_version_noexist(self, mock_exists):
         for f in [
-            'AAA', 'AAA.v1', 'D/C/B/AAA', 'D/C/B/AAAA/', 'D/C/B/AAA.v23', 
+            'AAA', 'AAA.v1', 'D/C/B/AAA', 'D/C/B/AAAA/', 'D/C/B/AAA.v23',
             'D/C/B/AAAA.v23/', 'A.foo', 'A.v23.foo', 'A.v23.bar.v45.foo',
             'D/C/A.foo', 'D/C/A.v23.foo', 'D/C/A.v23.bar.v45.foo'
         ]:
@@ -48,7 +48,7 @@ class TestBumpVersion(unittest.TestCase):
     @mock.patch('os.path.exists', return_value=False)
     def test_bump_version_getver(self, mock_exists):
         for f in [
-            'AAA.v42', 'D/C/B/AAA.v42', 'D/C.v7/B/AAAA.v42/', 'A.v42.foo', 
+            'AAA.v42', 'D/C/B/AAA.v42', 'D/C.v7/B/AAAA.v42/', 'A.v42.foo',
             'A.v23.bar.v42.foo', 'D/C/A.v42.foo', 'D/C/A.v23.bar.v42.foo'
         ]:
             _, ver = util.bump_version(f)
@@ -57,9 +57,9 @@ class TestBumpVersion(unittest.TestCase):
     @mock.patch('os.path.exists', return_value=False)
     def test_bump_version_delver(self, mock_exists):
         for f in [
-            ('AAA','AAA'), ('AAA.v1','AAA'), ('D/C/B/AA','D/C/B/AA'), 
+            ('AAA','AAA'), ('AAA.v1','AAA'), ('D/C/B/AA','D/C/B/AA'),
             ('D/C.v1/B/AA/','D/C.v1/B/AA/'), ('D/C/B/AA.v23','D/C/B/AA'),
-            ('D/C3/B.v8/AA.v23/','D/C3/B.v8/AA/'), ('A.foo','A.foo'), 
+            ('D/C3/B.v8/AA.v23/','D/C3/B.v8/AA/'), ('A.foo','A.foo'),
             ('A.v23.foo','A.foo'), ('A.v23.bar.v45.foo','A.v23.bar.foo'),
             ('D/C/A.foo','D/C/A.foo'), ('D/C.v1/A234.v3.foo','D/C.v1/A234.foo'),
             ('D/C/A.v23.bar.v45.foo','D/C/A.v23.bar.foo')
@@ -71,9 +71,9 @@ class TestBumpVersion(unittest.TestCase):
     @mock.patch('os.path.exists', return_value=False)
     def test_bump_version_setver(self, mock_exists):
         for f in [
-            ('AAA','AAA.v42'), ('AAA.v1','AAA.v42'), ('D/C/B/AA','D/C/B/AA.v42'), 
+            ('AAA','AAA.v42'), ('AAA.v1','AAA.v42'), ('D/C/B/AA','D/C/B/AA.v42'),
             ('D/C.v1/B/AA/','D/C.v1/B/AA.v42/'), ('D/C/B/AA.v23','D/C/B/AA.v42'),
-            ('D/C3/B.v8/AA.v23/','D/C3/B.v8/AA.v42/'), ('A.foo','A.v42.foo'), 
+            ('D/C3/B.v8/AA.v23/','D/C3/B.v8/AA.v42/'), ('A.foo','A.v42.foo'),
             ('A.v23.foo','A.v42.foo'), ('A.v23.bar.v45.foo','A.v23.bar.v42.foo'),
             ('D/C/A.foo','D/C/A.v42.foo'), ('D/C.v1/A.v23.foo','D/C.v1/A.v42.foo'),
             ('D/C/A.v23.bar.v45.foo','D/C/A.v23.bar.v42.foo')
@@ -87,7 +87,7 @@ class TestBumpVersion(unittest.TestCase):
     # @mock.patch('os.path.exists', side_effect=itertools.cycle([True,False]))
     # def test_bump_version_dirs(self, mock_exists):
     #     for f in [
-    #         ('AAA','AAA.v1',1), ('AAA.v1','AAA.v2',2), ('D/C/B/AA','D/C/B/AA.v1',1), 
+    #         ('AAA','AAA.v1',1), ('AAA.v1','AAA.v2',2), ('D/C/B/AA','D/C/B/AA.v1',1),
     #         ('D/C.v1/B/AA/','D/C.v1/B/AA.v1/',1), ('D/C/B/AA.v23','D/C/B/AA.v24',24),
     #         ('D/C3/B.v8/AA.v9/','D/C3/B.v8/AA.v10/',10)
     #     ]:
@@ -98,9 +98,9 @@ class TestBumpVersion(unittest.TestCase):
     # @mock.patch('os.path.exists', side_effect=itertools.cycle([True,False]))
     # def test_bump_version_files(self, mock_exists):
     #     for f in [
-    #         ('A.foo','A.v1.foo',1), ('A.v23.foo','A.v24.foo',24), 
+    #         ('A.foo','A.v1.foo',1), ('A.v23.foo','A.v24.foo',24),
     #         ('A.v23.bar.v45.foo','A.v23.bar.v46.foo',46),
-    #         ('D/C/A.foo','D/C/A.v1.foo',1), 
+    #         ('D/C/A.foo','D/C/A.v1.foo',1),
     #         ('D/C.v1/A.v99.foo','D/C.v1/A.v100.foo', 100),
     #         ('D/C/A.v23.bar.v78.foo','D/C/A.v23.bar.v79.foo', 79)
     #     ]:
@@ -223,7 +223,7 @@ class TestJSONC(unittest.TestCase):
         except json.JSONDecodeError as exc:
             flag = True
             self.assertEqual(exc.lineno, 6)
-            self.assertEqual(exc.colno, 5) 
+            self.assertEqual(exc.colno, 5)
         self.assertTrue(flag)
 
     def test_strip_comments_quote_escape(self):
@@ -260,25 +260,25 @@ class TestDoubleBraceTemplate(unittest.TestCase):
 
     def test_replace_2(self):
         self.assertEqual(
-            self.sub("asdf\t{{\t foo \n\t }}baz", {'foo': 'bar'}), 
+            self.sub("asdf\t{{\t foo \n\t }}baz", {'foo': 'bar'}),
             "asdf\tbarbaz"
             )
 
     def test_replace_3(self):
         self.assertEqual(
             self.sub(
-                "{{FOO}}\n{{  foo }}asdf\t{{\t FOO \n\t }}baz_{{foo}}", 
+                "{{FOO}}\n{{  foo }}asdf\t{{\t FOO \n\t }}baz_{{foo}}",
                 {'foo': 'bar', 'FOO':'BAR'}
-            ), 
+            ),
             "BAR\nbarasdf\tBARbaz_bar"
             )
 
     def test_replace_4(self):
         self.assertEqual(
             self.sub(
-                "]{ {{_F00}}\n{{  f00 }}as{ { }\n.d'f\t{{\t _F00 \n\t }}ba} {[z_{{f00}}", 
+                "]{ {{_F00}}\n{{  f00 }}as{ { }\n.d'f\t{{\t _F00 \n\t }}ba} {[z_{{f00}}",
                 {'f00': 'bar', '_F00':'BAR'}
-            ), 
+            ),
             "]{ BAR\nbaras{ { }\n.d'f\tBARba} {[z_bar"
             )
 
@@ -287,16 +287,16 @@ class TestDoubleBraceTemplate(unittest.TestCase):
 
     def test_ignore_2(self):
         self.assertEqual(
-            self.sub("asdf\t{{\t goo \n\t }}baz", {'foo': 'bar'}), 
+            self.sub("asdf\t{{\t goo \n\t }}baz", {'foo': 'bar'}),
             "asdf\t{{\t goo \n\t }}baz"
             )
 
     def test_ignore_3(self):
         self.assertEqual(
             self.sub(
-                "{{FOO}}\n{{  goo }}asdf\t{{\t FOO \n\t }}baz_{{goo}}", 
+                "{{FOO}}\n{{  goo }}asdf\t{{\t FOO \n\t }}baz_{{goo}}",
                 {'foo': 'bar', 'FOO':'BAR'}
-            ), 
+            ),
             "BAR\n{{  goo }}asdf\tBARbaz_{{goo}}"
             )
 
@@ -305,16 +305,16 @@ class TestDoubleBraceTemplate(unittest.TestCase):
 
     def test_nomatch_2(self):
         self.assertEqual(
-            self.sub("asdf\t{{\t foo \n\t }baz", {'foo': 'bar'}), 
+            self.sub("asdf\t{{\t foo \n\t }baz", {'foo': 'bar'}),
             "asdf\t{{\t foo \n\t }baz"
             )
 
     def test_nomatch_3(self):
         self.assertEqual(
             self.sub(
-                "{{FOO\n{{  foo }asdf}}\t{{\t FOO \n\t }}baz_{{foo}}", 
+                "{{FOO\n{{  foo }asdf}}\t{{\t FOO \n\t }}baz_{{foo}}",
                 {'foo': 'bar', 'FOO':'BAR'}
-            ), 
+            ),
             "{{FOO\n{{  foo }asdf}}\tBARbaz_bar"
             )
 

--- a/src/util/tests/test_processes.py
+++ b/src/util/tests/test_processes.py
@@ -15,7 +15,7 @@ class TestSubprocessInteraction(unittest.TestCase):
         self.assertEqual(len(out), 2)
         self.assertEqual(out[0], 'foo')
         self.assertEqual(out[1], 'bar')
-        
+
     def test_run_shell_commands_exitcode(self):
         input = 'echo "foo"; false'
         with self.assertRaises(Exception):
@@ -39,7 +39,7 @@ class TestSubprocessInteraction(unittest.TestCase):
     def test_poll_command_shell_false(self):
         rc = util.poll_command(['echo', 'foo'], shell=False)
         self.assertEqual(rc, 0)
-    
+
     @unittest.skip("Skipping poll_command tests")
     def test_poll_command_error(self):
         rc = util.poll_command(['false'], shell=False)

--- a/src/validate_environment.sh
+++ b/src/validate_environment.sh
@@ -1,9 +1,9 @@
 #! /usr/bin/env bash
-# Script that determines whether POD's requested (non-data) dependencies are 
-# present in the current environment. This is called in a subprocess by the 
-# run() method of EnvironmentManager. Exit normally if everything is found, 
-# otherwise exit with code 1 which aborts the subprocess. 
-# It's hacky to do this in a shell script, but didn't want to assume the 
+# Script that determines whether POD's requested (non-data) dependencies are
+# present in the current environment. This is called in a subprocess by the
+# run() method of EnvironmentManager. Exit normally if everything is found,
+# otherwise exit with code 1 which aborts the subprocess.
+# It's hacky to do this in a shell script, but didn't want to assume the
 # current environment has python, etc.
 set -Eeuo pipefail
 

--- a/src/verify_links.py
+++ b/src/verify_links.py
@@ -37,9 +37,9 @@ Attributes:
 """
 
 class LinkParser(HTMLParser):
-    """Custom subclass of :py:class:`~html.parser.HTMLParser` which constructs 
+    """Custom subclass of :py:class:`~html.parser.HTMLParser` which constructs
     an iterable over each <a> tag.
-    
+
     Adapted from `<https://stackoverflow.com/a/41663924>`__.
     """
     def reset(self):
@@ -56,16 +56,16 @@ class LinkParser(HTMLParser):
 class LinkVerifier(object):
     def __init__(self, root, rel_path_root=None, verbose=False):
         """Initialize search for broken links.
-        
+
         Args:
-            root (str): Either a URL or path on the local filesystem. Location 
+            root (str): Either a URL or path on the local filesystem. Location
                 of the top-level html file to begin the search from.
-            rel_path_root (str, optional): Either a URL or path on the local 
-                filesystem. If given, used as the path that relative paths to 
-                missing files are given relative to. Defaults to root (if root 
-                is a directory) or the directory containing root (if root is a 
+            rel_path_root (str, optional): Either a URL or path on the local
+                filesystem. If given, used as the path that relative paths to
+                missing files are given relative to. Defaults to root (if root
+                is a directory) or the directory containing root (if root is a
                 file.)
-            verbose (bool, default False): Set to True to print each file 
+            verbose (bool, default False): Set to True to print each file
                 examined.
         """
         def munge_input_url(url):
@@ -88,7 +88,7 @@ class LinkVerifier(object):
         self.verbose = verbose
         self.pod_name = None
         # NB: WK_DIR isn't a "working directory"; it's just the base path
-        # relative to which paths are reported 
+        # relative to which paths are reported
         (self.root_url, self.WK_DIR, self.root_file) = munge_input_url(root)
         if rel_path_root:
             self.rel_path_root, _, _ = munge_input_url(rel_path_root)
@@ -97,20 +97,20 @@ class LinkVerifier(object):
 
     @staticmethod
     def gen_links(f, parser):
-        """Generator which parses the contents of an HTML file f and yields 
+        """Generator which parses the contents of an HTML file f and yields
         targets of all the links it contains.
 
         Adapted from `<https://stackoverflow.com/a/41663924>`__.
 
         Args:
-            f: :py:mod:`urllib.respose` object of the form returned by 
-                :py:func:`~urllib.request.urlopen`: either 
-                :py:class:`~http.client.HTTPResponse` for http or https, or 
+            f: :py:mod:`urllib.respose` object of the form returned by
+                :py:func:`~urllib.request.urlopen`: either
+                :py:class:`~http.client.HTTPResponse` for http or https, or
                 :py:class:`urllib.response.addinfourl` for files.
             parser: instance of :class:`LinkParser`.
 
         Yields:
-            Contents of the `href` attribute of each `a` tag of f, as extracted 
+            Contents of the `href` attribute of each `a` tag of f, as extracted
                 by :class:`LinkParser`.
         """
         encoding = f.headers.get_content_charset() or 'UTF-8'
@@ -125,12 +125,12 @@ class LinkVerifier(object):
             link (:obj:`Link`): Instance of :class:`Link`. Only the URL in
                 link.target is examined.
 
-        Returns: 
-            Either 
+        Returns:
+            Either
 
-                #. None if link.target can't be opened, 
-                #. the empty list if link.target is not an html document, or 
-                #. a list of links contained in link.target, expressed as 
+                #. None if link.target can't be opened,
+                #. the empty list if link.target is not an html document, or
+                #. a list of links contained in link.target, expressed as
                     :class:`Link` objects.
         """
         if hasattr(link, 'target'):
@@ -145,7 +145,7 @@ class LinkVerifier(object):
         except urllib.error.URLError as e:
             # print('\nFailed to find file or connect to server.')
             # print('Reason: ', e.reason)
-            tup = re.split(r"\[Errno 2\] No such file or directory: \'(.*)\'", 
+            tup = re.split(r"\[Errno 2\] No such file or directory: \'(.*)\'",
                 str(e.reason))
             if len(tup) == 3:
                 str_ = util.abbreviate_path(tup[1], self.WK_DIR, '$WK_DIR')
@@ -165,18 +165,18 @@ class LinkVerifier(object):
             return links
 
     def breadth_first(self, root_url):
-        """Breadth-first search of all files linked from an initial root_url. 
+        """Breadth-first search of all files linked from an initial root_url.
 
-        The search correctly handles cycles (ie, A.html links to B.html and 
-        B.html links to A.html) and only examines files in subdirectories of 
-        root_url's directory, so that links to external sites are ignored, 
+        The search correctly handles cycles (ie, A.html links to B.html and
+        B.html links to A.html) and only examines files in subdirectories of
+        root_url's directory, so that links to external sites are ignored,
         rather than trying to trace the link structure of the whole internet.
 
         Args:
             root_url (str): URL of an html file to start the search at.
 
         Returns:
-            list of (link_source, link_target) tuples where the file in 
+            list of (link_source, link_target) tuples where the file in
                 link_target couldn't be found.
         """
         missing = []
@@ -214,17 +214,17 @@ class LinkVerifier(object):
         return missing
 
     def group_relative_links(self, missing):
-        """Format paths to missing linked files as relative paths, grouped by 
+        """Format paths to missing linked files as relative paths, grouped by
         POD.
 
         Args:
-            missing (list): List of :class:`Link` objects found by 
+            missing (list): List of :class:`Link` objects found by
                 :meth:`breadth_first`, whose targets correspond to missing files.
 
         Returns:
             dict, with keys given by the short names of PODs with missing files
-                and values given by a list of the files that POD is missing. 
-                Missing files are listed by their path relative to the POD's 
+                and values given by a list of the files that POD is missing.
+                Missing files are listed by their path relative to the POD's
                 output directory.
         """
         missing_dict = collections.defaultdict(list)
@@ -237,7 +237,7 @@ class LinkVerifier(object):
         return missing_dict
 
     def verify_pod_links(self, pod_name):
-        """Perform search for missing linked files that were supposed to have 
+        """Perform search for missing linked files that were supposed to have
         been output by pod_name.
 
         Args:
@@ -264,8 +264,8 @@ class LinkVerifier(object):
 
         Returns:
             dict, with keys given by the short names of PODs with missing files
-                and values given by a list of the files that POD is missing. 
-                Missing files are listed by their path relative to the POD's 
+                and values given by a list of the files that POD is missing.
+                Missing files are listed by their path relative to the POD's
                 output directory.
         """
         if not self.root_file:
@@ -281,10 +281,10 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("-v", "--verbose", action="store_true",
         help="increase output verbosity")
-    parser.add_argument("path_or_url", 
+    parser.add_argument("path_or_url",
         help="URL or filesystem path to the MDTF framework output directory.")
     args = parser.parse_args()
-    
+
     link_verifier = LinkVerifier(args.path_or_url, verbose=args.verbose)
     missing_dict = link_verifier.verify_all_links()
 

--- a/tests/make_file_checksums.py
+++ b/tests/make_file_checksums.py
@@ -11,7 +11,7 @@ def checksum_in_subtree_1(rootdir, reference_subdirs, exclude_exts=[]):
     checksum_dict = {}
     for d1 in reference_subdirs:
         p1 = os.path.join(rootdir, d1)
-        assert os.path.isdir(p1)   
+        assert os.path.isdir(p1)
         checksum_dict[d1] = shared.checksum_files_in_subtree(p1, exclude_exts)
     return checksum_dict
 
@@ -21,18 +21,18 @@ def make_output_data_dict(rootdir, case_list, exclude_exts=[]):
     for c in case_list:
         d1 = c['dir']
         p1 = os.path.join(rootdir, d1)
-        assert os.path.isdir(p1)   
+        assert os.path.isdir(p1)
         checksum_dict[d1] = {}
         for d2 in c['pod_list']:
             p2 = os.path.join(rootdir, d1, d2)
-            assert os.path.isdir(p2) 
+            assert os.path.isdir(p2)
             checksum_dict[d1][d2] = shared.checksum_files_in_subtree(p2, exclude_exts)
     return checksum_dict
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('config_file', nargs='?', type=str, 
+    parser.add_argument('config_file', nargs='?', type=str,
                         default='', help="Configuration file.")
     args = parser.parse_args()
 

--- a/tests/pod_test_configs.yml
+++ b/tests/pod_test_configs.yml
@@ -1,5 +1,5 @@
 # Specifications for models to use for convergence testing of individual PODs.
-# 
+#
 case_list:
   - CASENAME: QBOi.EXP1.AMIP.001
     model: CESM
@@ -12,7 +12,7 @@ case_list:
       - convective_transition_diag
       - MJO_suite
       - MJO_teleconnection
-      - precip_diurnal_cycle 
+      - precip_diurnal_cycle
   - CASENAME: GFDL.CM4.c96L32.am4g10r8
     model: AM4
     variable_convention: AM4

--- a/tests/test_POD_execution.py
+++ b/tests/test_POD_execution.py
@@ -8,8 +8,8 @@ from src.tests import shared_test_utils as shared
 DOING_TRAVIS = (os.environ.get('TRAVIS', False) == 'true')
 DOING_MDTF_DATA_TESTS = ('--data_tests' in sys.argv)
 DOING_SETUP = DOING_MDTF_DATA_TESTS and not DOING_TRAVIS
-# All this is a workaround because tests are programmatically generated at 
-# import time, but the tests are skipped at runtime. We're skipping tests 
+# All this is a workaround because tests are programmatically generated at
+# import time, but the tests are skipped at runtime. We're skipping tests
 # because we're not in an environment where we have the data to set them up,
 # so we just throw everything in an if-block to ensure they don't get generated
 # if they're going to be skipped later.
@@ -20,7 +20,7 @@ if DOING_SETUP:
 
     case_list = shared.get_test_data_configuration()
 
-    # write temp configuration, one for each POD  
+    # write temp configuration, one for each POD
     temp_config = config.copy()
     temp_config['pod_list'] = []
     temp_config['settings']['make_variab_tar'] = False
@@ -32,7 +32,7 @@ if DOING_SETUP:
 
 
 # Python 3 has subTest; in 2.7 to avoid introducing other dependencies we use
-# the advanced construction presented in https://stackoverflow.com/a/20870875 
+# the advanced construction presented in https://stackoverflow.com/a/20870875
 # to programmatically generate tests
 
 class TestSequenceMeta(type):
@@ -44,7 +44,7 @@ class TestSequenceMeta(type):
                     ['python', 'src/mdtf.py', temp_config_file]
                 ))
                 # should do better cleanup here
-            return test       
+            return test
 
         if DOING_SETUP:
             for pod in case_list['pods']:

--- a/tests/test_input_checksums.py
+++ b/tests/test_input_checksums.py
@@ -7,8 +7,8 @@ from src.tests import shared_test_utils as shared
 DOING_TRAVIS = (os.environ.get('TRAVIS', False) == 'true')
 DOING_MDTF_DATA_TESTS = ('--data_tests' in sys.argv)
 DOING_SETUP = DOING_MDTF_DATA_TESTS and not DOING_TRAVIS
-# All this is a workaround because tests are programmatically generated at 
-# import time, but the tests are skipped at runtime. We're skipping tests 
+# All this is a workaround because tests are programmatically generated at
+# import time, but the tests are skipped at runtime. We're skipping tests
 # because we're not in an environment where we have the data to set them up,
 # so we just throw everything in an if-block to ensure they don't get generated
 # if they're going to be skipped later.
@@ -25,11 +25,11 @@ if DOING_SETUP:
     model_data_checksums = read_json(os.path.join(md5_path, 'checksum_model_data.json'))
 
 # Python 3 has subTest; in 2.7 to avoid introducing other dependencies we use
-# the advanced construction presented in https://stackoverflow.com/a/20870875 
+# the advanced construction presented in https://stackoverflow.com/a/20870875
 # to programmatically generate tests
 
 class TestSequenceMeta(type):
-    def __new__(mcs, name, bases, test_dict):     
+    def __new__(mcs, name, bases, test_dict):
         if DOING_SETUP:
             for pod in case_list['pods']:
                 test_name = "test_input_checksum_"+pod

--- a/tests/test_output_checksums.py
+++ b/tests/test_output_checksums.py
@@ -8,8 +8,8 @@ from src.tests import shared_test_utils as shared
 DOING_TRAVIS = (os.environ.get('TRAVIS', False) == 'true')
 DOING_MDTF_DATA_TESTS = ('--data_tests' in sys.argv)
 DOING_SETUP = DOING_MDTF_DATA_TESTS and not DOING_TRAVIS
-# All this is a workaround because tests are programmatically generated at 
-# import time, but the tests are skipped at runtime. We're skipping tests 
+# All this is a workaround because tests are programmatically generated at
+# import time, but the tests are skipped at runtime. We're skipping tests
 # because we're not in an environment where we have the data to set them up,
 # so we just throw everything in an if-block to ensure they don't get generated
 # if they're going to be skipped later.
@@ -24,8 +24,8 @@ if DOING_SETUP:
     output_checksums = read_json(os.path.join(md5_path, 'checksum_output.json'))
 
 # Python 3 has subTest; in 2.7 to avoid introducing other dependencies we use
-# the advanced construction presented in https://stackoverflow.com/a/20870875 
-# to programmatically generate tests   
+# the advanced construction presented in https://stackoverflow.com/a/20870875
+# to programmatically generate tests
 
 class PNGTestSequenceMeta(type):
     def __new__(mcs, name, bases, test_dict):

--- a/tests/travis_test.jsonc
+++ b/tests/travis_test.jsonc
@@ -1,19 +1,19 @@
 // Configuration for MDTF-diagnostics driver script self-test.
 //
-// Copy this file and customize the settings as needed to run the framework on 
-// your own model output without repeating command-line options. Pass it to the 
-// framework at the end of the command line (positionally) or with the 
+// Copy this file and customize the settings as needed to run the framework on
+// your own model output without repeating command-line options. Pass it to the
+// framework at the end of the command line (positionally) or with the
 // -f/--input-file flag. Any other explicit command line options will override
 // what's listed here.
 //
 // All text to the right of an unquoted "//" is a comment and ignored, as well
-// as blank lines (JSONC quasi-standard.) 
+// as blank lines (JSONC quasi-standard.)
 {
   "case_list" : [
     // The cases below correspond to the different sample model data sets. Note
-    // that the MDTF package does not currently support analyzing multiple 
-    // models in a single invocation. Comment out or delete the first entry and 
-    // uncomment the second to run NOAA-GFDL-AM4 only for the MJO_prop_amp POD, 
+    // that the MDTF package does not currently support analyzing multiple
+    // models in a single invocation. Comment out or delete the first entry and
+    // uncomment the second to run NOAA-GFDL-AM4 only for the MJO_prop_amp POD,
     // and likewise for the SM_ET_coupling POD.
     {
       "CASENAME" : "NCAR-CAM5.timeslice",
@@ -32,7 +32,7 @@
   // Location of supporting data downloaded when the framework was installed.
 
   // If a relative path is given, it's resolved relative to the MDTF-diagnostics
-  // code directory. Environment variables (eg, $HOME) can be referenced with a 
+  // code directory. Environment variables (eg, $HOME) can be referenced with a
   // "$" and will be expended to their current values when the framework runs.
 
   // Parent directory containing observational data used by individual PODs.
@@ -48,12 +48,12 @@
   // put in a subdirectory of this directory.
   "OUTPUT_DIR": "../wkdir",
 
-  // Location of the Anaconda/miniconda installation to use for managing 
-  // dependencies (path returned by running `conda info --base`.) If empty, 
+  // Location of the Anaconda/miniconda installation to use for managing
+  // dependencies (path returned by running `conda info --base`.) If empty,
   // framework will attempt to determine location of system's conda installation.
   "conda_root": "$HOME/miniconda",
 
-  // Directory containing the framework-specific conda environments. This should 
+  // Directory containing the framework-specific conda environments. This should
   // be equal to the "--env_dir" flag passed to conda_env_setup.sh. If left
   // blank, the framework will look for its environments in the system default
   // location.
@@ -83,19 +83,19 @@
   // Set to true to save HTML and bitmap plots in a .tar file.
   "make_variab_tar": false,
 
-  // Set to true to overwrite results in OUTPUT_DIR; otherwise results saved 
+  // Set to true to overwrite results in OUTPUT_DIR; otherwise results saved
   // under a unique name.
   "overwrite": false,
 
   // Settings used in debugging:
 
   // Log verbosity level.
-  "verbose": 1, 
+  "verbose": 1,
 
   // Set to true for framework test. Data is fetched but PODs are not run.
   "test_mode": false,
 
-  // Set to true for framework test. No external commands are run and no remote 
+  // Set to true for framework test. No external commands are run and no remote
   // data is copied. Implies test_mode.
   "dry_run": false
 }


### PR DESCRIPTION
**Description**

Apply VSCode files.trimTrailingWhitespace setting to all .py, .json, .jsonc and .yaml files not in /diagnostics. This is done to avoid noise in diffs purely due to whitespace in future PRs.
*No code is altered and no functionality is changed.* The only content of this PR is to remove semantically unimportant whitespace in the above files.

**Checklist:**
- [ ] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/ subdirectory, and include a main_driver script template html, and settings.jsonc
- [ ] The main_driver script header has all of the information in the POD documentation, excluding the "More about this diagnostic" section
- [ ] The POD directory and html template have the same short name as my POD
- [ ] The html template has a 1-paragraph synopsis of the POD and links to the main documentation
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with conda_env_setup.sh 
- [ ] The POD scripts do not access the internet or networked resources
- [ ] I have commented the code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have created the directory input_data/obs_data/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have added information about the raw data files to the documentation
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
- [X] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
