### PR TITLE
Improvements to documentation on CLI settings

### DIFF
--- a/doc/sphinx/ref_cli.rst
+++ b/doc/sphinx/ref_cli.rst
@@ -47,21 +47,21 @@ General options
 
 -f, --input-file <input_file>    Path to a user configuration file that sets options listed here. This can be a JSON file of the form given in `src/default_tests.jsonc <https://github.com/NOAA-GFDL/MDTF-diagnostics/blob/main/src/default_tests.jsonc>`__ (which is intended to be copied and used as a template), or a text file containing flags and command-line arguments as they would be entered in the shell. Additional options set explicitly on the command line will still override settings in this file.
 
-Paths
-+++++
+Path settings
++++++++++++++
 
 Locations of input and output data. All the paths in this section must be on a locally mounted filesystem. Environment variables in paths (e.g., ``$HOME``) are resolved at runtime according to the shell context the package is called from. Relative paths are resolved relative to the code directory.
 
 --CASE-ROOT-DIR <CASE_ROOT_DIR>    Alternate method to specify the root directory of input model data, with a flag instead of a positional argument.
 --MODEL-DATA-ROOT <MODEL_DATA_ROOT>    Directory to store input data from different models. Depending on the choice of <*data_manager*> (see below), input model data will typically be copied from a remote filesystem to this location.
---OBS-DATA-ROOT <OBS_DATA_ROOT>     Directory containing observational and supporting data required by individual PODs. Currently, this must be downloaded manually as part of the framework installation. See :numref:`ref-download` of the :doc:`installation guide<start_install>` for instructions.
---WORKING-DIR <WORKING_DIR>     Working directory. This will be used as scratch storage by the framework and the PODs.
--o, --OUTPUT-DIR <OUTPUT_DIR>    Destination for output files.
+--OBS-DATA-ROOT <OBS_DATA_ROOT>     Required setting. Directory containing observational and supporting data required by individual PODs. Currently, this must be downloaded manually as part of the framework installation. See :numref:`ref-download` of the :doc:`installation guide<start_install>` for instructions.
+--WORKING-DIR <WORKING_DIR>     Working directory. This will be used as scratch storage by the framework and the PODs. Optional; defaults to <*OUTPUT_DIR*> if not specified.
+-o, --OUTPUT-DIR <OUTPUT_DIR>    Required setting. Destination for output files.
 
-Data
-++++
+Data options
+++++++++++++
 
-Settings that describe the input model data and how it should be obtained.
+Options that describe the input model data and how it should be obtained.
 
 -c, --convention <naming_convention>   | The convention for variable names and units used in the input model data. Defaults to ``CMIP``, for data produced as part of CMIP6 data request, or compatible with it.
    |
@@ -72,21 +72,23 @@ Settings that describe the input model data and how it should be obtained.
 --overwrite-file-metadata     If set, this flag overwrites metadata in input model data files with the metadata in the framework's record. The framework's metadata record can either be set through the choice of a naming convention (the ``--convention`` flag above), or explicitly per variable in the configuration file used by the :ref:`ref-data-source-explictfile` option for ``--data-manager`` (see below). The default behavior is to either raise an error or update the framework's record in the event of a conflict with the file's metadata, since the latter is assumed to be an accurate description of the file's contents. Like the previous flag, this is setting is intended as a workaround for input data which is known to have incorrect metadata.
 --data-manager <data_manager>   | Method used to search for and fetch input model data. <*data_manager*> is case-insensitive, and spaces and underscores are ignored.
    |
+   | Default value is ``"Local_file"``, which looks for sample model data in a local directory <*CASE_ROOT_DIR*>. This assumes you have downloaded this data beforehand, by following the recommended :ref:`installation instructions<ref-conda-install>`.
+   |
    | See the :doc:`ref_data_sources` for documentation on the available options, and the settings that are specific to each.
 --large_file   | Set this flag when running the package on a large volume of input model data: specifically, if the full time series for any requested variable is over 4gb. This may impact performance for variables less than 4gb but otherwise has no effect.
    |
    | When set, this causes the framework and PODs to use the netCDF-4 format (CDF-5 standard, using the HDF5 API; see the `netCDF FAQ <https://www.unidata.ucar.edu/software/netcdf/docs/faq.html#How-many-netCDF-formats-are-there-and-what-are-the-differences-among-them>`__) for all intermediate data files generated during the package run. If the flag is not set (default), the netCDF4 Classic format is used instead. Regardless of this setting, the package can read input model data in any netCDF4 format.
 
 
-Analysis
-++++++++
+Analysis settings
++++++++++++++++++
 
 Settings determining what analyses the package performs.
 
--n, --CASENAME <name>    Identifier used to label this run of the package. Can be set to any string.
--Y, --FIRSTYR <YYYY>    Starting year of analysis period.
--Z, --LASTYR <YYYY>     Ending year of analysis period. The analysis period is taken to be a **closed interval**, including all model data that falls between the start of 1 Jan on <*FIRSTYR*> and the end of 31 Dec on <*LASTYR*>.
--p, --pods <list of POD identifiers>    Specification for which diagnostics (PODs) the package should run on the model data, given as a list separated by spaces. If given as the last command-line option, you will need to add ``--`` to distinguish the last entry from <*CASE_ROOT_DIR*> (standard shell syntax). 
+-n, --CASENAME <name>    Required setting. Identifier used to label this run of the package. Can be set to any string.
+-Y, --FIRSTYR <YYYY>    Required setting. Starting year of analysis period.
+-Z, --LASTYR <YYYY>     Required setting. Ending year of analysis period. The analysis period is taken to be a **closed interval**, including all model data that falls between the start of 1 Jan on <*FIRSTYR*> and the end of 31 Dec on <*LASTYR*>.
+-p, --pods <list of POD identifiers>    Specification for which diagnostics (PODs) the package should run on the model data, given as a list separated by spaces. Optional; default behavior is to attempt to run all PODs.
 
   Valid identifiers for PODs are:
 
@@ -94,24 +96,26 @@ Settings determining what analyses the package performs.
   - The name of a modeling realm, in which case all PODs analyzing data from that realm will be selected. Run :console:`% mdtf info realms` for a list of installed diagnostics sorted by realm.
   - ``all``, the default setting, which selects all installed diagnostics.
 
-  Giving multiple identifiers selects the union of all PODs described by each identifier.
+  Giving multiple identifiers selects the union of all PODs described by each identifier. If given as the last command-line option, you will need to add ``--`` to distinguish the last entry from <*CASE_ROOT_DIR*> (standard shell syntax). 
 
-Runtime settings
-++++++++++++++++
+Runtime options
++++++++++++++++
 
-Settings that control how the package is deployed (how code dependencies are managed) and how the diagnostics are run.
+Options that control how the package is deployed (how code dependencies are managed) and how the diagnostics are run.
 
 --environment-manager <environment_manager>   | Method the package should use to manage third-party code dependencies of diagnostics. <*environment_manager*> is case-insensitive, and spaces and underscores are ignored.
    |
-   | See the :doc:`ref_runtime_mgrs` for documentation on the available options, and the settings that are specific to each.
+   | Default value is ``"Conda"``, which uses third-party dependencies installed via the `conda <https://docs.conda.io/en/latest/>`__ package manager. This assumes you have installed these dependencies beforehand, by following the recommended :ref:`installation instructions<ref-conda-install>`.
+   |
+   | See the :doc:`ref_runtime_mgrs` for documentation on other available options, and the settings that are specific to each.
 
    .. note::
       The values used for this option and its settings must be compatible with how the package was set up during :doc:`installation<start_install>`. Missing code dependencies are not installed at runtime; instead any POD with missing dependencies raises an error and is not run.
 
-Output settings
-+++++++++++++++
+Output options
+++++++++++++++
 
-Settings determining what files are output by the package.
+Options determining what files are output by the package.
 
 --save-ps    Set flag to have PODs save postscript figures in addition to bitmaps.
 --save-nc    Set flag to have PODs save netCDF files of processed data.
@@ -119,12 +123,12 @@ Settings determining what files are output by the package.
 --make-variab-tar    Set flag to save package output in a single .tar file. This will only contain HTML and bitmap plots, regardless of whether the flags above are used.
 --overwrite    If this flag is set, new runs of the package will overwrite any pre-existing results in <*OUTPUT_DIR*>. The default behavior is for subsequent runs of the package to be output as MDTF\_<*CASENAME*>\_<*FIRSTYR*>\_<*LASTYR*>, MDTF\_<*CASENAME*>\_<*FIRSTYR*>\_<*LASTYR*>.v1, MDTF\_<*CASENAME*>\_<*FIRSTYR*>\_<*LASTYR*>.v2, etc. Setting this flag disables the use of the ".v1", ".v2", ... suffixes.
 
-Debugging settings
-++++++++++++++++++
+Debugging options
++++++++++++++++++
 
--v, --verbose    Increase log verbosity level. ``-v`` prints more detailed debug information. This setting only affects console output: all logged information is always recorded in the log file saved with the package output.
+-v, --verbose    Increase log verbosity level, printing more detailed debug information. This setting only affects console output: all logged information is always recorded in the log file saved with the package output.
 -q, --quiet    Decreases the console log verbosity level. ``-q`` prints only warnings and errors, ``-qq`` prints errors only, and ``-qqq`` prints no output. This setting only affects console output: all logged information is always recorded in the log file saved with the package output.
---file-transfer-timeout <seconds>    Time (in seconds) to wait before giving up on transferring a data file to the local filesystem. Set to zero to wait indefinitely.
+--file-transfer-timeout <seconds>    Time (in seconds) to wait before giving up on transferring a data file to the local filesystem. Set to zero to wait indefinitely. Default value is 300.
 --keep-temp    Set flag to retain local copies of fetched model data (in <*MODEL_DATA_ROOT*>) between runs of the framework. The default behavior deletes this data after the package runs successfully. Retaining a local copy of the data can be useful when the model data is hosted remotely and you need to run a diagnostic repeatedly for development purposes.
 --test-mode    Flag for use in framework testing: model data is fetched but PODs are not run.
 --dry-run    Flag for use in framework testing: no external commands are run and no remote data is copied. Implies ``--test-mode``.

--- a/doc/sphinx/ref_cli.rst
+++ b/doc/sphinx/ref_cli.rst
@@ -67,6 +67,10 @@ Options that describe the input model data and how it should be obtained.
    |
    | See the :doc:`ref_conventions` for documentation on the recognized values for this option.
 
+--large_file   | Set this flag when running the package on a large volume of input model data: specifically, if the full time series for any requested variable is over 4gb. This may impact performance for variables less than 4gb but otherwise has no effect.
+   |
+   | When set, this causes the framework and PODs to use the netCDF-4 format (CDF-5 standard, using the HDF5 API; see the `netCDF FAQ <https://www.unidata.ucar.edu/software/netcdf/docs/faq.html#How-many-netCDF-formats-are-there-and-what-are-the-differences-among-them>`__) for all intermediate data files generated during the package run. If the flag is not set (default), the netCDF4 Classic format is used instead. Regardless of this setting, the package can read input model data in any netCDF4 format.
+
 --strict    Disables any model data selection heuristics provided by <*data_manager*>. The details of what this does depend on the <*data_manager*>, but in general this means that model data will only be searched for based on a literal interpretation of the user's input, with an error raised if that input doesn't specify a unique model run/experiment.
 --disable-preprocessor    If set, this flag disables preprocessing of input model data done by the framework before the PODs are run. Specifically, this skips validation of ``standard_name`` and ``units`` CF attributes in file metadata, and skips unit conversion and level extraction functions. This is only provided as a workaround for input data which is known to have incorrect metadata: using this flag means that the user assumes responsibility for verifying that the input data has the units requested by all PODs being run.
 --overwrite-file-metadata     If set, this flag overwrites metadata in input model data files with the metadata in the framework's record. The framework's metadata record can either be set through the choice of a naming convention (the ``--convention`` flag above), or explicitly per variable in the configuration file used by the :ref:`ref-data-source-explictfile` option for ``--data-manager`` (see below). The default behavior is to either raise an error or update the framework's record in the event of a conflict with the file's metadata, since the latter is assumed to be an accurate description of the file's contents. Like the previous flag, this is setting is intended as a workaround for input data which is known to have incorrect metadata.
@@ -75,9 +79,6 @@ Options that describe the input model data and how it should be obtained.
    | Default value is ``"Local_file"``, which looks for sample model data in a local directory <*CASE_ROOT_DIR*>. This assumes you have downloaded this data beforehand, by following the recommended :ref:`installation instructions<ref-conda-install>`.
    |
    | See the :doc:`ref_data_sources` for documentation on the available options, and the settings that are specific to each.
---large_file   | Set this flag when running the package on a large volume of input model data: specifically, if the full time series for any requested variable is over 4gb. This may impact performance for variables less than 4gb but otherwise has no effect.
-   |
-   | When set, this causes the framework and PODs to use the netCDF-4 format (CDF-5 standard, using the HDF5 API; see the `netCDF FAQ <https://www.unidata.ucar.edu/software/netcdf/docs/faq.html#How-many-netCDF-formats-are-there-and-what-are-the-differences-among-them>`__) for all intermediate data files generated during the package run. If the flag is not set (default), the netCDF4 Classic format is used instead. Regardless of this setting, the package can read input model data in any netCDF4 format.
 
 
 Analysis settings

--- a/doc/sphinx/ref_cli.rst
+++ b/doc/sphinx/ref_cli.rst
@@ -32,7 +32,7 @@ Command-line options
 
 For long command line flags, words may be separated with hyphens (GNU standard) or with underscores (python variable name convention). For example, ``--file-transfer-timeout`` and ``--file_transfer_timeout`` are both recognized by the package as synonyms for the same setting.
 
-If you're using site-specific functionality (via the ``--site`` flag, described below), additional options may be available beyond what is listed here: see the :doc:`site-specific documentation<site_toc>` for your site. In addition, your choice of site may set default values for these options; the default values and the location of the configuration file defining them are listed as part of running :console:`% mdtf --site <your site> --help`. 
+If you're using site-specific functionality (via the ``--site`` flag, described below), additional options may be available beyond what is listed here: see the :doc:`site-specific documentation<site_toc>` for your site. In addition, your choice of site may set default values for these options; the default values and the location of the configuration file defining them are listed as part of running :console:`% mdtf --site <site_name> --help`. 
 
 General options
 +++++++++++++++
@@ -41,9 +41,9 @@ General options
 --version      Show the program's version number and exit.
 -s, --site <site_name>   | Setting to use site-specific customizations and functionality. <*site_name*> is the name of one of the directories in `sites/ <https://github.com/NOAA-GFDL/MDTF-diagnostics/blob/main/sites>`__, which contain additional code and configuration files to use. 
    |
-   | The default value for this setting is ``local``. The sites/local/ directory is left empty in order to enable any installation to be customized (e.g. settings the paths to where supporting data was installed) without needing to alter the framework code. For more information on how to do this, see the documentation for the `'local' site <../sphinx_sites/local.html>`__.
+   | Sites can define new command-line options and new values for existing options. This is reflected in the online help: run :console:`% mdtf --site <site_name> --help` to see a list of options and allowed values specific to <*site_name*>. In general, see the :doc:`site-specific documentation<site_toc>` for information on what functionality is added for a given site.
    |
-   | In general, see the :doc:`site-specific documentation<site_toc>` for information on what functionality is added for a given site.
+   | The default value for this setting is ``local``. The sites/local/ directory is left empty in order to enable any installation to be customized (e.g. settings the paths to where supporting data was installed) without needing to alter the framework code. For more information on how to do this, see the documentation for the `'local' site <../sphinx_sites/local.html>`__.
 
 -f, --input-file <input_file>    Path to a user configuration file that sets options listed here. This can be a JSON file of the form given in `src/default_tests.jsonc <https://github.com/NOAA-GFDL/MDTF-diagnostics/blob/main/src/default_tests.jsonc>`__ (which is intended to be copied and used as a template), or a text file containing flags and command-line arguments as they would be entered in the shell. Additional options set explicitly on the command line will still override settings in this file.
 
@@ -76,10 +76,9 @@ Options that describe the input model data and how it should be obtained.
 --overwrite-file-metadata     If set, this flag overwrites metadata in input model data files with the metadata in the framework's record. The framework's metadata record can either be set through the choice of a naming convention (the ``--convention`` flag above), or explicitly per variable in the configuration file used by the :ref:`ref-data-source-explictfile` option for ``--data-manager`` (see below). The default behavior is to either raise an error or update the framework's record in the event of a conflict with the file's metadata, since the latter is assumed to be an accurate description of the file's contents. Like the previous flag, this is setting is intended as a workaround for input data which is known to have incorrect metadata.
 --data-manager <data_manager>   | Method used to search for and fetch input model data. <*data_manager*> is case-insensitive, and spaces and underscores are ignored.
    |
-   | Default value is ``"Local_file"``, which looks for sample model data in a local directory <*CASE_ROOT_DIR*>. This assumes you have downloaded this data beforehand, by following the recommended :ref:`installation instructions<ref-conda-install>`.
+   | This is a "plug-in setting": Different choices of <*data_manager*> may define additional command-line options, which will be documented below the entry for ``--data-manager`` in the CLI help (run :console:`% mdtf --site <site_name> --data-manager <data_manager> --help`). See the :doc:`ref_data_sources` and site-specific documentation a list of available values for <*data_manager*>, and the command-line options that are specific to each value.
    |
-   | See the :doc:`ref_data_sources` for documentation on the available options, and the settings that are specific to each.
-
+   | Default value is ``"Local_file"``, which looks for sample model data in a local directory <*CASE_ROOT_DIR*>. This assumes you have downloaded this data beforehand, by following the recommended :ref:`installation instructions<ref-conda-install>`.
 
 Analysis settings
 +++++++++++++++++
@@ -106,9 +105,9 @@ Options that control how the package is deployed (how code dependencies are mana
 
 --environment-manager <environment_manager>   | Method the package should use to manage third-party code dependencies of diagnostics. <*environment_manager*> is case-insensitive, and spaces and underscores are ignored.
    |
-   | Default value is ``"Conda"``, which uses third-party dependencies installed via the `conda <https://docs.conda.io/en/latest/>`__ package manager. This assumes you have installed these dependencies beforehand, by following the recommended :ref:`installation instructions<ref-conda-install>`.
+   | This is a "plug-in setting": Different choices of <*environment_manager*> may define additional command-line options, which will be documented below the entry for ``--environment-manager`` in the CLI help (run :console:`% mdtf --site <site_name> --environment-manager <environment_manager> --help`). See the :doc:`ref_runtime_mgrs` and site-specific documentation a list of available values for <*environment_manager*>, and the command-line options that are specific to each value.
    |
-   | See the :doc:`ref_runtime_mgrs` for documentation on other available options, and the settings that are specific to each.
+   | Default value is ``"Conda"``, which uses third-party dependencies installed via the `conda <https://docs.conda.io/en/latest/>`__ package manager. This assumes you have installed these dependencies beforehand, by following the recommended :ref:`installation instructions<ref-conda-install>`.
 
    .. note::
       The values used for this option and its settings must be compatible with how the package was set up during :doc:`installation<start_install>`. Missing code dependencies are not installed at runtime; instead any POD with missing dependencies raises an error and is not run.

--- a/mdtf_framework.py
+++ b/mdtf_framework.py
@@ -41,7 +41,7 @@ def main():
     # poor man's subparser: argparse's subparser doesn't handle this
     # use case easily, so just dispatch on first argument
     if len(sys.argv) == 1 or \
-        len(sys.argv) == 2 and sys.argv[1].lower().endswith('help'):
+        len(sys.argv) == 2 and sys.argv[1].lower() in ('-h', '--help'):
         # case where we print CLI help
         cli_obj = cli.MDTFTopLevelArgParser(code_root)
         cli_obj.print_help()

--- a/sites/NOAA_GFDL/cli_gfdl.jsonc
+++ b/sites/NOAA_GFDL/cli_gfdl.jsonc
@@ -29,7 +29,7 @@
       "arguments" : [
         {
           "name": "OBS_DATA_ROOT",
-          "help": "Parent directory containing observational data used by individual PODs.",
+          "help": "Required setting. Parent directory containing observational data used by individual PODs.",
           "metavar" : "<DIR>",
           "action": "PathAction"
         },{
@@ -46,14 +46,14 @@
         },{
           "name": "OUTPUT_DIR",
           "short_name" : "o",
-          "help": "Directory to write output files.",
+          "help": "Required setting. Directory to write output files.",
           "metavar" : "<DIR>",
           "action": "PathAction"
         }
       ]
     },{
       "title" : "DATA",
-      "description" : "Settings describing the input model data.",
+      "description" : "Options describing the input model data.",
       "arguments" : [
         {
           "name": "convention",
@@ -61,6 +61,10 @@
           "help": "Variable name/unit convention used in model data.",
           "default": "CMIP",
           "metavar" : "<convention>"
+        },{
+          "name": "large_file",
+          "help": "Set this flag to handle large volumes of input model data. If set, use netCDF4 format in intermediate data files to handle variables >4gb (HDF5 API). Default is to use netCDF4 classic format.",
+          "default" : false
         },{
           "name": "strict",
           "help": "If set, disables experiment selection heuristics and raises error if experiment not uniquely specified by user input.",
@@ -78,10 +82,6 @@
           "help": "Source used to query and fetch model data.",
           "default": "Local_file",
           "action": "PluginArgAction"
-        },{
-          "name": "large_file",
-          "help": "Set this flag to handle large volumes of input model data. If set, use netCDF4 format in intermediate data files to handle variables >4gb (HDF5 API). Default is to use netCDF4 classic format.",
-          "default" : false
         }
       ]
     },{
@@ -91,18 +91,18 @@
         {
           "name": "CASENAME",
           "short_name" : "n",
-          "help": "Identifier used to label the package's output for the selected model data.",
+          "help": "Required setting. Identifier used to label the package's output for the selected model data.",
           "metavar" : "<name>"
         },{
           "name": "FIRSTYR",
           "short_name" : "Y",
-          "help": "Starting year of analysis period.",
+          "help": "Required setting. Starting year of analysis period.",
           "type" : "int",
           "metavar" : "<year>"
         },{
           "name": "LASTYR",
           "short_name" : "Z",
-          "help": "Ending year of analysis period (inclusive).",
+          "help": "Required setting. Ending year of analysis period (inclusive).",
           "type" : "int",
           "metavar" : "<year>"
         },{
@@ -118,7 +118,7 @@
       ]
     },{
       "title" : "RUNTIME",
-      "description" : "Settings affecting the runtime environment of the PODs.",
+      "description" : "Options affecting the runtime environment of the PODs.",
       "arguments" : [
         {
           "name": "environment_manager",
@@ -135,7 +135,7 @@
       ]
     },{
       "title" : "OUTPUT",
-      "description" : "Settings affecting what output is generated.",
+      "description" : "Options affecting what output is generated.",
       "arguments" : [
         {
           "name": "output_manager",
@@ -179,7 +179,7 @@
       ]
     },{
       "title" : "DEBUG",
-      "description" : "Settings used in debugging.",
+      "description" : "Options used in debugging.",
       "arguments" : [
         {
           "name": "verbose",

--- a/sites/NOAA_GFDL/cli_gfdl.jsonc
+++ b/sites/NOAA_GFDL/cli_gfdl.jsonc
@@ -152,7 +152,7 @@
         {
           "name": "OBS_DATA_REMOTE",
           "help": "Site-specific installation of observational data used by individual PODs. This will be GCP'ed locally if running on PPAN.",
-          "default" : "/home/Oar.Gfdl.Mdteam/DET/analysis/mdtf/obs_data",
+          "default" : "/home/oar.gfdl.mdtf/mdtf/inputdata/obs_data",
           "metavar" : "<DIR>",
           "action": "PathAction"
         },{

--- a/sites/NOAA_GFDL/cli_plugins.jsonc
+++ b/sites/NOAA_GFDL/cli_plugins.jsonc
@@ -188,13 +188,13 @@
           {
             "name": "conda_root",
             "help": "Path to the conda installation. Set equal to '' to use conda from your system's $PATH.",
-            "default" : "/home/mdteam/anaconda",
+            "default" : "/home/oar.gfdl.mdtf/miniconda3",
             "metavar" : "<DIR>",
             "action": "PathAction"
           },{
             "name": "conda_env_root",
             "help": "Root directory for conda environment installs. Set equal to '' to install in your system's default location.",
-            "default" : "/home/mdteam/DET/analysis/mdtf/MDTF-diagnostics/envs",
+            "default" : "/home/oar.gfdl.mdtf/miniconda3/envs",
             "metavar" : "<DIR>",
             "action": "PathAction"
           }
@@ -210,13 +210,13 @@
           {
             "name": "conda_root",
             "help": "Path to the conda installation. Set equal to '' to use conda from your system's $PATH.",
-            "default" : "/home/mdteam/anaconda",
+            "default" : "/home/oar.gfdl.mdtf/miniconda3",
             "metavar" : "<DIR>",
             "action": "PathAction"
           },{
             "name": "conda_env_root",
             "help": "Root directory for conda environment installs. Set equal to '' to install in your system's default location.",
-            "default" : "/home/mdteam/DET/analysis/mdtf/MDTF-diagnostics/envs",
+            "default" : "/home/oar.gfdl.mdtf/miniconda3/envs",
             "metavar" : "<DIR>",
             "action": "PathAction"
           }

--- a/sites/NOAA_GFDL/gfdl.py
+++ b/sites/NOAA_GFDL/gfdl.py
@@ -75,11 +75,17 @@ class GFDLMDTFFramework(core.MDTFFramework):
         if os.path.exists(p.WORKING_DIR) and not \
             (keep_temp or p.WORKING_DIR == p.OUTPUT_DIR):
             gfdl_util.rmtree_wrapper(p.WORKING_DIR)
-        util.check_dir(p, 'CODE_ROOT', create=False)
-        util.check_dir(p, 'OBS_DATA_REMOTE', create=False)
-        util.check_dir(p, 'MODEL_DATA_ROOT', create=True)
-        util.check_dir(p, 'OBS_DATA_ROOT', create=True)
-        util.check_dir(p, 'WORKING_DIR', create=True)
+
+        try:
+            for dir_name, create_ in (
+                ('CODE_ROOT', False), ('OBS_DATA_REMOTE', False),
+                ('OBS_DATA_ROOT', True), ('MODEL_DATA_ROOT', True), ('WORKING_DIR', True)
+            ):
+                util.check_dir(p, dir_name, create=create_)
+        except Exception as exc:
+            _log.fatal((f"Input settings for {dir_name} mis-specified (caught "
+                f"{repr(exc)}.)"))
+            util.exit_handler(code=1)
 
         # Use GCP to create OUTPUT_DIR on a volume that may be read-only
         if not os.path.exists(p.OUTPUT_DIR):

--- a/src/cli_template.jsonc
+++ b/src/cli_template.jsonc
@@ -62,6 +62,10 @@
           "default": "CMIP",
           "metavar" : "<convention>"
         },{
+          "name": "large_file",
+          "help": "Set this flag to handle large volumes of input model data. If set, use netCDF4 format in intermediate data files to handle variables >4gb (HDF5 API). Default is to use netCDF4 classic format.",
+          "default" : false
+        },{
           "name": "strict",
           "help": "If set, disables experiment selection heuristics and raises error if experiment not uniquely specified by user input.",
           "default" : false
@@ -78,10 +82,6 @@
           "help": "Source used to query and fetch model data.",
           "default": "Local_file",
           "action": "PluginArgAction"
-        },{
-          "name": "large_file",
-          "help": "Set this flag to handle large volumes of input model data. If set, use netCDF4 format in intermediate data files to handle variables >4gb (HDF5 API). Default is to use netCDF4 classic format.",
-          "default" : false
         }
       ]
     },{

--- a/src/cli_template.jsonc
+++ b/src/cli_template.jsonc
@@ -29,7 +29,7 @@
       "arguments" : [
         {
           "name": "OBS_DATA_ROOT",
-          "help": "Parent directory containing observational data used by individual PODs.",
+          "help": "Required setting. Parent directory containing observational data used by individual PODs.",
           "metavar" : "<DIR>",
           "action": "PathAction"
         },{
@@ -46,14 +46,14 @@
         },{
           "name": "OUTPUT_DIR",
           "short_name" : "o",
-          "help": "Directory to write output files.",
+          "help": "Required setting. Directory to write output files.",
           "metavar" : "<DIR>",
           "action": "PathAction"
         }
       ]
     },{
       "title" : "DATA",
-      "description" : "Settings describing the input model data.",
+      "description" : "Options describing the input model data.",
       "arguments" : [
         {
           "name": "convention",
@@ -91,18 +91,18 @@
         {
           "name": "CASENAME",
           "short_name" : "n",
-          "help": "Identifier used to label the package's output for the selected model data.",
+          "help": "Required setting. Identifier used to label the package's output for the selected model data.",
           "metavar" : "<name>"
         },{
           "name": "FIRSTYR",
           "short_name" : "Y",
-          "help": "Starting year of analysis period.",
+          "help": "Required setting. Starting year of analysis period.",
           "type" : "int",
           "metavar" : "<year>"
         },{
           "name": "LASTYR",
           "short_name" : "Z",
-          "help": "Ending year of analysis period (inclusive).",
+          "help": "Required setting. Ending year of analysis period (inclusive).",
           "type" : "int",
           "metavar" : "<year>"
         },{
@@ -118,7 +118,7 @@
       ]
     },{
       "title" : "RUNTIME",
-      "description" : "Settings affecting the runtime environment of the PODs.",
+      "description" : "Options affecting the runtime environment of the PODs.",
       "arguments" : [
         {
           "name": "environment_manager",
@@ -135,7 +135,7 @@
       ]
     },{
       "title" : "OUTPUT",
-      "description" : "Settings affecting what output is generated.",
+      "description" : "Options affecting what output is generated.",
       "arguments" : [
         {
           "name": "output_manager",
@@ -147,7 +147,7 @@
       ]
     },{
       "title" : "DEBUG",
-      "description" : "Settings used in debugging.",
+      "description" : "Options used in debugging.",
       "arguments" : [
         {
           "name": "verbose",

--- a/src/core.py
+++ b/src/core.py
@@ -243,7 +243,9 @@ class PathManager(util.Singleton, util.NameSpace):
             return 'TEST_'+key
         else:
             # need to check existence in case we're being called directly
-            assert key in d, f"Error: {key} not initialized."
+            if not d.get(key, False):
+                _log.fatal(f"Error: {key} not initialized.")
+                util.exit_handler(code=1)
             return util.resolve_path(
                 util.from_iter(d[key]), root_path=self.CODE_ROOT, env=env,
                 log=_log
@@ -972,10 +974,15 @@ class MDTFFramework(MDTFObjectBase):
             (keep_temp or p.WORKING_DIR == p.OUTPUT_DIR):
             shutil.rmtree(p.WORKING_DIR)
 
-        util.check_dir(p, 'CODE_ROOT', create=False)
-        util.check_dir(p, 'OBS_DATA_ROOT', create=False)
-        util.check_dir(p, 'MODEL_DATA_ROOT', create=True)
-        util.check_dir(p, 'WORKING_DIR', create=True)
+        try:
+            for dir_name, create_ in (
+                ('CODE_ROOT', False), ('OBS_DATA_ROOT', False),
+                ('MODEL_DATA_ROOT', True), ('WORKING_DIR', True)
+            ):
+                util.check_dir(p, dir_name, create=create_)
+        except Exception as exc:
+            _log.fatal(f"Input settings for {dir_name} mis-specified (caught {repr(exc)}.) ")
+            util.exit_handler(code=1)
 
     def _post_parse_hook(self, cli_obj, config, paths):
         # init other services

--- a/src/core.py
+++ b/src/core.py
@@ -857,6 +857,15 @@ class MDTFFramework(MDTFObjectBase):
                 cli_obj.config.get('convention', ''),
                 tags=util.ObjectLogTag.BANNER
             )
+        # check this here, otherwise error raised about missing caselist is not informative
+        try:
+            if not cli_obj.config.get('CASE_ROOT_DIR', ''):
+                raise Exception('CASE_ROOT_DIR not specified.')
+            util.check_dir(cli_obj.config['CASE_ROOT_DIR'], 'CASE_ROOT_DIR', create=False)
+        except Exception as exc:
+            _log.fatal((f"Mis-specified input for CASE_ROOT_DIR (received "
+                f"'{cli_obj.config.get('CASE_ROOT_DIR', '')}', caught {repr(exc)}.)"))
+            util.exit_handler(code=1)
 
     def parse_env_vars(self, cli_obj):
         # don't think PODs use global env vars?
@@ -981,7 +990,8 @@ class MDTFFramework(MDTFObjectBase):
             ):
                 util.check_dir(p, dir_name, create=create_)
         except Exception as exc:
-            _log.fatal(f"Input settings for {dir_name} mis-specified (caught {repr(exc)}.) ")
+            _log.fatal((f"Input settings for {dir_name} mis-specified (caught "
+                f"{repr(exc)}.)"))
             util.exit_handler(code=1)
 
     def _post_parse_hook(self, cli_obj, config, paths):

--- a/src/core.py
+++ b/src/core.py
@@ -859,9 +859,9 @@ class MDTFFramework(MDTFObjectBase):
             )
         # check this here, otherwise error raised about missing caselist is not informative
         try:
-            if not cli_obj.config.get('CASE_ROOT_DIR', ''):
-                raise Exception('CASE_ROOT_DIR not specified.')
-            util.check_dir(cli_obj.config['CASE_ROOT_DIR'], 'CASE_ROOT_DIR', create=False)
+            if cli_obj.config.get('CASE_ROOT_DIR', ''):
+                util.check_dir(cli_obj.config['CASE_ROOT_DIR'], 'CASE_ROOT_DIR',
+                    create=False)
         except Exception as exc:
             _log.fatal((f"Mis-specified input for CASE_ROOT_DIR (received "
                 f"'{cli_obj.config.get('CASE_ROOT_DIR', '')}', caught {repr(exc)}.)"))

--- a/src/util/filesystem.py
+++ b/src/util/filesystem.py
@@ -157,7 +157,7 @@ def check_dir(dir_, attr_name="", create=False):
     if not isinstance(dir_, str):
         dir_ = getattr(dir_, attr_name, None)
     if not isinstance(dir_, str):
-        raise ValueError(f"Received bad directory: {repr(dir_)}.")
+        raise ValueError(f"Expected string, received {repr(dir_)}.")
     try:
         if not os.path.isdir(dir_):
             if create:
@@ -168,12 +168,16 @@ def check_dir(dir_, attr_name="", create=False):
         if isinstance(exc, FileNotFoundError):
             path = getattr(exc, 'filename', '')
             if attr_name:
-                raise exceptions.MDTFFileNotFoundError(
-                    f"{attr_name} not found at '{path}'.")
+                if not os.path.exists(dir_):
+                    raise exceptions.MDTFFileNotFoundError(
+                        f"{attr_name} not found at '{path}'.")
+                else:
+                    raise exceptions.MDTFFileNotFoundError(
+                        f"{attr_name}: Path '{dir_}' exists but is not a directory.")
             else:
                 raise exceptions.MDTFFileNotFoundError(path)
         else:
-            raise OSError(f"Caught exception when checking {attr_name}={dir_}.") \
+            raise OSError(f"Caught exception when checking {attr_name}={dir_}: {repr(exc)}") \
                 from exc
 
 def bump_version(path, new_v=None, extra_dirs=None):


### PR DESCRIPTION
**Description**
- Describes which CLI flags are required, in online CLI help and Sphinx documentation website.
- Additional clarification on effects of site and plug-in settings 
- Correct default CLI paths for the GFDL site installation to new site installation location (taken from default_gfdl.jsonc values in 6b08ebf8e879ebac55e6a305a8a0178350fe3391)
- Print more explicit error messages if validation of input paths fails
- Check existence of CASE_ROOT_DIR before other validation. This is intended to catch input errors where arguments to CLI flags are parsed as positional arguments instead, e.g. https://github.com/NOAA-GFDL/MDTF-diagnostics/discussions/152#discussioncomment-1334531.

Associated issue #275 

**How Has This Been Tested?**
Verified that modified sphinx documentation builds correctly, and that CLI help displays correctly.

**Checklist:**
- [X] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [X] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
