### PR TITLE
Add pytest to _env_synthetic_data.yml

### DIFF
--- a/src/conda/_env_synthetic_data.yml
+++ b/src/conda/_env_synthetic_data.yml
@@ -15,6 +15,7 @@ dependencies:
 - python-dateutil >= 2.8.0
 - pandas >= 1.2.0
 - pytz=2020.4
+- pytest >= 6.2.4
 - pip=21.1.1
 - pip :
   - https://files.pythonhosted.org/packages/6d/e7/2b1c334e313b689eb067f34edc82d083e39c01979fb3b00003c9e3cddf57/envyaml-1.8.210417-py2.py3-none-any.whl


### PR DESCRIPTION
**Description**
Add pytest to _env_synthetic_data.yml, which is required by the latest version of the synthetic data generator

Associated issue # (replace this phrase and parentheses with the issue number)  

**Checklist:**
- [x] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [x] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [x] The repository contains no extra test scripts or data files
