### PR TITLE
Add XQuartz dependency to installation instructions

### DIFF
--- a/doc/sphinx/start_install.rst
+++ b/doc/sphinx/start_install.rst
@@ -111,7 +111,7 @@ Installing dependencies
 Installing XQuartz on MacOS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you're installing on a MacOS system, you will need to install `XQuartz <https://www.xquartz.org/>`__ if it's not already present. 
+If you're installing on a MacOS system, you will need to install `XQuartz <https://www.xquartz.org/>`__. If the XQuartz executable isn't present in ``/Applications/Utilities``, you will need to download and run the installer from the previous link.
 
 The reason for this requirement is that the X11 libraries are `required dependencies <https://www.ncl.ucar.edu/Download/macosx.shtml#InstallXQuartz>`__ for the NCL scripting language, even when it's run non-interactively. Because the required libraries cannot be installed through conda (next section), this installation needs to be done as a manual step.
 

--- a/doc/sphinx/start_install.rst
+++ b/doc/sphinx/start_install.rst
@@ -105,8 +105,18 @@ You can put the observational data and model output in different locations, e.g.
 
 .. _ref-conda-install:
 
-Installing dependencies via the conda package manager
------------------------------------------------------
+Installing dependencies
+-----------------------
+
+Installing XQuartz on MacOS
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you're installing on a MacOS system, you will need to install `XQuartz <https://www.xquartz.org/>`__ if it's not already present. 
+
+The reason for this requirement is that the X11 libraries are `required dependencies <https://www.ncl.ucar.edu/Download/macosx.shtml#InstallXQuartz>`__ for the NCL scripting language, even when it's run non-interactively. Because the required libraries cannot be installed through conda (next section), this installation needs to be done as a manual step.
+
+Managing dependencies with the conda package manager
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The MDTF framework code is written in Python 3.7, but supports running PODs written in a variety of scripting languages and combinations of libraries. To ensure that the correct versions of these dependencies are installed and available, we use `conda <https://docs.conda.io/en/latest/>`__, a free, open-source package manager. Conda is one component of the `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`__ and `Anaconda <https://www.anaconda.com/>`__ python distributions, so having Miniconda/Anaconda is sufficient but not necessary.
 


### PR DESCRIPTION
**Description**
Associated issue: #65
Closes #65 , since the MacOS CI configurations have already been updated to include XQuartz.

Instruct MacOS users to install XQuartz if they haven't already done so, in light of the debugging work done in #65. Adding another step to the installation is undesirable, but is the simplest workaround for the fact that the current [conda recipe](https://anaconda.org/conda-forge/ncl/files/modal/info/5ec553f3fe6b2a019f6937cf) for NCL doesn't include cairo (or other required graphics libraries -- again, it's unclear to me to what extent NCL's X11 dependency is hard-coded). It's beyond our scope to spend time fixing this upstream issue.

**How Has This Been Tested?**
N/A - change to docs only

**Checklist:**
- [X] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/ subdirectory, and include a main_driver script template html, and settings.jsonc
- [ ] The main_driver script header has all of the information in the POD documentation, excluding the "More about this diagnostic" section
- [ ] The POD directory and html template have the same short name as my POD
- [ ] The html template has a 1-paragraph synopsis of the POD and links to the main documentation
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with conda_env_setup.sh 
- [ ] The POD scripts do not access the internet or networked resources
- [ ] I have commented the code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have created the directory input_data/obs_data/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have added information about the raw data files to the documentation
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
- [X] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
