### PR TITLE
Production fixes for bugs encountered on GFDL high-res expt

### DIFF
--- a/data/fieldlist_GFDL.jsonc
+++ b/data/fieldlist_GFDL.jsonc
@@ -36,13 +36,13 @@
     "ucomp": {
       "standard_name": "eastward_wind",
       "units": "m s-1",
-      "scalar_coord_templates": {"plev": "ucomp{value}"},
+      "scalar_coord_templates": {"plev": "u{value}"},
       "ndim": 4
     },
     "vcomp": {
       "standard_name": "northward_wind",
       "units": "m s-1",
-      "scalar_coord_templates": {"plev": "vcomp{value}"},
+      "scalar_coord_templates": {"plev": "v{value}"},
       "ndim": 4
     },
     "hght": {

--- a/sites/NOAA_GFDL/gfdl.py
+++ b/sites/NOAA_GFDL/gfdl.py
@@ -6,6 +6,7 @@ import io
 import dataclasses
 import shutil
 import tempfile
+import pandas as pd
 from src import (util, core, diagnostic, data_manager,
     preprocessor, environment_manager, output_manager, cmip6)
 from sites.NOAA_GFDL import gfdl_util
@@ -171,6 +172,9 @@ class GCPFetchMixin(data_manager.AbstractFetchMixin):
         tmpdir = core.TempDirManager().make_tempdir()
         _log.debug("Created GCP fetch temp dir at %s.", tmpdir)
         (cp_command, smartsite) = self._get_fetch_method(self._fetch_method)
+
+        if isinstance(paths, pd.Series):
+            paths = paths.to_list()
         if not util.is_iterable(paths):
             paths = (paths, )
 

--- a/src/cli_plugins.jsonc
+++ b/src/cli_plugins.jsonc
@@ -21,7 +21,7 @@
     },
     "CMIP6": {
       "help": "DataManager for working with input model data files that are already present on a local filesystem, for example the PODs' sample model data.",
-      "entry_point": "src.data_source:CMIP6DataSource",
+      "entry_point": "src.data_manager:CMIP6LocalFileDataSource",
       "cli": {
         "arguments": [
           {

--- a/src/data_manager.py
+++ b/src/data_manager.py
@@ -829,17 +829,22 @@ class DataframeQueryDataSourceBase(DataSourceBase, metaclass=util.MDTFABCMeta):
         clauses = [self._query_clause(k, k, v) for k,v in query_d.items()]
         query_str = '&'.join(c for c in clauses if c)
 
-        # need to do filtering on DateRange separately due to limitations on
-        # pd.query()/pd.eval() -- arbitrary methods not supported, at least not
-        # efficiently. TODO: better implementation with <=/>= separate start/end
-        # date columns.
+        # filtering on DateRange is done here, separately, due to limitations on
+        # pd.query()/pd.eval() -- arbitrary method calls not supported, at least
+        # not efficiently. TODO: better implementation with <=/>= separate
+        # start/end date columns.
         catalog_df = self.df
         for col_name, v in query_d.items():
             if isinstance(v, util.DateRange):
                 if col_name not in catalog_df:
                     # e.g., for sample model data where date_range not in catalog
                     continue
-                row_sel = catalog_df.apply((lambda r: v in r[col_name]), axis=1)
+                # select files whose date range overlaps analysis date range
+                # (in case we're dealing with chunked/multi-file data)
+                row_sel = catalog_df.apply(
+                    (lambda r: r[col_name].overlaps(v)),
+                    axis=1
+                )
                 catalog_df = catalog_df[row_sel]
 
         return catalog_df.query(


### PR DESCRIPTION
**Description**
Three disjoint bug fixes to correct bugs found in running framework on CM4_piControl_c192_OM4p125_v5_proto1 high-res experiment:

d45e9db: Incorrect field names in the GFDL convention. Obtaining an up-to-date mapping from GFDL naming conventions to CF/CMIP conventions has been a persistent issue.
e4e190b: Incorrect date range query logic. Existing logic fails for the case of chunked data when the analysis period spans two or more chunks.
386e01d: Covert collection of paths to download (via gcp, for GFDL data sources only) from pandas Series to list, if this collection originated from a pandas DataFrame catalog.

Diff also shows 6f3cdbf, which should have been merged into develop as part of #244.

**How Has This Been Tested?**
These fixes address bugs that were encountered in running the framework on the above experiment at GFDL. Verified that, with the changes, code successfully proceeds past the query and fetch stages on this case.

**Checklist:**
- [X] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [X] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
