### PR TITLE
Support large data files

### DIFF
--- a/diagnostics/EOF_500hPa/compute_anomalies.ncl
+++ b/diagnostics/EOF_500hPa/compute_anomalies.ncl
@@ -5,6 +5,8 @@
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl"
 begin
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 wk_dir = getenv("WK_DIR")
 casename = getenv("CASENAME")
 yr1 = getenv("FIRSTYR")

--- a/diagnostics/EOF_500hPa/eof_natlantic.ncl
+++ b/diagnostics/EOF_500hPa/eof_natlantic.ncl
@@ -6,6 +6,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_code.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl"
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 begin
 yr1 = getenv("FIRSTYR")
 yr2 = getenv("LASTYR")

--- a/diagnostics/EOF_500hPa/eof_npacific.ncl
+++ b/diagnostics/EOF_500hPa/eof_npacific.ncl
@@ -5,6 +5,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_code.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl"
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 begin
 yr1 = getenv("FIRSTYR")
 yr2 = getenv("LASTYR")

--- a/diagnostics/MJO_prop_amp/m_diag.ncl
+++ b/diagnostics/MJO_prop_amp/m_diag.ncl
@@ -5,6 +5,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_code.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl"
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 begin
 
 wk_dir = getenv("WK_DIR")

--- a/diagnostics/MJO_prop_amp/m_intp.ncl
+++ b/diagnostics/MJO_prop_amp/m_intp.ncl
@@ -4,6 +4,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_code.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 begin
 
 print_clock("Starting model data inteperation")

--- a/diagnostics/MJO_suite/calc_utils.ncl
+++ b/diagnostics/MJO_suite/calc_utils.ncl
@@ -11,6 +11,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"
 ;load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/shea_util.ncl"
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 ;; Local variables for alll plot routines ;;
 
 pwks = "ps"        ; Output format (ps,X11,png,gif)

--- a/diagnostics/MJO_suite/daily_anom.ncl
+++ b/diagnostics/MJO_suite/daily_anom.ncl
@@ -6,6 +6,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl"
 load "$POD_HOME/calc_utils.ncl"
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 begin
 
 routine_name = "daily_anom"

--- a/diagnostics/MJO_suite/daily_netcdf.ncl
+++ b/diagnostics/MJO_suite/daily_netcdf.ncl
@@ -6,6 +6,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl"
 load "$POD_HOME/utils.ncl"
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 undef("debug_print")
 procedure debug_print(string_to_print,routine_name,debug_flag)
 begin

--- a/diagnostics/MJO_suite/mjo.ncl
+++ b/diagnostics/MJO_suite/mjo.ncl
@@ -6,6 +6,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_code.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl"
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 begin
 ; read daily output files from CAM2 and process the u200 data
 ; each daily file has 30 days of data

--- a/diagnostics/MJO_suite/mjo_EOF.ncl
+++ b/diagnostics/MJO_suite/mjo_EOF.ncl
@@ -7,6 +7,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_code.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"  
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl" 
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 begin
 ; ===========================================================
 ; input data

--- a/diagnostics/MJO_suite/mjo_EOF_cal.ncl
+++ b/diagnostics/MJO_suite/mjo_EOF_cal.ncl
@@ -7,6 +7,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_code.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"  
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl" 
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 begin
 
   routine_name = "mjo_EOF_cal.ncl"

--- a/diagnostics/MJO_suite/mjo_lag_lat_lon.ncl
+++ b/diagnostics/MJO_suite/mjo_lag_lat_lon.ncl
@@ -5,6 +5,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl"    
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/diagnostics_cam.ncl"    
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
   
 ;******************** MAIN **********************************
 begin

--- a/diagnostics/MJO_suite/mjo_life_cycle.ncl
+++ b/diagnostics/MJO_suite/mjo_life_cycle.ncl
@@ -8,6 +8,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_code.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"  
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl" 
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 begin
 
   routine_name = "mjo_life_cycle"

--- a/diagnostics/MJO_suite/mjo_spectra.ncl
+++ b/diagnostics/MJO_suite/mjo_spectra.ncl
@@ -5,7 +5,9 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl"    
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/diagnostics_cam.ncl"    
 load "$POD_HOME/my_cam_diags.ncl"
-   
+
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 ;++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 begin
 routine_name = "mjo_spectra.ncl"

--- a/diagnostics/MJO_suite/utils.ncl
+++ b/diagnostics/MJO_suite/utils.ncl
@@ -1,5 +1,7 @@
 ; This file is part of the MJO_suite module of the MDTF code package (see LICENSE.txt)
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 ;================================================================================
 function pinterp (var_name:string,plev:float,fin:file,fin_ps:file)
 begin

--- a/diagnostics/MJO_teleconnection/mjo_daig_Corr_MDTF.ncl
+++ b/diagnostics/MJO_teleconnection/mjo_daig_Corr_MDTF.ncl
@@ -10,6 +10,7 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_code.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/shea_util.ncl" 
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
 
 begin
 

--- a/diagnostics/MJO_teleconnection/mjo_diag_EWR_MDTF.ncl
+++ b/diagnostics/MJO_teleconnection/mjo_diag_EWR_MDTF.ncl
@@ -5,6 +5,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl"    
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/diagnostics_cam.ncl"    
    
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 ;++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 ;This scripts calculates wave frequeency specra fo a given models precipitation
 ;Written by : Sptephnaie Handerson

--- a/diagnostics/MJO_teleconnection/mjo_diag_RMM_MDTF.ncl
+++ b/diagnostics/MJO_teleconnection/mjo_diag_RMM_MDTF.ncl
@@ -23,6 +23,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_code.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/shea_util.ncl" 
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 ;--------------Choose Model--------------
 ;previously used models (already have RMM indices for all of these)
 ;As Multimodel daignostic the RMM following model are already calculated and will be used in diagnostic  

--- a/diagnostics/MJO_teleconnection/mjo_diag_U250_MDTF.ncl
+++ b/diagnostics/MJO_teleconnection/mjo_diag_U250_MDTF.ncl
@@ -12,6 +12,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_code.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/shea_util.ncl" 
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 begin
 print("--------------------------------------------------------------------------")
 print("              ** Calculating 250-hPa Zonal Wind RMS Error **              ")

--- a/diagnostics/MJO_teleconnection/mjo_diag_fig1_MDTF.ncl
+++ b/diagnostics/MJO_teleconnection/mjo_diag_fig1_MDTF.ncl
@@ -14,6 +14,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_code.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/shea_util.ncl" 
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 begin
 
 err = NhlGetErrorObjectId()

--- a/diagnostics/MJO_teleconnection/mjo_diag_fig2_MDTF.ncl
+++ b/diagnostics/MJO_teleconnection/mjo_diag_fig2_MDTF.ncl
@@ -5,6 +5,7 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_code.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/shea_util.ncl" 
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
 
 begin
 print("--------------------------------------------------------------------")

--- a/diagnostics/MJO_teleconnection/mjo_diag_geop_hgt_comp_MDTF.ncl
+++ b/diagnostics/MJO_teleconnection/mjo_diag_geop_hgt_comp_MDTF.ncl
@@ -14,6 +14,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_code.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/shea_util.ncl" 
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 begin
 
 ;lag desired for geopotential height plots

--- a/diagnostics/MJO_teleconnection/mjo_diag_prec_comp_MDTF.ncl
+++ b/diagnostics/MJO_teleconnection/mjo_diag_prec_comp_MDTF.ncl
@@ -14,6 +14,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_code.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/shea_util.ncl" 
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 begin
 
 ;lag desired for geopotential height plots

--- a/diagnostics/Wheeler_Kiladis/debug_plots.ncl
+++ b/diagnostics/Wheeler_Kiladis/debug_plots.ncl
@@ -1,4 +1,5 @@
 load "$POD_HOME/panel_two_sets.ncl" 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
 
 undef("debug_print")
 procedure debug_print(string_to_print,routine_name,debug_flag)

--- a/diagnostics/Wheeler_Kiladis/diagnostics_cam.ncl
+++ b/diagnostics/Wheeler_Kiladis/diagnostics_cam.ncl
@@ -1,5 +1,6 @@
 load "$POD_HOME/debug_plots.ncl"  
 ; DRB this contains debug_print so should get it from there
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
 
 ;-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 ;                  diagnostics_cam.ncl                             

--- a/diagnostics/Wheeler_Kiladis/getVarSlice.ncl
+++ b/diagnostics/Wheeler_Kiladis/getVarSlice.ncl
@@ -1,4 +1,5 @@
 ; This file is part of the Wheeler_Kiladis module of the MDTF code package (see LICENSE.txt)
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
 
 
 ;==================================================================

--- a/diagnostics/Wheeler_Kiladis/panel_two_sets.ncl
+++ b/diagnostics/Wheeler_Kiladis/panel_two_sets.ncl
@@ -16,6 +16,8 @@
 ; Given two sets of nrow x ncol dimensions, return an orientation to 
 ; use for paneling plots given these dimensions.
 ;----------------------------------------------------------------------
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 undef("get_orientation")
 function get_orientation(dims1[2]:numeric,dims2[2]:numeric)
 local ncols1, ncols2, nrows1, nrows2

--- a/diagnostics/Wheeler_Kiladis/wkSpaceTime_driver.ncl
+++ b/diagnostics/Wheeler_Kiladis/wkSpaceTime_driver.ncl
@@ -5,6 +5,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl"
 load "$POD_HOME/diagnostics_cam.ncl"
 load "$POD_HOME/getVarSlice.ncl"
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 ;==================================================================
 ; Function to fix contour levels according to variable name
 ; The variable name's used here are the CESM variables as used in diagnostics_cam.ncl

--- a/diagnostics/precip_diurnal_cycle/calc_utils.ncl
+++ b/diagnostics/precip_diurnal_cycle/calc_utils.ncl
@@ -11,6 +11,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"
 ;load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/shea_util.ncl"
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 ;; Local variables for alll plot routines ;;
 
 pwks = "ps"        ; Output format (ps,X11,png,gif)

--- a/diagnostics/precip_diurnal_cycle/evans_plot.ncl
+++ b/diagnostics/precip_diurnal_cycle/evans_plot.ncl
@@ -18,6 +18,7 @@ undef("add_ep_label_bar")
 undef("evans_plot_map")
 undef("evans_plot_vector_map")
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
 
 ;**********************************************************************;
 ; Function : evans_plot_color_map

--- a/diagnostics/precip_diurnal_cycle/pr_diurnal_cycle.ncl
+++ b/diagnostics/precip_diurnal_cycle/pr_diurnal_cycle.ncl
@@ -5,6 +5,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/gsn_csm.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl"
 load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/shea_util.ncl"
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 begin
 
 ;==== INPUT DATA ============================================

--- a/diagnostics/precip_diurnal_cycle/pr_diurnal_phase.ncl
+++ b/diagnostics/precip_diurnal_cycle/pr_diurnal_phase.ncl
@@ -13,6 +13,8 @@ load "$NCARG_ROOT/lib/ncarg/nclscripts/csm/contributed.ncl"
 load "$POD_HOME/calc_utils.ncl"
 load "$POD_HOME/evans_plot.ncl"
 
+setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
 begin
 ; Set variables for two runs.
 

--- a/doc/sphinx/dev_coding_tips.rst
+++ b/doc/sphinx/dev_coding_tips.rst
@@ -123,6 +123,15 @@ Python: Plotting
 NCL
 ---
 
+- **Large file support**: By default, NCL cannot read netCDF files larger than 2gb. To drop this limitation, call `setfileoption <https://www.ncl.ucar.edu/Document/Functions/Built-in/setfileoption.shtml>`__ with the following arguments in every script before any file operations:
+
+  .. code-block:: 
+
+    setfileoption("nc", "Format", getenv("MDTF_NC_FORMAT"))
+
+  ``"netCDF4"`` can also be used as the requested format in the above call.
+
+
 - **Deprecated calendar functions**: Check the `function reference <https://www.ncl.ucar.edu/Document/Functions/index.shtml>`__ to verify that the functions you use are not deprecated in the current version of `NCL <https://www.ncl.ucar.edu/>`__. This is especially necessary for `date/calendar functions <https://www.ncl.ucar.edu/Document/Functions/date.shtml>`__.
 
   *Why*: The framework uses a current version of `NCL <https://www.ncl.ucar.edu/>`__ (6.6.x), to avoid plotting bugs that were present in earlier versions. This is especially relevant for calendar functions: the ``ut_*`` set of functions have been deprecated in favor of counterparts beginning with ``cd_`` that take identical arguments (so code can be updated using find/replace). For example, use `cd_calendar <https://www.ncl.ucar.edu/Document/Functions/Built-in/cd_calendar.shtml>`__ instead of the deprecated `ut_calendar <https://www.ncl.ucar.edu/Document/Functions/Built-in/ut_calendar.shtml>`__.

--- a/doc/sphinx/ref_cli.rst
+++ b/doc/sphinx/ref_cli.rst
@@ -73,6 +73,10 @@ Settings that describe the input model data and how it should be obtained.
 --data-manager <data_manager>   | Method used to search for and fetch input model data. <*data_manager*> is case-insensitive, and spaces and underscores are ignored.
    |
    | See the :doc:`ref_data_sources` for documentation on the available options, and the settings that are specific to each.
+--large_file   | Set this flag when running the package on a large volume of input model data: specifically, if the full time series for any requested variable is over 4gb. This may impact performance for variables less than 4gb but otherwise has no effect.
+   |
+   | When set, this causes the framework and PODs to use the netCDF-4 format (CDF-5 standard, using the HDF5 API; see the `netCDF FAQ <https://www.unidata.ucar.edu/software/netcdf/docs/faq.html#How-many-netCDF-formats-are-there-and-what-are-the-differences-among-them>`__) for all intermediate data files generated during the package run. If the flag is not set (default), the netCDF4 Classic format is used instead. Regardless of this setting, the package can read input model data in any netCDF4 format.
+
 
 Analysis
 ++++++++

--- a/doc/sphinx/ref_settings.rst
+++ b/doc/sphinx/ref_settings.rst
@@ -179,7 +179,7 @@ Example
 
   - ``"any_netcdf_classic"`` includes all the above *except* ``"netcdf4"`` (classic data model only).
 
-  See the `netCDF FAQ <https://www.unidata.ucar.edu/software/netcdf/docs/faq.html>`__ (under "Formats, Data Models, and Software Releases") for information on the distinctions. Any recent version of a supported language for diagnostics with netCDF support will be able to read all of these. However, the extended features of the ``"netcdf4"`` data model are not commonly used in practice and currently only supported at a beta level in NCL, which is why we've chosen ``"any_netcdf_classic"`` as the default.
+  See the `netCDF FAQ <https://www.unidata.ucar.edu/software/netcdf/docs/faq.html#How-many-netCDF-formats-are-there-and-what-are-the-differences-among-them>`__ for information on the distinctions. Any recent version of a supported language for diagnostics with netCDF support will be able to read all of these. However, the extended features of the ``"netcdf4"`` data model are not commonly used in practice and currently only supported at a beta level in NCL, which is why we've chosen ``"any_netcdf_classic"`` as the default.
 
 
 ``rename_dimensions``:

--- a/sites/NOAA_GFDL/cli_gfdl.jsonc
+++ b/sites/NOAA_GFDL/cli_gfdl.jsonc
@@ -78,6 +78,10 @@
           "help": "Source used to query and fetch model data.",
           "default": "Local_file",
           "action": "PluginArgAction"
+        },{
+          "name": "large_file",
+          "help": "Set this flag to handle large volumes of input model data. If set, use netCDF4 format in intermediate data files to handle variables >4gb (HDF5 API). Default is to use netCDF4 classic format.",
+          "default" : false
         }
       ]
     },{

--- a/src/cli_template.jsonc
+++ b/src/cli_template.jsonc
@@ -78,6 +78,10 @@
           "help": "Source used to query and fetch model data.",
           "default": "Local_file",
           "action": "PluginArgAction"
+        },{
+          "name": "large_file",
+          "help": "Set this flag to handle large volumes of input model data. If set, use netCDF4 format in intermediate data files to handle variables >4gb (HDF5 API). Default is to use netCDF4 classic format.",
+          "default" : false
         }
       ]
     },{

--- a/src/diagnostic.py
+++ b/src/diagnostic.py
@@ -650,9 +650,19 @@ class Diagnostic(core.MDTFObjectBase, util.PODLoggerMixin):
 
         self.nc_largefile = config.get('large_file', False)
         if self.nc_largefile:
-            self.pod_env_vars['MDTF_NCL_NC_FORMAT'] = "NetCDF4"
+            if self.program == 'ncl':
+                # argument to ncl setfileoption()
+                self.pod_env_vars['MDTF_NC_FORMAT'] = "NetCDF4"
+            else:
+                # argument to netCDF4-python/xarray/etc.
+                self.pod_env_vars['MDTF_NC_FORMAT'] = "NETCDF4"
         else:
-            self.pod_env_vars['MDTF_NCL_NC_FORMAT'] = "NetCDF4Classic"
+            if self.program == 'ncl':
+                # argument to ncl setfileoption()
+                self.pod_env_vars['MDTF_NC_FORMAT'] = "NetCDF4Classic"
+            else:
+                # argument to netCDF4-python/xarray/etc.
+                self.pod_env_vars['MDTF_NC_FORMAT'] = "NETCDF4_CLASSIC"
 
     def setup_pod_directories(self):
         """Check and create directories specific to this POD.

--- a/src/diagnostic.py
+++ b/src/diagnostic.py
@@ -524,6 +524,7 @@ class Diagnostic(core.MDTFObjectBase, util.PODLoggerMixin):
     runtime_requirements: dict = dc.field(default_factory=dict)
     pod_env_vars: util.ConsistentDict = dc.field(default_factory=util.ConsistentDict)
     log_file: io.IOBase = dc.field(default=None, init=False)
+    nc_largefile: bool = False
 
     varlist: Varlist = None
     preprocessor: typing.Any = dc.field(default=None, compare=False)
@@ -646,6 +647,12 @@ class Diagnostic(core.MDTFObjectBase, util.PODLoggerMixin):
                 'uses input metadata.'), tags=util.ObjectLogTag.BANNER)
         # set up env vars
         self.pod_env_vars.update(data_source.env_vars)
+
+        self.nc_largefile = config.get('large_file', False)
+        if self.nc_largefile:
+            self.pod_env_vars['MDTF_NCL_NC_FORMAT'] = "NetCDF4"
+        else:
+            self.pod_env_vars['MDTF_NCL_NC_FORMAT'] = "NetCDF4Classic"
 
     def setup_pod_directories(self):
         """Check and create directories specific to this POD.

--- a/src/environment_manager.py
+++ b/src/environment_manager.py
@@ -376,6 +376,8 @@ class SubprocessRuntimePODWrapper(object):
     def tear_down(self, retcode=None):
         # just to be safe
         if self.process is not None:
+            if hasattr(self.process, 'retcode'):
+                retcode = self.process.returncode
             try:
                 self.process.kill()
             except ProcessLookupError:
@@ -498,7 +500,7 @@ class SubprocessRuntimeManager(AbstractRuntimeManager):
         for p in self.pods:
             if p.process is not None:
                 p.process.wait()
-            p.tear_down(retcode=p.process.returncode)
+            p.tear_down()
         self.case.log.info('%s: completed all PODs.', self.__class__.__name__)
         self.tear_down()
 

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -500,6 +500,10 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         self.convention = data_mgr.attrs.convention
         self.pod_convention = pod.convention
 
+        if getattr(pod, 'nc_largefile', False):
+            self.nc_format = "NETCDF4_CLASSIC"
+        else:
+            self.nc_format = "NETCDF4"
         # HACK only used for _FillValue workaround in clean_output_encoding
         self.output_to_ncl = ('ncl' in pod.runtime_requirements)
 
@@ -555,11 +559,14 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         "decode_times": False,
         "use_cftime": False
     }
+
     # arguments passed to xr.to_netcdf
-    save_dataset_kwargs = {
-        "engine": "netcdf4",
-        "format": "NETCDF4_CLASSIC" # NETCDF3* not supported by this engine (?)
-    }
+    @property
+    def save_dataset_kwargs(self):
+        return {
+            "engine": "netcdf4",
+            "format": self.nc_format
+        }
 
     def read_one_file(self, var, path_list):
         if len(path_list) != 1:

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -712,6 +712,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         except Exception as exc:
             raise util.chain_exc(exc, (f"loading "
                 f"dataset for {var.full_name}."), util.DataPreprocessEvent)
+        var.log.debug("Read %d mb for %s.", ds.nbytes / (1024*1024), var.full_name)
         try:
             ds = self.parser.parse(var, ds)
         except Exception as exc:
@@ -740,7 +741,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         that child classes can modify it.
         """
         path_str = util.abbreviate_path(var.dest_path, self.WK_DIR, '$WK_DIR')
-        var.log.info("Writing to %s", path_str)
+        var.log.info("Writing %d mb to %s", ds.nbytes / (1024*1024), path_str)
         try:
             ds = self.clean_output_attrs(var, ds)
             ds = self.log_history_attr(var, ds)


### PR DESCRIPTION
**Description**
Add support for running the package on large volumes of model data by adding a `--large_file` CLI flag. When set, this changes the netCDF4 format used for intermediate data files from "netCDF4 classic" to "netCDF4" (i.e., CDF-5: see the [netCDF FAQ](https://www.unidata.ucar.edu/software/netcdf/docs/faq.html#How-many-netCDF-formats-are-there-and-what-are-the-differences-among-them)) which removes the size restrictions in the former format.

**An arguably better approach** may be to remove the flag and use the CDF-5 format in all cases, rather than asking the user to assess the size of their data beforehand. I'm not aware of any concrete disadvantages to doing this, except possibly compatibility issues and performance penalties within the scripting languages for using the more complicated HFD5 API. **I'm requesting feedback from netCDF4 experts on this issue**.

"Intermediate files" refers to the output of the preprocessor (= input files to the PODs) and any intermediate files written during the execution of the PODs themselves. This is done by adding a `setfileoption` call to all NCL scripts, as [suggested](https://github.com/NOAA-GFDL/MDTF-diagnostics/issues/18#issuecomment-887982854) by @Wen-hao-Dong. Any future PODs involving NCL scripts will also need this modification to their code; I'm not aware of a way to set this globally when invoking NCL.

- As before, the input model data (input to the preprocessor) can be in any netCDF4 format. The preprocessor uses xarray with the `netCDF4` backend for this purpose.
- The code change only affects NCL PODs: 'convective_transition_diag' always uses CDF-5 for its intermediate files, and 'example' and 'SM_ET_coupling' don't generate intermediate files.

Associated issue #18 

**How Has This Been Tested?**
This PR contains code changes needed to fix large data issues encountered when running the package on the `CM4_piControl_c192_OM4p125_v5_proto1` experiment at GFDL. With the code changes in this PR, the package ran successfully on this experiment.

**Checklist:**
- [X] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [X] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
