### PR TITLE
Add multirun support

### DIFF
--- a/diagnostics/example/settings.jsonc
+++ b/diagnostics/example/settings.jsonc
@@ -69,7 +69,7 @@
 
       // Time frequency the data should be sampled at. Currently recognized
       // values are '1hr', '3hr', '6hr', 'day' and 'mon'.
-      "frequency" : "mon",
+      "frequency" : "day", // "mon"
 
       // Coordinates of the variable (defined in the section above.)
       "dimensions": ["time", "lat", "lon"],

--- a/multirun_scratch.py
+++ b/multirun_scratch.py
@@ -1,0 +1,113 @@
+#!/usr/env/bin/python3
+# test script for read_json utility
+import os
+import io
+import sys
+import collections
+import json
+import re
+from src.util import strip_comments
+
+
+# jsonc reading and parsing routines from util.filesystem
+def parse_json(str_):
+    """Parse JSONC (JSON with ``//``-comments) string *str\_* into a Python object.
+    Comments are discarded. Wraps standard library :py:func:`json.loads`.
+
+    Syntax errors in the input (:py:class:`~json.JSONDecodeError`) are passed
+    through from the Python standard library parser. We correct the line numbers
+    mentioned in the errors to refer to the original file (i.e., with comments.)
+    """
+    def _pos_from_lc(lineno, colno, str_):
+        # fix line number, since we stripped commented-out lines. JSONDecodeError
+        # computes line/col no. in error message from character position in string.
+        lines = str_.splitlines()
+        return (colno - 1) + sum( (len(line) + 1) for line in lines[:lineno])
+
+    (strip_str, line_nos) = strip_comments(str_, delimiter= '//')
+    try:
+        parsed_json = json.loads(strip_str,
+            object_pairs_hook=collections.OrderedDict)
+    except json.JSONDecodeError as exc:
+        # fix reported line number, since we stripped commented-out lines.
+        assert exc.lineno <= len(line_nos)
+        raise json.JSONDecodeError(
+            msg=exc.msg, doc=str_,
+            pos=_pos_from_lc(line_nos[exc.lineno-1], exc.colno, str_)
+        )
+    except UnicodeDecodeError as exc:
+        raise json.JSONDecodeError(
+            msg=f"parse_json received UnicodeDecodeError:\n{exc}",
+            doc=strip_str, pos=0
+        )
+    return parsed_json
+
+
+def read_json(file_path):
+    """Reads a struct from a JSONC file at *file_path*.
+
+    Raises:
+        :class:`~src.util.exceptions.MDTFFileNotFoundError`: If file not found at
+            *file_path*.
+
+    Returns:
+        dict: data contained in the file, as parsed by :func:`parse_json`.
+
+    Execution exits with error code 1 on all other exceptions.
+    """
+    print('Reading file %s', file_path)
+    if not os.path.isfile(file_path):
+        raise FileNotFoundError(file_path)
+    try:
+        with io.open(file_path, 'r', encoding='utf-8') as file_:
+            str_ = file_.read()
+    except Exception as exc:
+        # something more serious than missing file
+        print("Caught exception when trying to read %s: %r", file_path, exc)
+        exit(1)
+    return parse_json(str_)
+
+
+def pretty_print_json(struct, sort_keys=False):
+    """Serialize *struct* to a pseudo-YAML string for human-readable debugging
+    purposes only. Output is not valid JSON (or YAML).
+    """
+    str_ = json.dumps(struct, sort_keys=sort_keys, indent=2)
+    for char in [',', '{', '}', '[', ']']:
+        str_ = str_.replace(char, '')
+    # remove isolated double quotes, but keep ""
+    str_ = re.sub(r'(?<!\")\"(?!\")', "", str_)
+    # remove lines containing only whitespace
+    return os.linesep.join([s for s in str_.splitlines() if s.strip()])
+
+
+def main():
+    code_root = "/home/jessica.liptak/mdtf/MDTF-diagnostics"
+    file_name = "src/multirun_config_template.jsonc"
+    file_name_og = "src/default_tests.jsonc"
+    json_obj_og = read_json(os.path.join(code_root, file_name_og))
+
+    if json_obj_og.get('case_list') is None:
+        print("ERROR: case_list not present in", json_obj_og)
+        sys.exit(1)
+    if json_obj_og.get('pod_list') is None:
+        print('pod_list not present; framework will run in non-multirun mode')
+    else:
+        print('Found pod list separate from case list. Framework will use multirun mode. ')
+    json_obj = read_json(os.path.join(code_root, file_name))
+    case_list = json_obj.get('case_list')
+    pod_list = json_obj_og.get('pod_list')
+    num_cases = len(case_list)
+
+    # example of accessing known key name in first case_list element
+    print(case_list[0].get('CASENAME'))
+    # access each case dictionary in case_list
+    for cl in case_list:
+        # dict for each case/ensemble member
+        for key, val in cl.items():
+            # case keys and values
+            print(key, val)
+    return case_list
+if __name__ == '__main__':
+    exit_code = main()
+    sys.exit(exit_code)

--- a/src/case_config_example.yml
+++ b/src/case_config_example.yml
@@ -1,0 +1,69 @@
+## Sample configuration file for configuring environment settings
+## PODs to run, and case/ensemble names and attributes
+
+# POD(s) to run with ensemble case members
+pod_list:
+  name :
+    -  "example"
+# case names (a.k.a. ensemble members)
+case_list :
+  name :
+   - "case_name_01"
+   - "case_name_02"
+# define attributes for each case in blocks that match the case names
+case_name_01 :
+  FIRSTYR : "YYYY"
+  LASTYR : "YYYY"
+  model : "model_name"
+  convention: "CESM|CMIP|GFDL"
+
+case_name_02 :
+  FIRSTYR : "YYYY"
+  LASTYR : "YYYY"
+  model : "model_name"
+  convention: "CESM|CMIP|GFDL"
+
+environment_paths :
+  # Parent directory containing observational data used by individual PODs.
+  OBS_DATA_ROOT : "../inputdata/obs_data"
+  # Parent directory containing results from different models.
+  MODEL_DATA_ROOT : "../mdtf_test_data"
+  # Working directory.
+  WORKING_DIR : "../wkdir"
+  # Directory to write output. The results of each run of the framework will be
+  # put in a subdirectory of this directory. Defaults to WORKING_DIR if blank.
+  OUTPUT_DIR : "../wkdir"
+  # Location of the Anaconda/miniconda installation to use for managing
+  # dependencies (path returned by running `conda info --base`.) If empty,
+  # framework will attempt to determine location of system's conda installation.
+  conda_root : "~/miniconda3"
+  # Directory containing the framework-specific conda environments. This should
+  # be equal to the "--env_dir" flag passed to conda_env_setup.sh. If left
+  # blank, the framework will look for its environments in the system default location.
+  conda_env_root : "~/miniconda3/envs"
+  ## OPTIONAL SETTINGS ------------------------------------------------------------------
+  # Any command-line option recognized by the mdtf script (type `mdtf --help`)
+  # can be set here, in the form "flag name": "desired setting".
+optional_settings :
+  # Method used to fetch model data.
+  data_manager : "Local_File"
+  #  Method used to manage dependencies.
+  environment_manager: "Conda"
+  ## Settings affecting what output is generated:
+  # Set to true to have PODs save postscript figures in addition to bitmaps.
+  save_ps: false
+  # Set to true to have PODs save netCDF files of processed data.
+  save_nc: false
+  # Set to true to save HTML and bitmap plots in a .tar file.
+  make_variab_tar : false
+  # Set to true to overwrite results in OUTPUT_DIR; otherwise results saved  under a unique name.
+  overwrite: false
+  ## Settings used in debugging:
+  # Log verbosity level.
+  verbose: 1
+  # Set to true for framework test. Data is fetched but PODs are not run.
+  test_mode : false
+  # Set to true for framework test. No external commands are run and no remote
+  # data is copied. Implies test_mode.
+  dry_run: false
+

--- a/src/cli.py
+++ b/src/cli.py
@@ -20,9 +20,11 @@ import typing
 from src import util
 
 import logging
+
 _log = logging.getLogger(__name__)
 
-_SCRIPT_NAME = 'mdtf.py' # mimic argparse error message text
+_SCRIPT_NAME = 'mdtf.py'  # mimic argparse error message text
+
 
 def canonical_arg_name(str_):
     """Convert a flag or other specification to a destination variable name.
@@ -33,6 +35,7 @@ def canonical_arg_name(str_):
     """
     return str_.lstrip('-').rstrip().replace('-', '_')
 
+
 def plugin_key(plugin_name):
     """Convert user input for plugin options to string used to lookup plugin
     value from options defined in cli_plugins.jsonc files.
@@ -41,6 +44,7 @@ def plugin_key(plugin_name):
     make matching of plugin names case-insensititve.
     """
     return re.sub(r"[\s_]+", "", plugin_name).lower()
+
 
 def word_wrap(str_):
     """Clean whitespace and perform 80-column word wrapping for multi-line help
@@ -51,6 +55,7 @@ def word_wrap(str_):
     paragraphs = [re.sub(r'\s+', ' ', s).strip() for s in paragraphs]
     paragraphs = [textwrap.fill(s, width=80) for s in paragraphs]
     return '\n\n'.join(paragraphs)
+
 
 def read_config_files(code_root, file_name, site=""):
     """Utility function to read a pair of configuration files: one for the
@@ -74,6 +79,7 @@ def read_config_files(code_root, file_name, site=""):
     fmwk_d = util.find_json(src_dir, file_name, exit_if_missing=True, log=_log)
     return (site_d, fmwk_d)
 
+
 def read_config_file(code_root, file_name, site=""):
     """Return the site's config file if present, else the framework's file. Wraps
     :func:`read_config_files`.
@@ -93,16 +99,18 @@ def read_config_file(code_root, file_name, site=""):
         return fmwk_d
     return site_d
 
+
 class CustomHelpFormatter(
-        argparse.RawDescriptionHelpFormatter,
-        argparse.ArgumentDefaultsHelpFormatter
-    ):
+    argparse.RawDescriptionHelpFormatter,
+    argparse.ArgumentDefaultsHelpFormatter
+):
     """Modify help text formatter to only display variable placeholder text
     ("metavar") once, to save space. Taken from
     `<https://stackoverflow.com/a/16969505>`__. Also inherit from
     :py:class:`argparse.RawDescriptionHelpFormatter` in order to preserve line
     breaks in description only (`<https://stackoverflow.com/a/18462760>`__).
     """
+
     def __init__(self, *args, **kwargs):
         # tweak indentation of help strings
         if not kwargs.get('indent_increment', None):
@@ -139,7 +147,7 @@ class CustomHelpFormatter(
             # ignore hidden CLI items
             return help_str
         if action.default not in (None, argparse.SUPPRESS) \
-            and '%(default)' not in help_str:
+                and '%(default)' not in help_str:
             defaulting_nargs = [argparse.OPTIONAL, argparse.ZERO_OR_MORE]
             if action.option_strings or action.nargs in defaulting_nargs:
                 if isinstance(action.default, str):
@@ -168,13 +176,13 @@ class RecordDefaultsAction(argparse.Action):
     default values.
     """
     default_value_suffix = '_is_default_'
-    call_on_defaults = False # call action on default values
+    call_on_defaults = False  # call action on default values
 
     def __init__(self, option_strings, dest, nargs=None, const=None,
-        default=None, type=None, **kwargs):
+                 default=None, type=None, **kwargs):
         if isinstance(default, bool):
-            nargs = 0             # behave like a flag
-            const = (not default) # set flag = store opposite of default
+            nargs = 0  # behave like a flag
+            const = (not default)  # set flag = store opposite of default
         elif (isinstance(default, str) or type == str) and nargs is None:
             # unless nargs given explictly, string-valued options accept 1 argument
             nargs = 1
@@ -192,7 +200,8 @@ class RecordDefaultsAction(argparse.Action):
         else:
             setattr(namespace, self.dest, values)
         # set additional flag to indicate user has set this argument
-        setattr(namespace, self.dest+self.default_value_suffix, False)
+        setattr(namespace, self.dest + self.default_value_suffix, False)
+
 
 class PathAction(RecordDefaultsAction):
     """Argparse :py:class:`~argparse.Action` that performs shell environment
@@ -211,6 +220,7 @@ class PathAction(RecordDefaultsAction):
         # resolve paths, so that's now done later, in core.PathManager.__init__()
         super(PathAction, self).__call__(parser, namespace, path, option_string)
 
+
 class ClassImportAction(RecordDefaultsAction):
     """Argparse :py:class:`~argparse.Action` to import classes on demand. Values
     are looked up from the 'cli_plugins.jsonc' file. This is a placeholder used
@@ -226,13 +236,13 @@ class ClassImportAction(RecordDefaultsAction):
             parser, namespace, p_key, option_string
         )
 
+
 class PluginArgAction(ClassImportAction):
     """Argparse :py:class:`~argparse.Action` to invoke the CLI plugin functionality,
     specificially importing the plugin's entry point via :class:`ClassImportAction`.
     All CLI options which define a plugin should specify this as the action.
     """
     call_on_defaults = False
-
 
 
 # ===========================================================================
@@ -265,21 +275,22 @@ class CLIArgument(object):
     def __post_init__(self):
         """Post-initialization type conversion of attributes.
         """
+
         def _flag_names(_arg_name):
             _arg_flags = [_arg_name]
             if '_' in _arg_name:
                 # recognize both --hyphen_opt and --hyphen-opt (GNU CLI convention)
                 _arg_flags.append(_arg_name.replace('_', '-'))
-            return ['--'+s for s in _arg_flags]
+            return ['--' + s for s in _arg_flags]
 
         # Format flag name(s) and destination variables
         if self.is_positional:
-            assert isinstance(self.name, str) # not a list
+            assert isinstance(self.name, str)  # not a list
             arg_name = canonical_arg_name(self.name)
             self.arg_flags = [arg_name]
             self.name = arg_name
-            self.dest = None # positionals can't specify independent dest
-            self.required = None # positionals always required
+            self.dest = None  # positionals can't specify independent dest
+            self.required = None  # positionals always required
         else:
             # argument is a command-line flag (default)
             # if self.name is a list, recognize all entries as synonyms
@@ -316,8 +327,9 @@ class CLIArgument(object):
         if self.action is None:
             self.action = RecordDefaultsAction
         elif isinstance(self.action, str) and self.action not in ['store',
-            'store_const','store_true','store_false','append','append_const',
-            'count','help','version']:
+                                                                  'store_const', 'store_true', 'store_false', 'append',
+                                                                  'append_const',
+                                                                  'count', 'help', 'version']:
             self.action = util.deserialize_class(self.action)
         if isinstance(self.action, type) and issubclass(self.action, ClassImportAction):
             # Enforce case-insensitive matching on plugin names.
@@ -339,11 +351,12 @@ class CLIArgument(object):
             target_p: Parser object (or argument group, or subparser) to which the
                 argument will be added.
         """
-        kwargs = {k:v for k,v in dataclasses.asdict(self).items() \
-                if v is not None and k not in [
-                'name', 'arg_flags', 'is_positional', 'short_name', 'hidden'
-            ]}
+        kwargs = {k: v for k, v in dataclasses.asdict(self).items() \
+                  if v is not None and k not in [
+                      'name', 'arg_flags', 'is_positional', 'short_name', 'hidden'
+                  ]}
         return target_p.add_argument(*self.arg_flags, **kwargs)
+
 
 @dataclasses.dataclass
 class CLIArgumentGroup(object):
@@ -377,12 +390,13 @@ class CLIArgumentGroup(object):
         """
         if self.arguments:
             # only add group if it has > 0 arguments
-            kwargs = {k:v for k,v in dataclasses.asdict(self).items() \
-                if v is not None and k in ['title', 'description']}
+            kwargs = {k: v for k, v in dataclasses.asdict(self).items() \
+                      if v is not None and k in ['title', 'description']}
             arg_gp = target_p.add_argument_group(**kwargs)
             for arg in self.arguments:
                 _ = arg.add(arg_gp)
             return arg_gp
+
 
 @dataclasses.dataclass
 class CLIParser(object):
@@ -425,6 +439,7 @@ class CLIParser(object):
         parser; if *filter_class* is specified, only iterate over objects having
         (a subclass of) *filter_class* as their ``action``.
         """
+
         def _iter_all_args():
             yield from self.arguments
             for arg_gp in self.argument_groups:
@@ -434,7 +449,7 @@ class CLIParser(object):
             yield from _iter_all_args()
         else:
             filter_fn = (lambda arg: isinstance(arg.action, type) \
-                and issubclass(arg.action, filter_class))
+                                     and issubclass(arg.action, filter_class))
             yield from filter(filter_fn, _iter_all_args())
 
     def configure(self, target_p):
@@ -494,6 +509,7 @@ class CLIParser(object):
                 :class:`.PluginArgAction`), and values are the values assigned
                 to them by preparsing.
         """
+
         def _add_plugins_to_arg_list(arg_list, splice_d):
             # insert plugin args into arg_list
             return util.splice_into_list(
@@ -508,10 +524,10 @@ class CLIParser(object):
             if not plugin:
                 choices = [f"'{x}'" for x in config.get_plugin(flag_name).keys()]
                 _log.critical(("%s: error: argument --%s: invalid choice: '%s' "
-                    "(choose from %s)"),
-                    _SCRIPT_NAME, flag_name, flag_value, ', '.join(choices)
-                )
-                util.exit_handler(code=2) # exit code for  CLI syntax error
+                               "(choose from %s)"),
+                              _SCRIPT_NAME, flag_name, flag_value, ', '.join(choices)
+                              )
+                util.exit_handler(code=2)  # exit code for  CLI syntax error
             d[flag_name] = list(plugin.cli.iter_args())
         self.arguments = _add_plugins_to_arg_list(self.arguments, d)
         for arg_gp in self.argument_groups:
@@ -525,13 +541,14 @@ class CLIParser(object):
             plugin = config.get_plugin(arg.name, flag_value)
             if plugin.help:
                 arg.help = arg.help.strip() + \
-                    f" Selected value = '{flag_value}': {plugin.help.strip()} "
+                           f" Selected value = '{flag_value}': {plugin.help.strip()} "
             else:
                 arg.help = arg.help.strip() + f" Selected value = '{flag_value}'. "
             arg.help = arg.help + word_wrap(f"""
                 NOTE: flags below are specific to this value. Set a different
                 value along with '--help' to see flags for that option.
             """)
+
 
 @dataclasses.dataclass
 class CLICommand(object):
@@ -556,7 +573,7 @@ class CLICommand(object):
                 )
             except util.MDTFFileNotFoundError:
                 _log.critical("Couldn't find CLI file %s.", self.cli_file)
-                util.exit_handler(code=2) # exit code for  CLI syntax error
+                util.exit_handler(code=2)  # exit code for  CLI syntax error
         if self.cli is not None:
             self.cli = CLIParser.from_dict(self.cli)
 
@@ -584,6 +601,7 @@ class CLICommand(object):
         instance = cls_(*args, **kwargs)
         return instance
 
+
 DefaultsFileTypes = util.MDTFEnum('DefaultsFileTypes', 'USER SITE GLOBAL')
 DefaultsFileTypes.__doc__ = """
     :class:`~util.MDTFEnum` to distinguish the three different categories of
@@ -595,6 +613,7 @@ DefaultsFileTypes.__doc__ = """
        of this file is to enable the user to configure a default site at
        install time.
 """
+
 
 class CLIConfigManager(util.Singleton):
     """:class:`~src.util.Singleton` to handle search, loading and parsing
@@ -608,6 +627,7 @@ class CLIConfigManager(util.Singleton):
        must be properly initialized before being referenced by the classes in
        this module.
     """
+
     def __init__(self, code_root=None, skip_defaults=False):
         # singleton, so this will only be invoked once
 
@@ -677,14 +697,14 @@ class CLIConfigManager(util.Singleton):
             path = os.path.join(self.site_dir, self.defaults_filename)
             dest_d = self.site_defaults
         elif def_type == DefaultsFileTypes.USER:
-            assert path # is not none
+            assert path  # is not none
             dest_d = self.user_defaults
 
         try:
             d = util.read_json(path, log=_log)
             self.defaults_files[def_type] = path
             # drop values equal to the empty string
-            d = {k:v for k,v in d.items() if (v is not None and v != "")}
+            d = {k: v for k, v in d.items() if (v is not None and v != "")}
             dest_d.update(d)
         except util.MDTFFileNotFoundError:
             _log.debug('Config file %s not found; not updating defaults.', path)
@@ -698,7 +718,7 @@ class CLIConfigManager(util.Singleton):
         files_str = '\n'.join([x for x in files_str if x is not None])
         if files_str:
             return "Default values have been set from the following files:" \
-                + '\n' + files_str
+                   + '\n' + files_str
         else:
             return None
 
@@ -716,9 +736,9 @@ class CLIConfigManager(util.Singleton):
         self.subparser_kwargs.update(site_d)
         self.subcommands = {
             k: CLICommand(name=k, **v, code_root=self.code_root) \
-                for k,v in fmwk_cmds.items()
+            for k, v in fmwk_cmds.items()
         }
-        for k,v in site_cmds.items():
+        for k, v in site_cmds.items():
             if k in self.subcommands:
                 _log.debug("Replacing subcommand '%s' with site-specific version.", k)
             self.subcommands[k] = CLICommand(name=k, **v, code_root=self.code_root)
@@ -727,10 +747,11 @@ class CLIConfigManager(util.Singleton):
         """Populates ``plugins`` attribute with contents of CLI plugin files for
         the framework and site.
         """
+
         def _add_new_plugin_type(plugin_arg, arg_choices):
             self.plugins[plugin_arg] = {
                 plugin_key(k): CLICommand(name=k, **v, code_root=self.code_root) \
-                    for k,v in arg_choices.items()
+                for k, v in arg_choices.items()
             }
 
         (site_d, fmwk_d) = read_config_files(
@@ -768,8 +789,8 @@ class CLIConfigManager(util.Singleton):
         """
         if plugin_name not in self.plugins:
             _log.error('Plugin %s not found (recognized: %s)',
-                plugin_name, str(list(self.plugins.keys()))
-            )
+                       plugin_name, str(list(self.plugins.keys()))
+                       )
             return dict()
         if choice_of_plugin is None:
             # return entire dict
@@ -777,12 +798,13 @@ class CLIConfigManager(util.Singleton):
         p_key = plugin_key(choice_of_plugin)
         if p_key not in self.plugins[plugin_name]:
             _log.critical(("%s: error: argument --%s: invalid choice: '%s' "
-                "(choose from %s)"),
-                _SCRIPT_NAME, plugin_name, choice_of_plugin,
-                str(list(self.plugins[plugin_name].keys()))
-            )
-            util.exit_handler(code=2) # exit code for CLI syntax error
+                           "(choose from %s)"),
+                          _SCRIPT_NAME, plugin_name, choice_of_plugin,
+                          str(list(self.plugins[plugin_name].keys()))
+                          )
+            util.exit_handler(code=2)  # exit code for CLI syntax error
         return self.plugins[plugin_name][p_key]
+
 
 # ===========================================================================
 # CLI parsers
@@ -798,6 +820,7 @@ class MDTFArgParser(argparse.ArgumentParser):
       <https://docs.python.org/3.7/library/argparse.html#argument-groups>`__,
       e.g. which arguments belong to which group.
     """
+
     def __init__(self, *args, **kwargs):
         # Dict to store whether default value was used, for arguments using the
         # RecordDefaultsAction
@@ -821,6 +844,7 @@ class MDTFArgParser(argparse.ArgumentParser):
         all user-defined arguments in parser, as well as those for any
         subcommands.
         """
+
         def _iter_all_actions():
             for act in self._actions:
                 if isinstance(act, argparse._SubParsersAction):
@@ -832,7 +856,7 @@ class MDTFArgParser(argparse.ArgumentParser):
 
         def _pred(act):
             return not isinstance(act,
-                (argparse._HelpAction, argparse._VersionAction))
+                                  (argparse._HelpAction, argparse._VersionAction))
 
         return filter(_pred, _iter_all_actions())
 
@@ -843,7 +867,7 @@ class MDTFArgParser(argparse.ArgumentParser):
         Args:
             parsed_args: dict of args and values returned by initial parsing.
         """
-        self.is_default = dict() # clear in case we parsed previously
+        self.is_default = dict()  # clear in case we parsed previously
         for act in self.iter_actions():
             if isinstance(act, RecordDefaultsAction):
                 default_value_flag = act.dest + act.default_value_suffix
@@ -912,6 +936,7 @@ class MDTFArgParser(argparse.ArgumentParser):
             unrecognized arguments, as with
             :py:meth:`argparse.ArgumentParser.parse_known_args`.
         """
+
         def _to_dict(ns):
             if isinstance(ns, argparse.Namespace):
                 return vars(ns)
@@ -933,8 +958,8 @@ class MDTFArgParser(argparse.ArgumentParser):
         # Highest priority: options that were explicitly set by user on CLI
         # Note that is_default[opt] = None (not True or False) if no default
         # value is defined for that option.
-        user_cli_opts = {k:v for k,v in parsed_args.items() \
-            if not self.is_default.get(k, True)}
+        user_cli_opts = {k: v for k, v in parsed_args.items() \
+                         if not self.is_default.get(k, True)}
         # Lowest priority: set of defaults from running parser on empty input
         try:
             parser_defaults, _ = super(MDTFArgParser, self).parse_known_args(
@@ -952,7 +977,7 @@ class MDTFArgParser(argparse.ArgumentParser):
         if namespace is None:
             namespace = argparse.Namespace(**parsed_args)
         else:
-            for k,v in parsed_args.items():
+            for k, v in parsed_args.items():
                 setattr(namespace, k, v)
         self._call_actions_on_defaults(namespace)
         return namespace, remainder
@@ -972,6 +997,7 @@ class MDTFArgPreparser(MDTFArgParser):
     what site and plugin values were set by the user. Plugin selector arguments
     are identified by having their ``action`` set to :class:`.PluginArgAction`.
     """
+
     def __init__(self):
         super(MDTFArgPreparser, self).__init__(add_help=False)
 
@@ -995,7 +1021,7 @@ class MDTFArgPreparser(MDTFArgParser):
         """
         d = vars(self.parse_known_args(argv)[0])
         keys = [act.dest for act in self.iter_actions() \
-            if isinstance(act, PluginArgAction)]
+                if isinstance(act, PluginArgAction)]
         return {k: d.get(k, None) for k in keys}
 
 
@@ -1003,6 +1029,7 @@ class MDTFTopLevelArgParser(MDTFArgParser):
     """Class for constructing the command-line interface, parsing the options,
     and handing off execution to the selected subcommand.
     """
+
     def __init__(self, code_root, skip_defaults=False, argv=None):
         _ = CLIConfigManager(code_root, skip_defaults=skip_defaults)
         self.code_root = code_root
@@ -1104,7 +1131,7 @@ class MDTFTopLevelArgParser(MDTFArgParser):
             try:
                 d = util.parse_json(str_)
                 self.file_case_list = d.pop('case_list', [])
-                d = {canonical_arg_name(k): v for k,v in d.items()}
+                d = {canonical_arg_name(k): v for k, v in d.items()}
                 config.user_defaults.update(d)
             except json.JSONDecodeError as exc:
                 sys.exit(f"ERROR: JSON syntax error in {path}:\n\t{exc}")
@@ -1160,9 +1187,9 @@ class MDTFTopLevelArgParser(MDTFArgParser):
         config.read_defaults(DefaultsFileTypes.GLOBAL)
         default_site = config.site_defaults.get('site', config.default_site)
 
-        self.sites = [d for d in os.listdir(config.sites_dir) \
-            if os.path.isdir(os.path.join(config.sites_dir, d)) \
-                and not d.startswith(('.','_'))]
+        self.sites = [d for d in os.listdir(config.sites_dir)
+                      if os.path.isdir(os.path.join(config.sites_dir, d))
+                      and not d.startswith(('.', '_'))]
         # TODO: if we're checking to see if installer has been run, only set
         # self.installed = True if default_site in self.sites
         self.installed = True
@@ -1171,10 +1198,10 @@ class MDTFTopLevelArgParser(MDTFArgParser):
         self.add_site_arg(site_p)
         site = util.from_iter(site_p.parse_site(self.argv, default_site))
         if site not in self.sites \
-            and not (site == default_site and not self.installed):
+                and not (site == default_site and not self.installed):
             _log.critical("Requested site %s not found in sites directory %s.",
-                site, config.sites_dir)
-            util.exit_handler(code=2) # exit code for  CLI syntax error
+                          site, config.sites_dir)
+            util.exit_handler(code=2)  # exit code for  CLI syntax error
         config.default_site = default_site
         config.site = site
         self.site = site
@@ -1202,7 +1229,7 @@ class MDTFTopLevelArgParser(MDTFArgParser):
         self.init_site()
         config.read_subcommands()
         config.subparser_kwargs.update({
-            'required':True, 'dest':'subcommand', 'parser_class': MDTFArgParser
+            'required': True, 'dest': 'subcommand', 'parser_class': MDTFArgParser
         })
         config.read_plugins()
         # preparse arguments to get plugin configuration, and revise CLI
@@ -1223,21 +1250,21 @@ class MDTFTopLevelArgParser(MDTFArgParser):
         configuration file mechanism.
         """
         MDTFArgParser.__init__(self,
-            prog="mdtf",
-            usage="%(prog)s [options] [CASE_ROOT_DIR]",
-            description=word_wrap("""
+                               prog="mdtf",
+                               usage="%(prog)s [options] [CASE_ROOT_DIR]",
+                               description=word_wrap("""
                 Driver script for the NOAA Model Diagnostics Task Force (MDTF)
                 package, which runs process-oriented diagnostics (PODs) on climate
                 model data. See documentation at https://mdtf-diagnostics.rtfd.io.
             """),
-            add_help=True,
-        )
+                               add_help=True,
+                               )
         self.add_argument(
             '--version', action="version", version="%(prog)s 3.0 beta 3"
         )
         self._optionals.title = 'GENERAL OPTIONS'
         if not self.installed:
-            self.epilog=word_wrap("""
+            self.epilog = word_wrap("""
                 Warning: User-customized configuration files not found. Consider
                 running 'mdtf install' to configure your installation.
             """)
@@ -1334,21 +1361,21 @@ class MDTFTopLevelSubcommandArgParser(MDTFTopLevelArgParser):
         for information on the configuration file mechanism.
         """
         MDTFArgParser.__init__(self,
-            prog="mdtf",
-            usage="%(prog)s [flags] <command> [command-specific options]",
-            description=word_wrap("""
+                               prog="mdtf",
+                               usage="%(prog)s [flags] <command> [command-specific options]",
+                               description=word_wrap("""
                 Driver script for the NOAA Model Diagnostics Task Force (MDTF)
                 package, which runs process-oriented diagnostics (PODs) on
                 climate model data. See documentation at
                 https://mdtf-diagnostics.rtfd.io.
             """)
-        )
+                               )
         self.add_argument(
             '--version', action="version", version="%(prog)s 3.0 beta 3"
         )
         self._optionals.title = 'GENERAL OPTIONS'
         if not self.installed:
-            self.epilog=word_wrap("""
+            self.epilog = word_wrap("""
                 Warning: User-customized configuration files not found. Consider
                 running 'mdtf install' to configure your installation.
             """)

--- a/src/cli.py
+++ b/src/cli.py
@@ -547,7 +547,7 @@ class CLICommand(object):
     code_root: dataclasses.InitVar = ""
 
     def __post_init__(self, code_root):
-        """Post-initialization type converstion of attributes.
+        """Post-initialization type conversion of attributes.
         """
         if self.cli is None and self.cli_file is not None:
             try:
@@ -955,7 +955,7 @@ class MDTFArgParser(argparse.ArgumentParser):
             for k,v in parsed_args.items():
                 setattr(namespace, k, v)
         self._call_actions_on_defaults(namespace)
-        return (namespace, remainder)
+        return namespace, remainder
 
     def parse_args(self, args=None, namespace=None):
         """Subclassed implementation of :py:meth:`~argparse.ArgumentParser.parse_args`
@@ -1024,6 +1024,7 @@ class MDTFTopLevelArgParser(MDTFArgParser):
         """Iterate over all arguments defined on the parser for the subcommand
         *subcommand*.
         """
+        config = CLIConfigManager()
         config = CLIConfigManager()
         if subcommand:
             subcmds = config.subcommands.get(subcommand, [])
@@ -1095,6 +1096,8 @@ class MDTFTopLevelArgParser(MDTFArgParser):
             raise ValueError()
         if not str_:
             return
+        # TODO define variable fname_suffix = os.path.splitext(path)[1].lower()
+        # add to json and yaml checks
         # try to determine if file is json
         if 'json' in os.path.splitext(path)[1].lower():
             # assume config_file a JSON dict of option:value pairs.
@@ -1108,6 +1111,15 @@ class MDTFTopLevelArgParser(MDTFArgParser):
             except Exception:
                 _log.exception('Attempted to parse %s as JSONC; failed.', path)
                 raise ValueError()
+        # TODO Add call to yaml parser here
+        # elif 'yml' in fname_suffix :
+        #    try:
+        #        d = util.parse_yaml(str_)
+        #        self.file_case_list = d.pop('case_list', [])
+        #        d = {canonical_arg_name(k): v for k,v in d.items()}
+        #        config.user_defaults.update(d)
+        #    except IOerror :
+        #       sys.exit(f"ERROR: Unable to parse yaml file in {path}:\n\t{exc}")
         else:
             # assume config_file is a plain text file containing flags, etc.
             # as they would be passed on the command line.

--- a/src/data_manager.py
+++ b/src/data_manager.py
@@ -632,7 +632,7 @@ class DataSourceBase(core.MDTFObjectBase, util.CaseLoggerMixin,
         for p in self.iter_children():
             for v in p.iter_children():
                 if v.status == core.ObjectStatus.ACTIVE:
-                    v.log.debug('Data request for %s completed succesfully.',
+                    v.log.debug('Data request for %s completed successfully.',
                         v.full_name)
                     v.status = core.ObjectStatus.SUCCEEDED
                 elif v.failed:
@@ -642,7 +642,7 @@ class DataSourceBase(core.MDTFObjectBase, util.CaseLoggerMixin,
             if p.failed:
                 p.log.debug('Data request for %s failed.', p.full_name)
             else:
-                p.log.debug('Data request for %s completed succesfully.',
+                p.log.debug('Data request for %s completed successfully.',
                     p.full_name)
 
     def query_and_fetch_cleanup(self, signum=None, frame=None):

--- a/src/multirun_config_template.jsonc
+++ b/src/multirun_config_template.jsonc
@@ -1,0 +1,103 @@
+// This a template for configuring MDTF to run PODs that analyze multi-run/ensemble data
+//
+// Copy this file, rename it, and customize the settings as needed
+// Pass your file to the framework using the -f/--input-file flag.
+// Any other explicit command line options will override what's listed here.
+//
+// All text to the right of an unquoted "//" is a comment and ignored, as well
+// as blank lines (JSONC quasi-standard.)
+//
+// Remove your test config file, or any changes you make to this template if you do not rename it,
+// from your remote repository before you submit a PR for review.
+{
+  // Run each ensemble on the example POD.
+  // Add other PODs that work on ensemble datasets to the pod_list as needed
+  "pod_list" : [
+     "example"
+   ],
+   // Each CASENAME corresponds to an ensemble member.
+  "case_list" : [
+     {
+       "CASENAME" : "case_name_01",
+       "model" : "test",
+       "convention" : "CMIP",
+       "FIRSTYR" : 1980,
+       "LASTYR" : 1984
+     },
+     {
+       "CASENAME": "case_name_02",
+       "model" : "test",
+       "convention" : "CMIP",
+       "FIRSTYR" : 1986,
+       "LASTYR" : 1984
+     }
+  ],
+  // PATHS ---------------------------------------------------------------------
+  // Location of supporting data downloaded when the framework was installed.
+
+  // If a relative path is given, it's resolved relative to the MDTF-diagnostics
+  // code directory. Environment variables (eg, $HOME) can be referenced with a
+  // "$" and will be expended to their current values when the framework runs.
+
+  // Parent directory containing observational data used by individual PODs.
+  "OBS_DATA_ROOT": "../inputdata/obs_data",
+
+  // Parent directory containing results from different models.
+ // "MODEL_DATA_ROOT": "../mdtf_test_data",
+  "MODEL_DATA_ROOT": "../inputdata/model",
+
+  // Working directory.
+  "WORKING_DIR": "../wkdir",
+
+  // Directory to write output. The results of each run of the framework will be
+  // put in a subdirectory of this directory. Defaults to WORKING_DIR if blank.
+  "OUTPUT_DIR": "../wkdir",
+
+  // Location of the Anaconda/miniconda installation to use for managing
+  // dependencies (path returned by running `conda info --base`.) If empty,
+  // framework will attempt to determine location of system's conda installation.
+  "conda_root": "~/miniconda3",
+
+  // Directory containing the framework-specific conda environments. This should
+  // be equal to the "--env_dir" flag passed to conda_env_setup.sh. If left
+  // blank, the framework will look for its environments in the system default
+  // location.
+  "conda_env_root": "~/miniconda3/envs",
+
+  // SETTINGS ------------------------------------------------------------------
+  // Any command-line option recognized by the mdtf script (type `mdtf --help`)
+  // can be set here, in the form "flag name": "desired setting".
+
+  // Method used to fetch model data.
+  "data_manager": "Local_File",
+
+  // Method used to manage dependencies.
+  "environment_manager": "Conda",
+
+  // Settings affecting what output is generated:
+
+  // Set to true to have PODs save postscript figures in addition to bitmaps.
+  "save_ps": false,
+
+  // Set to true to have PODs save netCDF files of processed data.
+  "save_nc": false,
+
+  // Set to true to save HTML and bitmap plots in a .tar file.
+  "make_variab_tar": false,
+
+  // Set to true to overwrite results in OUTPUT_DIR; otherwise results saved
+  // under a unique name.
+  "overwrite": false,
+
+  // Settings used in debugging:
+
+  // Log verbosity level.
+  "verbose": 1,
+
+  // Set to true for framework test. Data is fetched but PODs are not run.
+  "test_mode": false,
+
+  // Set to true for framework test. No external commands are run and no remote
+  // data is copied. Implies test_mode.
+  "dry_run": false
+}

--- a/src/multirun_config_template.jsonc
+++ b/src/multirun_config_template.jsonc
@@ -18,18 +18,18 @@
    // Each CASENAME corresponds to an ensemble member.
   "case_list" : [
      {
-       "CASENAME" : "case_name_01",
+       "CASENAME" : "CMIP_Synthetic_r1i1p1f1_gr1_19800101-19841231",
        "model" : "test",
        "convention" : "CMIP",
        "FIRSTYR" : 1980,
        "LASTYR" : 1984
      },
      {
-       "CASENAME": "case_name_02",
+       "CASENAME": "CMIP_Synthetic_r1i1p1f1_gr1_19850101-19891231",
        "model" : "test",
        "convention" : "CMIP",
-       "FIRSTYR" : 1986,
-       "LASTYR" : 1984
+       "FIRSTYR" : 1985,
+       "LASTYR" : 1989
      }
   ],
   // PATHS ---------------------------------------------------------------------
@@ -44,7 +44,7 @@
 
   // Parent directory containing results from different models.
  // "MODEL_DATA_ROOT": "../mdtf_test_data",
-  "MODEL_DATA_ROOT": "../inputdata/model",
+  "MODEL_DATA_ROOT": "~/mdtf_test_data",
 
   // Working directory.
   "WORKING_DIR": "../wkdir",

--- a/src/util/filesystem.py
+++ b/src/util/filesystem.py
@@ -12,6 +12,7 @@ import shutil
 import string
 from . import basic
 from . import exceptions
+# TODO from envyaml import EnvYAML
 
 import logging
 _log = logging.getLogger(__name__)
@@ -306,6 +307,7 @@ def strip_comments(str_, delimiter=None):
     new_str = '\n'.join([s for s in lines if (s and not s.isspace())])
     return (new_str, line_nos)
 
+
 def parse_json(str_):
     """Parse JSONC (JSON with ``//``-comments) string *str\_* into a Python object.
     Comments are discarded. Wraps standard library :py:func:`json.loads`.
@@ -337,6 +339,7 @@ def parse_json(str_):
             doc=strip_str, pos=0
         )
     return parsed_json
+
 
 def read_json(file_path, log=_log):
     """Reads a struct from a JSONC file at *file_path*.
@@ -399,6 +402,7 @@ def write_json(struct, file_path, sort_keys=False, log=_log):
     except IOError:
         _log.critical(f'Fatal IOError when trying to write {file_path}. Exiting.')
         exit(1)
+
 
 def pretty_print_json(struct, sort_keys=False):
     """Serialize *struct* to a pseudo-YAML string for human-readable debugging


### PR DESCRIPTION
**Description**
This PR adds the ability to run PODs on ensemble datasets--"multirun" mode. The input jsonc file is re-formatted so that the pod_list is separate from the case_list, and each case in the case_list corresponds to an ensemble member name. The file [multirun_config_template.jsonc](https://github.com/wrongkindofdoctor/MDTF-diagnostics/blob/add_multirun_support/src/multirun_config_template.jsonc) shows an example configuration to run the example POD on 2 cases/ensemble members. 

This PR will be extended pending additional user input and testing.

 
Associated issue #309 

**How Has This Been Tested?**


**Checklist:**
- [ ] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [ ] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
