### PR TITLE
Specify Pandas version in conda environments

### DIFF
--- a/src/conda/_env_synthetic_data.yml
+++ b/src/conda/_env_synthetic_data.yml
@@ -13,7 +13,7 @@ dependencies:
 - esmpy=8.1.0
 - xesmf=0.5.3
 - python-dateutil >= 2.8.0
-- pandas >= 1.2.4
+- pandas < 1.3
 - pytz=2020.4
 - pytest >= 6.2.4
 - pip=21.1.1

--- a/src/conda/env_base.yml
+++ b/src/conda/env_base.yml
@@ -16,6 +16,7 @@ dependencies:
 - xarray=0.16
 - matplotlib=3.3
 # - cartopy=0.18
+- pandas<1.3
 - pint=0.16
 - dask=2.30
 # additions dec 2020

--- a/src/conda/env_convective_transition_diag.yml
+++ b/src/conda/env_convective_transition_diag.yml
@@ -10,6 +10,7 @@ dependencies:
 - cftime=1.2
 - xarray=0.16
 - matplotlib=3.3
+- pandas<1.3
 - cartopy=0.18
 - numba = 0.51.2
 - networkx = 2.3

--- a/src/conda/env_dev.yml
+++ b/src/conda/env_dev.yml
@@ -13,6 +13,7 @@ dependencies:
 - xarray=0.16
 - matplotlib=3.3
 - cartopy=0.18
+- pandas<1.3
 - pint=0.16
 - dask=2.30
 # additional development tools

--- a/src/conda/env_python3_base.yml
+++ b/src/conda/env_python3_base.yml
@@ -14,6 +14,7 @@ dependencies:
 - cftime=1.2
 - xarray=0.16
 - matplotlib=3.3
+- pandas<1.3
 - cartopy=0.18
 - pint=0.16
 - dask=2021.03.0


### PR DESCRIPTION
Due to a known bug in Pandas v1.3.0, explicitly set the Pandas version to avoid error when the framework performs time slicing.

**Description**
In this PR, all Python-based environments that use Xarray now have an entry to ensure that the Pandas version is less than v1.3.0.

Associated issue #254

**How Has This Been Tested?**
This PR was tested by recreating all conda environments and running the `src/default_tests.jsonc` file with the framework

**Checklist:**
- [ ] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [x] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [x] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
