### PR TITLE
Fix mis-specified code location for CMIP6 local file data source (develop)

### DIFF
--- a/src/cli_plugins.jsonc
+++ b/src/cli_plugins.jsonc
@@ -21,7 +21,7 @@
     },
     "CMIP6": {
       "help": "DataManager for working with input model data files that are already present on a local filesystem, for example the PODs' sample model data.",
-      "entry_point": "src.data_source:CMIP6DataSource",
+      "entry_point": "src.data_manager:CMIP6LocalFileDataSource",
       "cli": {
         "arguments": [
           {


### PR DESCRIPTION
**Description**
The configuration for the [CMIP6 local file data source](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_data_sources.html#cmip6-local-file-data-source) refers to a non-existent file. Change this to use the correct module and class name.

**Checklist:**
- [ ] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/ subdirectory, and include a main_driver script template html, and settings.jsonc
- [ ] The main_driver script header has all of the information in the POD documentation, excluding the "More about this diagnostic" section
- [ ] The POD directory and html template have the same short name as my POD
- [ ] The html template has a 1-paragraph synopsis of the POD and links to the main documentation
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with conda_env_setup.sh 
- [ ] The POD scripts do not access the internet or networked resources
- [ ] I have commented the code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have created the directory input_data/obs_data/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have added information about the raw data files to the documentation
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
- [ ] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
