### PR TITLE
Revert "update env_base.yml"

### DIFF
--- a/src/conda/env_base.yml
+++ b/src/conda/env_base.yml
@@ -10,12 +10,12 @@ dependencies:
 - python=3.7
 - ghostscript
 - numpy=1.19
-- scipy=1.5.2
+# - scipy=1.5.2
 - netCDF4=1.5.4
 - cftime=1.2
 - xarray=0.16
 - matplotlib=3.3
-- cartopy=0.18
+# - cartopy=0.18
 - pandas<1.3
 - pint=0.16
 - dask=2.30
@@ -25,6 +25,3 @@ dependencies:
 - intake-esm=2020.11.4
 # bump version 0.3.1 -> 0.4 feb 2021
 - cf_xarray=0.4.0
-- esmpy=8.0.1
-- xesmf=0.3.0
-- gsw=3.3


### PR DESCRIPTION
Reverts NOAA-GFDL/MDTF-diagnostics#289

Only python3_base environment needs to be modified--will add xesmf in #283.