### PR TITLE
Pull synthetic data package from PyPi

### DIFF
--- a/.github/workflows/mdtf_tests.yml
+++ b/.github/workflows/mdtf_tests.yml
@@ -81,15 +81,12 @@ jobs:
     - name: Generate Model Data
       run: |
         cd ../
-        # clone the mdtf_test_data repo
-        git clone https://github.com/jkrasting/mdtf_test_data.git
-        # install the test data software
-        cd mdtf_test_data
-        # Defining dependencies in Conda env is faster than pip
-        conda activate _MDTF_synthetic_data
+        pip install pytest
+        pip install mdtf-test-data
+        mkdir mdtf_test_data ; cd mdtf_test_data
         # generate the data and run unit tests
-        ./mdtf_test_data/mdtf_synthetic.py -c GFDL --startyear 1 --nyears 10 --unittest
-        ./mdtf_test_data/mdtf_synthetic.py -c NCAR --startyear 1975 --nyears 7
+        mdtf_synthetic.py -c GFDL --startyear 1 --nyears 10 --unittest
+        mdtf_synthetic.py -c NCAR --startyear 1975 --nyears 7
         cd ../
         mkdir wkdir
     - name: Get Observational Data for Set 1

--- a/.github/workflows/mdtf_tests.yml
+++ b/.github/workflows/mdtf_tests.yml
@@ -82,7 +82,6 @@ jobs:
       run: |
         cd ../
         conda activate _MDTF_synthetic_data
-        pip install pytest
         pip install mdtf-test-data
         mkdir mdtf_test_data ; cd mdtf_test_data
         # generate the data and run unit tests

--- a/.github/workflows/mdtf_tests.yml
+++ b/.github/workflows/mdtf_tests.yml
@@ -81,6 +81,7 @@ jobs:
     - name: Generate Model Data
       run: |
         cd ../
+        conda activate _MDTF_synthetic_data
         pip install pytest
         pip install mdtf-test-data
         mkdir mdtf_test_data ; cd mdtf_test_data


### PR DESCRIPTION
- Uses packaged, released version of the tool rather
  than cloning the source code

**Description**
Include a summary of the change, and link the associated issue (if applicable).  
List any dependencies that are required for this change, including libraries and variables,  
and their metadata (units, frequencies, etc...). Be sure to separate PRs and issues for new PODs and PODs currently under development.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [ ] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [x] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [x] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [x] The repository contains no extra test scripts or data files
