### PR TITLE
add 3D and 4D wind_speed fields to CMIP fieldlist

### DIFF
--- a/data/fieldlist_CMIP.jsonc
+++ b/data/fieldlist_CMIP.jsonc
@@ -49,6 +49,12 @@
       "scalar_coord_templates": {"plev": "va{value}"},
       "ndim": 4
     },
+     "wind_speed": {
+      "standard_name": "wind_speed",
+      "units": "m s-1",
+      "scalar_coord_templates": {"plev": "wind_speed{value}"},
+      "ndim": 4
+    },
     "zg": {
       "standard_name": "geopotential_height",
       "units": "m",
@@ -109,6 +115,12 @@
     "psl": {
       "standard_name": "air_pressure_at_mean_sea_level",
       "units": "Pa",
+      "ndim": 3
+    },
+    "wind_speed": {
+      "standard_name": "wind_speed",
+      "units": "m s-1",
+      "modifier": "atmos_height",
       "ndim": 3
     },
     // radiative fluxes:


### PR DESCRIPTION
This requires PR #266 to be merged first.

**Description**
Adds 3D and 4D wind_speed fields to the CMIP field list 

Associated issue #284

**How Has This Been Tested?**

**Checklist:**
- [x] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [x] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [x] The repository contains no extra test scripts or data files
