### PR TITLE
Hotfix for GFDL CMIP6 DataSource bugs

### DIFF
--- a/sites/NOAA_GFDL/gfdl.py
+++ b/sites/NOAA_GFDL/gfdl.py
@@ -247,8 +247,9 @@ class Gfdludacmip6DataManager(
     _FileRegexClass = cmip6.CMIP6_DRSPath
     _DirectoryRegex = cmip6.drs_directory_regex
     _AttributesClass = GFDL_UDA_CMIP6DataSourceAttributes
-    _fetch_method = "cp" # copy locally instead of symlink due to NFS hanging
     _convention = "CMIP" # hard-code naming convention
+    col_spec = data_sources.cmip6LocalFileDataSource_col_spec
+    _fetch_method = "cp" # copy locally instead of symlink due to NFS hanging
 
 
 @util.mdtf_dataclass
@@ -267,8 +268,9 @@ class Gfdlarchivecmip6DataManager(
     _FileRegexClass = cmip6.CMIP6_DRSPath
     _DirectoryRegex = cmip6.drs_directory_regex
     _AttributesClass = GFDL_archive_CMIP6DataSourceAttributes
-    _fetch_method = "gcp"
     _convention = "CMIP" # hard-code naming convention
+    col_spec = data_sources.cmip6LocalFileDataSource_col_spec
+    _fetch_method = "gcp"
 
 
 @util.mdtf_dataclass
@@ -286,6 +288,9 @@ class Gfdldatacmip6DataManager(
     _FileRegexClass = cmip6.CMIP6_DRSPath
     _DirectoryRegex = cmip6.drs_directory_regex
     _AttributesClass = GFDL_data_CMIP6DataSourceAttributes
+    _convention = "CMIP" # hard-code naming convention
+    col_spec = data_sources.cmip6LocalFileDataSource_col_spec
+    _fetch_method = "gcp"
 
 # RegexPattern that matches any string (path) that doesn't end with ".nc".
 _ignore_non_nc_regex = util.RegexPattern(r".*(?<!\.nc)")
@@ -457,8 +462,7 @@ class GfdlppDataManager(GFDL_GCP_FileDataSourceBase):
         assert (hasattr(self, 'attrs') and hasattr(self.attrs, 'CASE_ROOT_DIR'))
         return self.attrs.CASE_ROOT_DIR
 
-    @staticmethod
-    def _filter_column(df, col_name, func, obj_name):
+    def _filter_column(self, df, col_name, func, obj_name):
         values = list(df[col_name].drop_duplicates())
         if len(values) <= 1:
             # unique value, no need to filter

--- a/sites/NOAA_GFDL/gfdl.py
+++ b/sites/NOAA_GFDL/gfdl.py
@@ -234,9 +234,9 @@ class GFDL_GCP_FileDataSourceBase(
 
 @util.mdtf_dataclass
 class GFDL_UDA_CMIP6DataSourceAttributes(data_sources.CMIP6DataSourceAttributes):
-    def __post_init__(self, model=None, experiment=None):
+    def __post_init__(self, model=None, experiment=None, log=_log):
         self.CASE_ROOT_DIR = os.sep + os.path.join('uda', 'CMIP6')
-        super(GFDL_UDA_CMIP6DataSourceAttributes, self).__post_init__(model, experiment)
+        super(GFDL_UDA_CMIP6DataSourceAttributes, self).__post_init__(model, experiment, log)
 
 class Gfdludacmip6DataManager(
     data_sources.CMIP6ExperimentSelectionMixin,
@@ -253,9 +253,9 @@ class Gfdludacmip6DataManager(
 
 @util.mdtf_dataclass
 class GFDL_archive_CMIP6DataSourceAttributes(data_sources.CMIP6DataSourceAttributes):
-    def __post_init__(self, model=None, experiment=None):
+    def __post_init__(self, model=None, experiment=None, log=_log):
         self.CASE_ROOT_DIR = os.sep + os.path.join('archive','pcmdi','repo','CMIP6')
-        super(GFDL_archive_CMIP6DataSourceAttributes, self).__post_init__(model, experiment)
+        super(GFDL_archive_CMIP6DataSourceAttributes, self).__post_init__(model, experiment, log)
 
 class Gfdlarchivecmip6DataManager(
     data_sources.CMIP6ExperimentSelectionMixin,
@@ -273,9 +273,9 @@ class Gfdlarchivecmip6DataManager(
 
 @util.mdtf_dataclass
 class GFDL_data_CMIP6DataSourceAttributes(data_sources.CMIP6DataSourceAttributes):
-    def __post_init__(self, model=None, experiment=None):
+    def __post_init__(self, model=None, experiment=None, log=_log):
         self.CASE_ROOT_DIR = os.sep + os.path.join('data_cmip6', 'CMIP6')
-        super(GFDL_data_CMIP6DataSourceAttributes, self).__post_init__(model, experiment)
+        super(GFDL_data_CMIP6DataSourceAttributes, self).__post_init__(model, experiment, log)
 
 class Gfdldatacmip6DataManager(
     data_sources.CMIP6ExperimentSelectionMixin,

--- a/sites/NOAA_GFDL/gfdl.py
+++ b/sites/NOAA_GFDL/gfdl.py
@@ -234,9 +234,9 @@ class GFDL_GCP_FileDataSourceBase(
 
 @util.mdtf_dataclass
 class GFDL_UDA_CMIP6DataSourceAttributes(data_sources.CMIP6DataSourceAttributes):
-    def __post_init__(self, model=None, experiment=None, log=_log):
+    def __post_init__(self, log=_log, model=None, experiment=None):
         self.CASE_ROOT_DIR = os.sep + os.path.join('uda', 'CMIP6')
-        super(GFDL_UDA_CMIP6DataSourceAttributes, self).__post_init__(model, experiment, log)
+        super(GFDL_UDA_CMIP6DataSourceAttributes, self).__post_init__(log, model, experiment)
 
 class Gfdludacmip6DataManager(
     data_sources.CMIP6ExperimentSelectionMixin,
@@ -253,9 +253,9 @@ class Gfdludacmip6DataManager(
 
 @util.mdtf_dataclass
 class GFDL_archive_CMIP6DataSourceAttributes(data_sources.CMIP6DataSourceAttributes):
-    def __post_init__(self, model=None, experiment=None, log=_log):
+    def __post_init__(self, log=_log, model=None, experiment=None):
         self.CASE_ROOT_DIR = os.sep + os.path.join('archive','pcmdi','repo','CMIP6')
-        super(GFDL_archive_CMIP6DataSourceAttributes, self).__post_init__(model, experiment, log)
+        super(GFDL_archive_CMIP6DataSourceAttributes, self).__post_init__(log, model, experiment)
 
 class Gfdlarchivecmip6DataManager(
     data_sources.CMIP6ExperimentSelectionMixin,
@@ -273,9 +273,9 @@ class Gfdlarchivecmip6DataManager(
 
 @util.mdtf_dataclass
 class GFDL_data_CMIP6DataSourceAttributes(data_sources.CMIP6DataSourceAttributes):
-    def __post_init__(self, model=None, experiment=None, log=_log):
+    def __post_init__(self, log=_log, model=None, experiment=None):
         self.CASE_ROOT_DIR = os.sep + os.path.join('data_cmip6', 'CMIP6')
-        super(GFDL_data_CMIP6DataSourceAttributes, self).__post_init__(model, experiment, log)
+        super(GFDL_data_CMIP6DataSourceAttributes, self).__post_init__(log, model, experiment)
 
 class Gfdldatacmip6DataManager(
     data_sources.CMIP6ExperimentSelectionMixin,

--- a/src/data_sources.py
+++ b/src/data_sources.py
@@ -424,7 +424,7 @@ class CMIP6DataSourceAttributes(dm.DataSourceAttributesBase):
     experiment: dataclasses.InitVar = "" # synonym for experiment_id
     CATALOG_DIR: str = dataclasses.field(init=False)
 
-    def __post_init__(self, model=None, experiment=None, log=_log):
+    def __post_init__(self, log=_log, model=None, experiment=None):
         super(CMIP6DataSourceAttributes, self).__post_init__(log=log)
         config = core.ConfigManager()
         cv = cmip6.CMIP6_CVs()


### PR DESCRIPTION
**Description**
Corrects bugs in GFDL CMIP6 DataSource classes which were introduced by PR #161. 

**How Has This Been Tested?**
Bugs were encountered in testing PR #264 on CMIP6 data at GFDL. Verified that included fixed corrected the errors (PODs ran to completion using CMIP6 data from these sources) and that related bugs weren't present in code for other DataSources (which also would have been found in testing done for #161).

**Checklist:**
- [X] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [X] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
