### PR TITLE
Add development cheatsheet to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ See the [documentation site](https://mdtf-diagnostics.readthedocs.io/en/latest/)
 ## Notes
 - `$` indicates strings to be substituted, e.g., the string `$CODE_ROOT` should be substituted by the actual path to the MDTF-diagnostics directory.
 - Consult the [Getting started](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/start_toc.html) section to learn how to run the framework on your own data and configure general settings.
+- POD contributors can consult the **[Developer Cheatsheet](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_cheatsheet.rst)** for brief instructions and useful tips
 
 ## 1. Install MDTF-diagnostics
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -121,8 +121,8 @@ html_theme = 'alabaster'
 # See https://alabaster.readthedocs.io/en/latest/customization.html
 html_theme_options = {
     'page_width': '1024px',
-    'sidebar_collapse': True,
-    'fixed_sidebar': True,
+    'sidebar_collapse': False,
+    'fixed_sidebar': False,
     'extra_nav_links' : {
         "Getting Started [PDF]": "https://mdtf-diagnostics.readthedocs.io/en/latest/_static/MDTF_getting_started.pdf",
         "Developer's Walkthough [PDF]": "https://mdtf-diagnostics.readthedocs.io/en/latest/_static/MDTF_walkthrough.pdf",

--- a/doc/sphinx/dev_cheatsheet.rst
+++ b/doc/sphinx/dev_cheatsheet.rst
@@ -25,9 +25,9 @@ default_tests.jsonc file (or whatever the name of your runtime settings jsonc fi
 
 Output Data from my POD
 ^^^^^^^^^^^^^^^^^^^^^^^
-${WK_DIR} is a framework environment variable defining the working directory, and is set to MDTF-diagnostics/../wkdir by default.
-${WK_DIR} contains POD output figures, temporary files, and logs.
-You can modify ${WK_DIR} by changing "WORKING_DIR" to the desired location in default_tests.jsonc.
+``${WK_DIR}`` is a framework environment variable defining the working directory, and is set to MDTF-diagnostics/../wkdir by default.
+``${WK_DIR}`` contains POD output figures, temporary files, and logs.
+You can modify ``${WK_DIR}`` by changing "WORKING_DIR" to the desired location in default_tests.jsonc.
 
 You can also modify the "OUTPUT_DIR" option in default_tests.jsonc to write output files to a different location if you wish.
 "OUTPUT_DIR" defaults to "WORKING_DIR" if it is not defined.
@@ -42,10 +42,11 @@ How do I define variables for my POD?
 -------------------------------------
 
 Add variables to the "varlist" block in the MDTF-diagnostics/diagnostics/[POD name]/settings.jsonc and define the following:
-- the variable name: the short name that will generate the corresponding ${ENV_VAR}
-(e.g., "zg500" generates the ${ENV_VAR} "zg500_var")
+- the variable name: the short name that will generate the corresponding ``${ENV_VAR}``
+(e.g., "zg500" generates the ``${ENV_VAR}`` "zg500_var")
 - the standard name with a corresponding entry in the appropriate fieldlist file(s). If your variable is not in the necessary fieldlist file(s),
-add them to the file(s), or open an issue on GitHub requesting that the framework team add them. Once the files are updated, merge the changes from the develop branch into your POD branch.
+add them to the file(s), or open an issue on GitHub requesting that the framework team add them.
+Once the files are updated, merge the changes from the develop branch into your POD branch. Note that the variable name and the standard name must be unique fieldlist entries.
 - variable units
 - variable dimensions (e.g., [time, lat, lon])
 - scalar coordinates for variables defined on a specific atmospheric pressure level (e.g. {"lev": 250} for a field on the 250-hPa p level).
@@ -54,7 +55,8 @@ How do I define and reference environment variables?
 ----------------------------------------------------
 
 - To define an environment variable specific to your POD, add a "pod_env_vars" block to the "settings" block inyour POD's settings.jsonc file and define the desired variables.
-Reference the a variable in your POD (python) code using os.environ["VARIABLE NAME"].
+Reference the a variable in your POD (python) code by calling ``os.environ["VARIABLE NAME"]``.
+NCL code can reference environment variables by calling ``getenv("VARIABLE NAME")``.
 
 - You can reference the environment variables defined by the framework using os.environ["ENV_VARIABLE_NAME"].
 Framework-specific environment variables include:

--- a/doc/sphinx/dev_cheatsheet.rst
+++ b/doc/sphinx/dev_cheatsheet.rst
@@ -6,13 +6,13 @@ Where are the files?
 
 My POD scripts and supporting documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-POD files should be placed in a directory that you create in MDTF-diagnostics/diagnostics: MDTF-diagnostics/diagnostics/[POD name]
+POD files should be placed in a directory that you create in MDTF-diagnostics/diagnostics: MDTF-diagnostics/diagnostics/[POD name].
 The files include:
-   - settings.jsonc: settings file for your POD. You can use the example/settings.jsonc file as template
-   - POD scripts
-   - documentation : place in a directory called MDTF-diagnostics/diagnostics/[POD name]/doc
-      - POD description and links to supporting documentation (.rst file(s))
-      - supporting figures
+- settings.jsonc: settings file for your POD. You can use the example/settings.jsonc file as template
+- POD scripts
+- documentation : place in a directory called MDTF-diagnostics/diagnostics/[POD name]/doc. Documentation includes:
+    - POD description and links to supporting documentation (.rst file(s))
+    - supporting figures
 
 Input Model Data for my POD
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -20,7 +20,7 @@ The default input data locations are:
    - model input data: MDTF-diagnostics/../inputdata/model/[dataset name]/[output frequency]
    - observational input data: MDTF-diagnostics/../inputdata/obs_data/[POD name]
 Sample datasets should be submitted using the default directory structure.
-You may re-define input data locations in the `MODEL_DATA_ROOT` and `OBS_DATA_ROOT`definitions in the
+You may re-define input data locations in the MODEL_DATA_ROOT and OBS_DATA_ROOT definitions in the
 default_tests.jsonc file (or whatever the name of your runtime settings jsonc file is).
 
 Output Data from my POD
@@ -41,9 +41,9 @@ The ${WK_DIR}/[POD NAME]/POD.html file should be modified to include the paths t
 How do I define variables for my POD?
 -------------------------------------
 
-Add variables to the `varlist` block in the MDTF-diagnostics/diagnostics/[POD name]/settings.jsonc and define the following:
+Add variables to the "varlist" block in the MDTF-diagnostics/diagnostics/[POD name]/settings.jsonc and define the following:
 - the variable name: the short name that will generate the corresponding ${ENV_VAR}
-(e.g., `zg500` generates the ${ENV_VAR} `zg500_var`)
+(e.g., "zg500" generates the ${ENV_VAR} "zg500_var")
 - the standard name with a corresponding entry in the appropriate fieldlist file(s). If your variable is not in the necessary fieldlist file(s),
 add them to the file(s), or open an issue on GitHub requesting that the framework team add them. Once the files are updated, merge the changes from the develop branch into your POD branch.
 - variable units

--- a/doc/sphinx/dev_cheatsheet.rst
+++ b/doc/sphinx/dev_cheatsheet.rst
@@ -54,7 +54,7 @@ Notes:
    - Note that the variable name and the standard name must be unique fieldlist entries
 - Environment variables
    - To define an environment variable specific to your POD, add a ``"pod_env_vars"`` block to the ``"settings"`` block in your POD's ``settings.jsonc`` file and define the desired variables 
-   - Reference the a variable in Python by calling ``os.environ["VARIABLE NAME"]``  
+   - Reference an environment variable in Python by calling ``os.environ["VARIABLE NAME"]``  
    - NCL code can reference environment variables by calling ``getenv("VARIABLE NAME")``  
    - Framework-specific environment variables include:
       - OBS_DATA : path to the top-level directory containing any observational or reference data for your POD

--- a/doc/sphinx/dev_cheatsheet.rst
+++ b/doc/sphinx/dev_cheatsheet.rst
@@ -1,0 +1,67 @@
+Development Cheatsheet
+==============================
+
+Where are the files?
+--------------------
+
+My POD scripts and supporting documentation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+POD files should be placed in a directory that you create in MDTF-diagnostics/diagnostics: MDTF-diagnostics/diagnostics/[POD name]
+The files include:
+   - settings.jsonc: settings file for your POD. You can use the example/settings.jsonc file as template
+   - POD scripts
+   - documentation : place in a directory called MDTF-diagnostics/diagnostics/[POD name]/doc
+      - POD description and links to supporting documentation (.rst file(s))
+      - supporting figures
+
+Input Model Data for my POD
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The default input data locations are:
+   - model input data: MDTF-diagnostics/../inputdata/model/[dataset name]/[output frequency]
+   - observational input data: MDTF-diagnostics/../inputdata/obs_data/[POD name]
+Sample datasets should be submitted using the default directory structure.
+You may re-define input data locations in the `MODEL_DATA_ROOT` and `OBS_DATA_ROOT`definitions in the
+default_tests.jsonc file (or whatever the name of your runtime settings jsonc file is).
+
+Output Data from my POD
+^^^^^^^^^^^^^^^^^^^^^^^
+${WK_DIR} is a framework environment variable defining the working directory, and is set to MDTF-diagnostics/../wkdir by default.
+${WK_DIR} contains POD output figures, temporary files, and logs.
+You can modify ${WK_DIR} by changing "WORKING_DIR" to the desired location in default_tests.jsonc.
+
+You can also modify the "OUTPUT_DIR" option in default_tests.jsonc to write output files to a different location if you wish.
+"OUTPUT_DIR" defaults to "WORKING_DIR" if it is not defined.
+
+POD output files are written to the following locations:
+   - Postscript files: ${WK_DIR}/[POD NAME]/[model,obs]/PS
+   - Other files, including PNG plots: ${WK_DIR}/[POD NAME]/[model,obs]
+The ${WK_DIR}/[POD NAME]/POD.html file should be modified to include the paths to the output plots.
+
+
+How do I define variables for my POD?
+-------------------------------------
+
+Add variables to the `varlist` block in the MDTF-diagnostics/diagnostics/[POD name]/settings.jsonc and define the following:
+- the variable name: the short name that will generate the corresponding ${ENV_VAR}
+(e.g., `zg500` generates the ${ENV_VAR} `zg500_var`)
+- the standard name with a corresponding entry in the appropriate fieldlist file(s). If your variable is not in the necessary fieldlist file(s),
+add them to the file(s), or open an issue on GitHub requesting that the framework team add them. Once the files are updated, merge the changes from the develop branch into your POD branch.
+- variable units
+- variable dimensions (e.g., [time, lat, lon])
+- scalar coordinates for variables defined on a specific atmospheric pressure level (e.g. {"lev": 250} for a field on the 250-hPa p level).
+
+How do I define and reference environment variables?
+----------------------------------------------------
+
+- To define an environment variable specific to your POD, add a "pod_env_vars" block to the "settings" block inyour POD's settings.jsonc file and define the desired variables.
+Reference the a variable in your POD (python) code using os.environ["VARIABLE NAME"].
+
+- You can reference the environment variables defined by the framework using os.environ["ENV_VARIABLE_NAME"].
+Framework-specific environment variables include:
+   - OBS_DATA : path to the top-level directory containing any observational or reference data for your POD
+   - POD_HOME : Path to the top-level directory containing your diagnostic’s source code (../MDTF-diagnostics/diagnostics/[POD NAME]).
+   - WK_DIR : path to the POD working directory
+   - DATADIR : Path to directory containing input data files for one case/experiment
+   - CASENAME : User-provided label describing the run of model data being analyzed
+   - FIRSTYR: Four-digit year describing the first year of the analysis period
+   - LASTYR: Four-digit year describing the last year of the analysis period

--- a/doc/sphinx/dev_cheatsheet.rst
+++ b/doc/sphinx/dev_cheatsheet.rst
@@ -1,68 +1,68 @@
 Development Cheatsheet
 ==============================
 
-Where are the files?
---------------------
+Creating and submitting a POD
+-----------------------------
+1. Prepare for implementation  
 
-My POD scripts and supporting documentation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   - Run the unmodified MDTF-diagnostics package to make sure that your conda installation, directory structure, etc... are set up properly  
+   - Modify the conda environment to work for your POD by adding a configuration file ``MDTF_diagnostics/src/conda/env_[YOUR POD NAME].yml`` with any new required modules.  Be sure to re-run ``MDTF-diagnostics/src/conda/conda_env_setup.sh`` to install your POD's environment if it requires a separate YAML file with additional modules.
+   - Name your POD, make a directory for your POD in MDTF-diagnostics/diagnostics, and move your code to your POD directory  
+   - ``cp`` your observational data to ``MDTF_diagnostics/../inputdata/obs_data/[YOUR POD NAME]``  
+   - If necessary, ``cp`` your model data to ``MDTF_diagnostics/../inputdata/model/[model dataset name]`` 
+2. Link your POD code into the framework  
 
-POD files should be placed in a directory that you create in MDTF-diagnostics/diagnostics called  
-MDTF-diagnostics/diagnostics/[POD name].  
+   - Modify your POD's driver script (e.g, ``driver.py``) to interface with your code
+   - Modify pod's ``settings.jsonc`` to specifiy variables that will be passed to the framework
+   - Modify your code to use ``ENV_VARS`` provided by the framework (see the *Notes* for descriptions of the available environment variables)
+      - Input files:
+         - model input data: ``MDTF-diagnostics/../inputdata/model/[dataset name]/[output frequency]``
+         - observational input data: ``MDTF-diagnostics/../inputdata/obs_data/[POD name]``
+         - Sample datasets should be submitted using the default directory structure
+         - You may re-define input data locations in the ``MODEL_DATA_ROOT`` and ``OBS_DATA_ROOT`` definitions in the ``default_tests.jsonc`` file (or whatever the name of your runtime settings jsonc file is).
+      - Working files: 
+         - ``${WK_DIR}`` is a framework environment variable defining the working directory. It is set to ``MDTF-diagnostics/../wkdir`` by default.
+         - ``${WK_DIR}`` contains temporary files and logs. 
+         - You can modify ``${WK_DIR}`` by changing "WORKING_DIR" to the desired location in ``default_tests.jsonc``
+      - Output files: 
+         - POD output files are written to the following locations by the framework:
+            - Postscript files: ``${WK_DIR}/[POD NAME]/[model,obs]/PS``
+            - Other files, including PNG plots: ``${WK_DIR}/[POD NAME]/[model,obs]``
+         - Set the "OUTPUT_DIR" option in default_tests.jsonc to write output files to a different location; "OUTPUT_DIR" defaults to "WORKING_DIR" if it is not defined.
+         - Output figure locations:  
+            - PNG files should be placed directly in ``$WK_DIR/obs/`` and ``$WK_DIR/model/``  
+            - If a POD chooses to save vector-format figures, they should be written into the ``$WK_DIR/obs/PS`` and ``$WK_DIR/model/PS`` directories. Files in these locations will be converted by the framework to PNG, so use those names in the html file.
+            - If a POD uses matplotlib, it is recommended to write as figures as EPS instead of PS because of potential bugs
+   
+   - Modify html files to point to the figure names
+   - If running an NCAR NCL-based POD, modify input.jsonc to call your POD
 
-The files include:
-   - settings.jsonc: settings file for your POD. You can use the example/settings.jsonc file as template
-   - POD scripts
-   - documentation should be placed in a directory called MDTF-diagnostics/diagnostics/[POD name]/doc.  
-     Documentation includes:  
-      - POD description and links to supporting documentation formatted as .rst files
-      - supporting figures
+3. Place your documentation in ``MDTF-diagnostics/diagnostics/[YOUR POD NAME]/docs``
+4. Test your code with the framework 
+5. Submit a Pull Request for your POD using the GitHub website
 
-Input Model Data for my POD
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The default input data locations are:
-   - model input data: MDTF-diagnostics/../inputdata/model/[dataset name]/[output frequency]
-   - observational input data: MDTF-diagnostics/../inputdata/obs_data/[POD name]
-Sample datasets should be submitted using the default directory structure.
-You may re-define input data locations in the MODEL_DATA_ROOT and OBS_DATA_ROOT definitions in the
-default_tests.jsonc file (or whatever the name of your runtime settings jsonc file is).
-
-Output Data from my POD
-^^^^^^^^^^^^^^^^^^^^^^^
-``${WK_DIR}`` is a framework environment variable defining the working directory, and is set to MDTF-diagnostics/../wkdir by default.
-``${WK_DIR}`` contains POD output figures, temporary files, and logs.
-You can modify ``${WK_DIR}`` by changing "WORKING_DIR" to the desired location in default_tests.jsonc.
-
-You can also modify the "OUTPUT_DIR" option in default_tests.jsonc to write output files to a different location if you wish.
-"OUTPUT_DIR" defaults to "WORKING_DIR" if it is not defined.
-
-POD output files are written to the following locations:
-   - Postscript files: ${WK_DIR}/[POD NAME]/[model,obs]/PS
-   - Other files, including PNG plots: ${WK_DIR}/[POD NAME]/[model,obs]
-The ${WK_DIR}/[POD NAME]/POD.html file should be modified to include the paths to the output plots.
-
-
-How do I define variables for my POD?
--------------------------------------
-
-Add variables to the "varlist" block in the MDTF-diagnostics/diagnostics/[POD name]/settings.jsonc and define the following:  
-   - the variable name: the short name that will generate the corresponding ``${ENV_VAR}`` (e.g., "zg500" generates the ``${ENV_VAR}`` "zg500_var")
-   - the standard name with a corresponding entry in the appropriate fieldlist file(s). If your variable is not in the necessary fieldlist file(s), add them to the file(s), or open an issue on GitHub requesting that the framework team add them. Once the files are updated, merge the changes from the develop branch into your POD branch. Note that the variable name and the standard name must be unique fieldlist entries.
-   - variable units
-   - variable dimensions (e.g., [time, lat, lon])
-   - scalar coordinates for variables defined on a specific atmospheric pressure level (e.g. {"lev": 250} for a field on the 250-hPa p level).
-
-How do I define and reference environment variables?
-----------------------------------------------------
-
-To define an environment variable specific to your POD, add a `"pod_env_vars"` block to the `"settings"` block in your POD's settings.jsonc file and define the desired variables. Reference the a variable in your POD (python) code by calling ``os.environ["VARIABLE NAME"]``. NCL code can reference environment variables by calling ``getenv("VARIABLE NAME")``.
-
-You can reference the environment variables defined by the framework using os.environ["ENV_VARIABLE_NAME"]. Framework-specific environment variables include:
-   - OBS_DATA : path to the top-level directory containing any observational or reference data for your POD
-   - POD_HOME : Path to the top-level directory containing your diagnostic’s source code (../MDTF-diagnostics/diagnostics/[POD NAME]).
-   - WK_DIR : path to the POD working directory
-   - DATADIR : Path to directory containing input data files for one case/experiment
-   - CASENAME : User-provided label describing the run of model data being analyzed
-   - FIRSTYR: Four-digit year describing the first year of the analysis period
-   - LASTYR: Four-digit year describing the last year of the analysis period
+Notes:
+------
+- **Make sure that WORKING_DIR and OUTPUT_DIR have enough space to hold datafor your POD(s) AND any PODs included in the package.**
+- Defining POD variables
+   - Add variables to the ``varlist`` block in the ``MDTF-diagnostics/diagnostics/[POD name]/settings.jsonc`` and define the following:  
+      - the variable name: the short name that will generate the corresponding ``${ENV_VAR}`` (e.g., "zg500" generates the ``${ENV_VAR}`` "zg500_var")
+      - the standard name with a corresponding entry in the appropriate fieldlist file(s)  
+      - variable units
+      - variable dimensions (e.g., [time, lat, lon])
+      - scalar coordinates for variables defined on a specific atmospheric pressure level (e.g. ``{"lev": 250}`` for a field on the 250-hPa p level).
+   - If your variable is not in the necessary fieldlist file(s), add them to the file(s), or open an issue on GitHub requesting that the framework team add them. Once the files are updated, merge the changes from the develop branch into your POD branch. 
+   - Note that the variable name and the standard name must be unique fieldlist entries
+- Environment variables
+   - To define an environment variable specific to your POD, add a ``"pod_env_vars"`` block to the ``"settings"`` block in your POD's ``settings.jsonc`` file and define the desired variables 
+   - Reference the a variable in your POD (python) code by calling ``os.environ["VARIABLE NAME"]``  
+   - NCL code can reference environment variables by calling ``getenv("VARIABLE NAME")``  
+   - You can reference the environment variables defined by the framework using ``os.environ["ENV_VARIABLE_NAME"]``
+   - Framework-specific environment variables include:
+      - OBS_DATA : path to the top-level directory containing any observational or reference data for your POD
+      - POD_HOME : Path to the top-level directory containing your POD's source code
+      - WK_DIR : path to the POD working directory
+      - DATADIR : Path to directory containing input data files for one case/experiment
+      - CASENAME : User-provided label describing the run of model data being analyzed
+      - FIRSTYR: Four-digit year describing the first year of the analysis period
+      - LASTYR: Four-digit year describing the last year of the analysis period

--- a/doc/sphinx/dev_cheatsheet.rst
+++ b/doc/sphinx/dev_cheatsheet.rst
@@ -54,9 +54,8 @@ Notes:
    - Note that the variable name and the standard name must be unique fieldlist entries
 - Environment variables
    - To define an environment variable specific to your POD, add a ``"pod_env_vars"`` block to the ``"settings"`` block in your POD's ``settings.jsonc`` file and define the desired variables 
-   - Reference the a variable in your POD (python) code by calling ``os.environ["VARIABLE NAME"]``  
+   - Reference the a variable in Python by calling ``os.environ["VARIABLE NAME"]``  
    - NCL code can reference environment variables by calling ``getenv("VARIABLE NAME")``  
-   - You can reference the environment variables defined by the framework using ``os.environ["ENV_VARIABLE_NAME"]``
    - Framework-specific environment variables include:
       - OBS_DATA : path to the top-level directory containing any observational or reference data for your POD
       - POD_HOME : Path to the top-level directory containing your POD's source code

--- a/doc/sphinx/dev_cheatsheet.rst
+++ b/doc/sphinx/dev_cheatsheet.rst
@@ -6,16 +6,21 @@ Where are the files?
 
 My POD scripts and supporting documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-POD files should be placed in a directory that you create in MDTF-diagnostics/diagnostics: MDTF-diagnostics/diagnostics/[POD name].
+
+POD files should be placed in a directory that you create in MDTF-diagnostics/diagnostics called  
+MDTF-diagnostics/diagnostics/[POD name].  
+
 The files include:
-- settings.jsonc: settings file for your POD. You can use the example/settings.jsonc file as template
-- POD scripts
-- documentation : place in a directory called MDTF-diagnostics/diagnostics/[POD name]/doc. Documentation includes:
-    - POD description and links to supporting documentation (.rst file(s))
-    - supporting figures
+   - settings.jsonc: settings file for your POD. You can use the example/settings.jsonc file as template
+   - POD scripts
+   - documentation should be placed in a directory called MDTF-diagnostics/diagnostics/[POD name]/doc.  
+     Documentation includes:  
+      - POD description and links to supporting documentation formatted as .rst files
+      - supporting figures
 
 Input Model Data for my POD
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 The default input data locations are:
    - model input data: MDTF-diagnostics/../inputdata/model/[dataset name]/[output frequency]
    - observational input data: MDTF-diagnostics/../inputdata/obs_data/[POD name]
@@ -41,25 +46,19 @@ The ${WK_DIR}/[POD NAME]/POD.html file should be modified to include the paths t
 How do I define variables for my POD?
 -------------------------------------
 
-Add variables to the "varlist" block in the MDTF-diagnostics/diagnostics/[POD name]/settings.jsonc and define the following:
-- the variable name: the short name that will generate the corresponding ``${ENV_VAR}``
-(e.g., "zg500" generates the ``${ENV_VAR}`` "zg500_var")
-- the standard name with a corresponding entry in the appropriate fieldlist file(s). If your variable is not in the necessary fieldlist file(s),
-add them to the file(s), or open an issue on GitHub requesting that the framework team add them.
-Once the files are updated, merge the changes from the develop branch into your POD branch. Note that the variable name and the standard name must be unique fieldlist entries.
-- variable units
-- variable dimensions (e.g., [time, lat, lon])
-- scalar coordinates for variables defined on a specific atmospheric pressure level (e.g. {"lev": 250} for a field on the 250-hPa p level).
+Add variables to the "varlist" block in the MDTF-diagnostics/diagnostics/[POD name]/settings.jsonc and define the following:  
+   - the variable name: the short name that will generate the corresponding ``${ENV_VAR}`` (e.g., "zg500" generates the ``${ENV_VAR}`` "zg500_var")
+   - the standard name with a corresponding entry in the appropriate fieldlist file(s). If your variable is not in the necessary fieldlist file(s), add them to the file(s), or open an issue on GitHub requesting that the framework team add them. Once the files are updated, merge the changes from the develop branch into your POD branch. Note that the variable name and the standard name must be unique fieldlist entries.
+   - variable units
+   - variable dimensions (e.g., [time, lat, lon])
+   - scalar coordinates for variables defined on a specific atmospheric pressure level (e.g. {"lev": 250} for a field on the 250-hPa p level).
 
 How do I define and reference environment variables?
 ----------------------------------------------------
 
-- To define an environment variable specific to your POD, add a "pod_env_vars" block to the "settings" block inyour POD's settings.jsonc file and define the desired variables.
-Reference the a variable in your POD (python) code by calling ``os.environ["VARIABLE NAME"]``.
-NCL code can reference environment variables by calling ``getenv("VARIABLE NAME")``.
+To define an environment variable specific to your POD, add a `"pod_env_vars"` block to the `"settings"` block in your POD's settings.jsonc file and define the desired variables. Reference the a variable in your POD (python) code by calling ``os.environ["VARIABLE NAME"]``. NCL code can reference environment variables by calling ``getenv("VARIABLE NAME")``.
 
-- You can reference the environment variables defined by the framework using os.environ["ENV_VARIABLE_NAME"].
-Framework-specific environment variables include:
+You can reference the environment variables defined by the framework using os.environ["ENV_VARIABLE_NAME"]. Framework-specific environment variables include:
    - OBS_DATA : path to the top-level directory containing any observational or reference data for your POD
    - POD_HOME : Path to the top-level directory containing your diagnostic’s source code (../MDTF-diagnostics/diagnostics/[POD NAME]).
    - WK_DIR : path to the POD working directory

--- a/doc/sphinx/dev_cheatsheet.rst
+++ b/doc/sphinx/dev_cheatsheet.rst
@@ -35,7 +35,6 @@ Creating and submitting a POD
             - If a POD uses matplotlib, it is recommended to write as figures as EPS instead of PS because of potential bugs
    
    - Modify html files to point to the figure names
-   - If running an NCAR NCL-based POD, modify input.jsonc to call your POD
 
 3. Place your documentation in ``MDTF-diagnostics/diagnostics/[YOUR POD NAME]/docs``
 4. Test your code with the framework 


### PR DESCRIPTION
**Description**
I've added a development cheatsheet with brief instructions on file locations and variable creation/reference in response to discussion #228 


**Checklist:**
- [x] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/ subdirectory, and include a main_driver script template html, and settings.jsonc
- [ ] The main_driver script header has all of the information in the POD documentation, excluding the "More about this diagnostic" section
- [ ] The POD directory and html template have the same short name as my POD
- [ ] The html template has a 1-paragraph synopsis of the POD and links to the main documentation
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with conda_env_setup.sh 
- [ ] The POD scripts do not access the internet or networked resources
- [ ] I have commented the code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have created the directory input_data/obs_data/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have added information about the raw data files to the documentation
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [x] The repository contains no extra test scripts or data files
- [x] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
