### PR TITLE
Add variables required by new PODs to the CMIP fieldlist file

### DIFF
--- a/data/fieldlist_CMIP.jsonc
+++ b/data/fieldlist_CMIP.jsonc
@@ -142,6 +142,26 @@
       "units": "W m-2",
       "ndim": 3
     },
+    "rsdscs": {
+      "standard_name": "surface_downwelling_shortwave_flux_in_air_assuming_clear_sky",
+      "units": "W m-2",
+      "ndim": 3
+    },
+    "rsuscs": {
+      "standard_name": "surface_upwelling_shortwave_flux_in_air_assuming_clear_sky",
+      "units": "W m-2",
+      "ndim": 3
+    },
+    "rlutcs": {
+      "standard_name": "toa_outgoing_longwave_flux_assuming_clear_sky",
+      "units": "W m-2",
+      "ndim": 3
+    },
+    "rsutcs": {
+      "standard_name": "toa_outgoing_shortwave_flux_assuming_clear_sky",
+      "units": "W m-2",
+      "ndim": 3
+    },
     "hfss": {
       "standard_name": "surface_upward_sensible_heat_flux",
       "units": "W m-2",
@@ -205,6 +225,27 @@
     "evspsbl": {
       "standard_name": "water_evapotranspiration_flux",
       "units": "kg m-2 s-1",
+      "ndim": 3
+    },
+    // Ice-Ocean variables
+    "siconc": {
+      "standard_name": "sea_ice_area_fraction",
+      "units": "%",
+      "ndim": 3
+    },
+    "tauuo": {
+      "standard_name": "downward_x_stress_at_sea_water_surface",
+      "units": "N m-2",
+      "ndim": 3
+    },
+    "tauvo": {
+      "standard_name": "downward_y_stress_at_sea_water_surface",
+      "units": "N m-2",
+      "ndim": 3
+    },
+    "zos": {
+      "standard_name": "sea_surface_height_above_geoid",
+      "units": "m",
       "ndim": 3
     }
   },


### PR DESCRIPTION
**Description**
This PR adds variables required by new PODs to fieldlist_CMIP.jsonc

Associated issue #134 

**Checklist:**
- [x] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/ subdirectory, and include a main_driver script template html, and settings.jsonc
- [ ] The main_driver script header has all of the information in the POD documentation, excluding the "More about this diagnostic" section
- [ ] The POD directory and html template have the same short name as my POD
- [ ] The html template has a 1-paragraph synopsis of the POD and links to the main documentation
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with conda_env_setup.sh 
- [ ] The POD scripts do not access the internet or networked resources
- [ ] I have commented the code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have created the directory input_data/obs_data/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have added information about the raw data files to the documentation
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [x] The repository contains no extra test scripts or data files
- [x] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
