### PR TITLE
Bug fix: Replace exit() with sys.exit()

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -482,7 +482,7 @@ class CLIParser(object):
                     "(choose from %s)"),
                     _SCRIPT_NAME, flag_name, flag_value, ', '.join(choices)
                 )
-                exit(2) # exit code for  CLI syntax error
+                util.exit_handler(code=2) # exit code for  CLI syntax error
             d[flag_name] = list(plugin.cli.iter_args())
         self.arguments = _add_plugins_to_arg_list(self.arguments, d)
         for arg_gp in self.argument_groups:
@@ -527,7 +527,7 @@ class CLICommand(object):
                 )
             except util.MDTFFileNotFoundError:
                 _log.critical("Couldn't find CLI file %s.", self.cli_file)
-                exit(2) # exit code for  CLI syntax error
+                util.exit_handler(code=2) # exit code for  CLI syntax error
         if self.cli is not None:
             self.cli = CLIParser.from_dict(self.cli)
 
@@ -732,7 +732,7 @@ class CLIConfigManager(util.Singleton):
                 _SCRIPT_NAME, plugin_name, choice_of_plugin,
                 str(list(self.plugins[plugin_name].keys()))
             )
-            exit(2) # exit code for CLI syntax error
+            util.exit_handler(code=2) # exit code for CLI syntax error
         return self.plugins[plugin_name][p_key]
 
 # ===========================================================================
@@ -1104,7 +1104,7 @@ class MDTFTopLevelArgParser(MDTFArgParser):
             and not (site == default_site and not self.installed):
             _log.critical("Requested site %s not found in sites directory %s.",
                 site, config.sites_dir)
-            exit(2) # exit code for  CLI syntax error
+            util.exit_handler(code=2) # exit code for  CLI syntax error
         config.default_site = default_site
         config.site = site
         self.site = site

--- a/src/core.py
+++ b/src/core.py
@@ -778,7 +778,7 @@ class MDTFFramework(MDTFObjectBase):
             tb_exc = traceback.TracebackException(*(sys.exc_info()))
             _log.critical("Framework caught exception %r", exc)
             print(''.join(tb_exc.format()))
-            exit(1)
+            util.exit_handler(code=1)
 
     @property
     def _children(self):
@@ -898,14 +898,14 @@ class MDTFFramework(MDTFObjectBase):
                 ', '.join(f"'{p}'" for p in valid_args),
                 str(list(args))
             )
-            exit(1)
+            util.exit_handler(code=1)
 
         pods = list(set(pods)) # delete duplicates
         if not pods:
             _log.critical(("ERROR: no PODs selected to be run. Do `./mdtf info pods`"
                 " for a list of available PODs, and check your -p/--pods argument."
                 f"\nReceived --pods = {str(list(args))}"))
-            exit(1)
+            util.exit_handler(code=1)
         return pods
 
     def set_case_pod_list(self, case, cli_obj, pod_info_tuple):
@@ -961,7 +961,7 @@ class MDTFFramework(MDTFObjectBase):
             _log.critical(("No valid entries in case_list. Please specify "
                 "model run information.\nReceived:"
                 f"\n{util.pretty_print_json(case_list_in)}"))
-            exit(1)
+            util.exit_handler(code=1)
 
     def verify_paths(self, config, p):
         # needs to be here, instead of PathManager, because we subclass it in

--- a/src/data_manager.py
+++ b/src/data_manager.py
@@ -184,7 +184,7 @@ class DataSourceAttributesBase():
         if not os.path.isdir(self.CASE_ROOT_DIR):
             log.critical("Data directory CASE_ROOT_DIR = '%s' not found.",
                 self.CASE_ROOT_DIR)
-            exit(1)
+            util.exit_handler(code=1)
 
     def __post_init__(self, log=_log):
         self._set_case_root_dir(log=log)
@@ -640,7 +640,7 @@ class DataSourceBase(core.MDTFObjectBase, util.CaseLoggerMixin,
         """
         util.signal_logger(self.__class__.__name__, signum, frame, log=self.log)
         self.post_query_and_fetch_hook()
-        exit(1)
+        util.exit_handler(code=1)
 
 # --------------------------------------------------------------------------
 

--- a/src/data_sources.py
+++ b/src/data_sources.py
@@ -63,7 +63,7 @@ class SampleDataAttributes(dm.DataSourceAttributesBase):
         if not os.path.isdir(self.CASE_ROOT_DIR):
             log.critical("Data directory CASE_ROOT_DIR = '%s' not found.",
                 self.CASE_ROOT_DIR)
-            exit(1)
+            util.exit_handler(code=1)
 
     def __post_init__(self, log=_log):
         """Validate user input.
@@ -83,7 +83,7 @@ class SampleDataAttributes(dm.DataSourceAttributesBase):
             log.critical(
                 "Sample dataset '%s' not found in CASE_ROOT_DIR = '%s'.",
                 self.sample_dataset, self.CASE_ROOT_DIR)
-            exit(1)
+            util.exit_handler(code=1)
 
 sampleLocalFileDataSource_col_spec = dm.DataframeQueryColumnSpec(
     # Catalog columns whose values must be the same for all variables.
@@ -312,7 +312,7 @@ class ExplicitFileDataAttributes(dm.DataSourceAttributesBase):
         if not self.config_file:
             log.critical(("No configuration file found for ExplicitFileDataSource "
                 "(--config-file)."))
-            exit(1)
+            util.exit_handler(code=1)
 
         if self.convention != core._NO_TRANSLATION_CONVENTION:
             log.debug("Received incompatible convention '%s'; setting to '%s'.",
@@ -451,7 +451,7 @@ class CMIP6DataSourceAttributes(dm.DataSourceAttributesBase):
         if not os.path.isdir(self.CASE_ROOT_DIR):
             log.critical("Data directory CASE_ROOT_DIR = '%s' not found.",
                 self.CASE_ROOT_DIR)
-            exit(1)
+            util.exit_handler(code=1)
 
         # should really fix this at the level of CLI flag synonyms
         if model and not self.source_id:

--- a/src/environment_manager.py
+++ b/src/environment_manager.py
@@ -520,4 +520,4 @@ class SubprocessRuntimeManager(AbstractRuntimeManager):
             p.pod.close_log_file(log=True)
         self.tear_down()
         self.case.close_log_file()
-        exit(1)
+        util.exit_handler(code=1)

--- a/src/install.py
+++ b/src/install.py
@@ -43,7 +43,7 @@ def fatal_exception_handler(exc, msg=None):
     print('ERROR: caught exception {0}({1!r})'.format(type(exc).__name__, exc.args))
     if msg:
         print(msg)
-    exit(1)
+    util.exit_handler(code=1)
 
 def find_conda(code_root, conda_config):
     """Attempt to determine conda location on this system.
@@ -162,7 +162,7 @@ def untar_data(ftp_data, install_config):
                 tar_cmd = tar_cmd.format(test_path)
             else:
                 print("ERROR: could not find Archive Utility.app.")
-                exit(1)
+                util.exit_handler(code=1)
     else:
         tar_cmd = 'tar -xf '
 
@@ -262,7 +262,7 @@ def framework_verify(code_root, run_output):
     if missing_dict:
         print("ERROR: the following files are missing:")
         print(util.pretty_print_json(missing_dict))
-        exit(1)
+        util.exit_handler(code=1)
     print("SUCCESS: no missing links found.")
     print("Finished: framework test run successful!")
 

--- a/src/mdtf_info.py
+++ b/src/mdtf_info.py
@@ -86,7 +86,7 @@ def load_pod_settings(code_root, pod=None, pod_list=None):
     if bad_pods:
         _log.critical(("Errors were encountered when finding the following PODS: "
             "[%s]."), ', '.join(f"'{p}'" for p in bad_pods))
-        exit(1)
+        util.exit_handler(code=1)
     return PodDataTuple(
         pod_data=pods, realm_data=realms,
         sorted_pods=pod_list,

--- a/src/util/exceptions.py
+++ b/src/util/exceptions.py
@@ -2,6 +2,7 @@
 imports.
 """
 import os
+import sys
 import errno
 from subprocess import CalledProcessError
 
@@ -21,7 +22,15 @@ def exit_on_exception(exc, msg=None):
     print(f'ERROR: caught exception {repr(exc)}')
     if msg:
         print(msg)
-    exit(1)
+    exit_handler(code=1)
+
+def exit_handler(code=1, msg=None):
+    """Wraps all calls to :py:func:`sys.exit`; could do additional
+    cleanup not handled by atexit() here.
+    """
+    if msg:
+        print(msg)
+    sys.exit(code)
 
 def chain_exc(exc, new_msg, new_exc_class=None):
     if new_exc_class is None:

--- a/src/verify_links.py
+++ b/src/verify_links.py
@@ -302,7 +302,7 @@ if __name__ == '__main__':
     if missing_dict:
         print("ERROR: the following files are missing:")
         print(util.pretty_print_json(missing_dict))
-        exit(1)
+        sys.exit(1)
     else:
         print("SUCCESS: no missing links found.")
-        exit(0)
+        sys.exit(0)


### PR DESCRIPTION
**Description**
The python exit() function is not supported for non-interactive execution (see
https://docs.python.org/3.7/library/constants.html and https://stackoverflow.com/a/6501134); sys.exit() should be used instead. This commit replaces existing calls to exit() throughout the code by calls to a new wrapper function util.exit_handler() which calls sys.exit().

This is **not a critical bug**, because in practice when we hit a call to exit() we exit anyway, from the unhandled exception raised in this condition. 

**How Has This Been Tested?**
Verified that exit_handler() is called during fatal error conditions, and that exception raised by calling exit() does not occurr.

**Checklist:**
- [X] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [X] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
