### PR TITLE
Change mdtf_synthetic.py path to the scripts directory

### DIFF
--- a/.github/workflows/mdtf_tests.yml
+++ b/.github/workflows/mdtf_tests.yml
@@ -88,8 +88,8 @@ jobs:
         # Defining dependencies in Conda env is faster than pip
         conda activate _MDTF_synthetic_data
         # generate the data and run unit tests
-        ./mdtf_test_data/mdtf_synthetic.py -c GFDL --startyear 1 --nyears 10 --unittest
-        ./mdtf_test_data/mdtf_synthetic.py -c NCAR --startyear 1975 --nyears 7
+        ./scripts/mdtf_synthetic.py -c GFDL --startyear 1 --nyears 10 --unittest
+        ./scripts/mdtf_synthetic.py -c NCAR --startyear 1975 --nyears 7
         cd ../
         mkdir wkdir
     - name: Get Observational Data for Set 1


### PR DESCRIPTION
**Description**
Update the mdtf_synthetic.py path to scripts to reflect the changes in the mdtf_test_data repo.


**Checklist:**
- [x] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [x] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [x] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [x] The repository contains no extra test scripts or data files
