### PR TITLE
Change cf_time calendar logic

### DIFF
--- a/src/xr_parser.py
+++ b/src/xr_parser.py
@@ -1117,10 +1117,12 @@ class DefaultDatasetParser():
 
         # normal case: T axis has been parsed into cftime Datetime objects, and
         # the following works successfully.
-        cftime_cal = getattr(t_coord.values[0], 'calendar', None)
+        cftime_cal = None
+        if 'calendar' in t_coord.values:
+            cftime_cal = getattr(t_coord.values, 'calendar', None)
         # look in other places if that failed:
         if not cftime_cal:
-            self.log.warning("cftime calendar info parse failed on '%s'.",
+            self.log.warning("cftime calendar info not available in t_coord.values in '%s'. Checking other t_coord elements.",
                 t_coord.name)
             cftime_cal = _get_calendar(t_coord.encoding)
         if not cftime_cal:

--- a/src/xr_parser.py
+++ b/src/xr_parser.py
@@ -1118,13 +1118,7 @@ class DefaultDatasetParser():
         # normal case: T axis has been parsed into cftime Datetime objects, and
         # the following works successfully.
         cftime_cal = None
-        if 'calendar' in t_coord.values:
-            cftime_cal = getattr(t_coord.values, 'calendar', None)
-        # look in other places if that failed:
-        if not cftime_cal:
-            self.log.warning("cftime calendar info not available in t_coord.values in '%s'. Checking other t_coord elements.",
-                t_coord.name)
-            cftime_cal = _get_calendar(t_coord.encoding)
+        cftime_cal = _get_calendar(t_coord.encoding)
         if not cftime_cal:
             cftime_cal = _get_calendar(t_coord.attrs)
         if not cftime_cal:


### PR DESCRIPTION
**Description**
The current cftime_cal definition assumes that the t_coord.values array contains the calendar attribute in its first element. However, the array is not populated after reading in some CMIP datasets that do not have the assumed metadata structure, which causes a framework crash when defining cftime_cal. This fix defines cftime_cal as None, then checks for the calendar attribute in t_coord.encoding. If the 'calendar 'attribute is not present here, the framework searches other t_coord and ds attributes for it.

Associated issue #284  

**How Has This Been Tested?**

Tested on CentOS 8 using QBOI and AM4 test PODs and datasets in default_tests.jsonc

**Checklist:**
- [x] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [x] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [x] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [x] The repository contains no extra test scripts or data files
