### PR TITLE
Changed argument handling of mdtf_framework.py

### DIFF
--- a/mdtf_framework.py
+++ b/mdtf_framework.py
@@ -63,5 +63,6 @@ def main(argv):
         return exit_code
 
 if __name__ == '__main__':
-    exit_code = main(sys.argv)
+    argv = sys.argv[1::] if len(sys.argv[1::]) >= 2 else sys.argv
+    exit_code = main(argv)
     sys.exit(exit_code)

--- a/mdtf_framework.py
+++ b/mdtf_framework.py
@@ -32,7 +32,7 @@ def validate_base_environment():
             "by calling the 'mdtf' wrapper script.\nSee installation instructions "
             "at mdtf-diagnostics.rtfd.io/en/latest/sphinx/start_install.html.")
 
-def main():
+def main(argv):
     # get dir of currently executing script:
     code_root = os.path.dirname(os.path.realpath(__file__))
     # Cache log info in memory until log file is set up
@@ -40,16 +40,16 @@ def main():
 
     # poor man's subparser: argparse's subparser doesn't handle this
     # use case easily, so just dispatch on first argument
-    if len(sys.argv) == 1 or \
-        len(sys.argv) == 2 and sys.argv[1].lower() in ('-h', '--help'):
+    if len(argv) == 1 or \
+        len(argv) == 2 and argv[1].lower() in ('-h', '--help'):
         # case where we print CLI help
         cli_obj = cli.MDTFTopLevelArgParser(code_root)
         cli_obj.print_help()
         return 0 # will actually exit from print_help
-    elif sys.argv[1].lower() == 'info':
+    elif argv[1].lower() == 'info':
         # case where we print command-line info on PODs
         from src import mdtf_info
-        mdtf_info.InfoCLIHandler(code_root, sys.argv[2:])
+        mdtf_info.InfoCLIHandler(code_root, argv[2:])
         return 0 # will actually exit from print_help
     else:
         # case where we run the actual framework
@@ -57,11 +57,11 @@ def main():
         validate_base_environment()
 
         # not printing help or info, setup CLI normally
-        cli_obj = cli.MDTFTopLevelArgParser(code_root)
+        cli_obj = cli.MDTFTopLevelArgParser(code_root,argv=argv)
         framework = cli_obj.dispatch()
         exit_code = framework.main()
         return exit_code
 
 if __name__ == '__main__':
-    exit_code = main()
+    exit_code = main(sys.argv)
     sys.exit(exit_code)


### PR DESCRIPTION
**Description**
- Pass arguments explicitly rather than use only sys.argv
- Allows for the script to be called directly, (e.g. PyCharm Console)

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x ] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [x ] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [x ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [x ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
