### PR TITLE
Add variables for flow-dep cross-timescale POD to fieldlists

### DIFF
--- a/data/fieldlist_CMIP.jsonc
+++ b/data/fieldlist_CMIP.jsonc
@@ -172,6 +172,22 @@
       "units": "W m-2",
       "ndim": 3
     },
+    // Variables for Flow Dependent Cross Timescale Model Diagnostic
+    "zg250": {
+      "standard_name": "geopotential_height_250_mbar",
+      "units": "m",
+      "ndim": 3
+    },
+    "ta250": {
+      "standard_name": "air_temperature_250_mbar",
+      "units": "K",
+      "ndim": 3
+    },
+    "ta500": {
+      "standard_name": "air_temperature_500_mbar",
+      "units": "K",
+      "ndim": 3
+    },
     // Variables for AMOC_3D_Structure module:
     "uo": {
       "standard_name": "sea_water_x_velocity",

--- a/data/fieldlist_GFDL.jsonc
+++ b/data/fieldlist_GFDL.jsonc
@@ -140,6 +140,22 @@
       "units": "W m-2",
       "ndim": 3
     },
+    // Variables for Flow Dependent Cross Timescale Model Diagnostic
+    "zg250": {
+      "standard_name": "geopotential_height_250_mbar",
+      "units": "m",
+      "ndim": 3
+    },
+    "ta250": {
+      "standard_name": "air_temperature_250_mbar",
+      "units": "K",
+      "ndim": 3
+    },
+    "ta500": {
+      "standard_name": "air_temperature_500_mbar",
+      "units": "K",
+      "ndim": 3
+    },
     // Variables for AMOC_3D_Structure module:
     // "uo": {
     // NB: need to perform rotation to get from u,v?


### PR DESCRIPTION
…ld lists

**Description**
This PR adds ta250, ta500, and zg250 to the CMIP and GFDL field lists to support the incoming flow-dependent cross-timescale diagnostic POD

Associated issue #247 

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [x] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [x] The repository contains no extra test scripts or data files
