### PR TITLE
Initial YAML configuration support

### DIFF
--- a/sites/NOAA_GFDL/default_gfdl.yml
+++ b/sites/NOAA_GFDL/default_gfdl.yml
@@ -1,0 +1,45 @@
+case_list:
+- CASENAME: ESM4_historical
+  model: GFDL-ESM4
+  convention: CMIP
+  FIRSTYR: 2000
+  LASTYR: 2004
+  CASE_ROOT_DIR: "/archive/Thomas.Jackson/ESM4/DECK/ESM4_historical_D1/gfdl.ncrc4-intel16-prod-openmp/pp/"
+  pod_list:
+  #- Wheeler_Kiladis
+  - EOF_500hPa
+  #- MJO_suite
+  #- MJO_teleconnection
+  #- precip_diurnal_cycle
+  #- ENSO_RWS
+  #- SM_ET_coupling
+  #- convective_transition_diag
+  #- MJO_prop_amp
+  #- ENSO_MSE
+  #- temp_extremes_distshape
+  #- precip_buoy_diag
+  #- eulerian_storm_track
+MODEL_DATA_ROOT: "$MDTF_TMPDIR/inputdata/model"
+OBS_DATA_REMOTE: "/home/oar.gfdl.mdtf/mdtf/inputdata/obs_data"
+OBS_DATA_ROOT: "$MDTF_TMPDIR/inputdata/obs_data"
+WORKING_DIR: "$MDTF_TMPDIR/wkdir"
+OUTPUT_DIR: "$MDTF_TMPDIR/mdtf_out"
+GFDL_PPAN_TEMP: "$TMPDIR"
+GFDL_WS_TEMP: "/net2/$USER/tmp"
+frepp: false
+ignore_component: false
+data_manager: GFDL_PP
+file_transfer_timeout: 900
+keep_temp: false
+environment_manager: conda
+conda_root: "/home/oar.gfdl.mdtf/miniconda3"
+conda_env_root: "/home/oar.gfdl.mdtf/miniconda3/envs"
+venv_root: "./envs/venv"
+r_lib_root: "./envs/r_libs"
+save_ps: false
+save_nc: false
+make_variab_tar: false
+overwrite: false
+verbose: 1
+test_mode: false
+dry_run: false

--- a/src/cli.py
+++ b/src/cli.py
@@ -1095,11 +1095,11 @@ class MDTFTopLevelArgParser(MDTFArgParser):
             raise ValueError()
         if not str_:
             return
-        # try to determine if file is json
-        if 'json' in os.path.splitext(path)[1].lower():
-            # assume config_file a JSON dict of option:value pairs.
+        # try to determine if file is json or yml
+        if any(x in os.path.splitext(path)[1].lower() for x in ["json", "yml"]):
+            # assume config_file a JSON or YAML dict of option:value pairs.
             try:
-                d = util.parse_json(str_)
+                d = util.parse_serialization_stream(str_)
                 self.file_case_list = d.pop('case_list', [])
                 d = {canonical_arg_name(k): v for k,v in d.items()}
                 config.user_defaults.update(d)

--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -21,7 +21,7 @@ from .exceptions import *
 from .filesystem import (
     abbreviate_path, resolve_path, recursive_copy,
     check_executable, find_files, check_dir, bump_version, strip_comments,
-    parse_json, read_json, find_json, write_json, pretty_print_json,
+    parse_serialization_stream, read_json, find_json, write_json, pretty_print_json,
     append_html_template
     # is_subpath,
 )

--- a/src/util/exceptions.py
+++ b/src/util/exceptions.py
@@ -300,7 +300,7 @@ class PodExceptionBase(MDTFBaseException):
 class PodConfigError(PodExceptionBase):
     """Exception raised if we can't parse info in a POD's settings.jsonc file.
     (Covers issues with the file format/schema; malformed JSONC will raise a
-    :py:class:`~json.JSONDecodeError` when :func:`~util.parse_json` attempts to
+    :py:class:`~json.JSONDecodeError` when :func:`~util._parse_json` attempts to
     parse the file.
     """
     _error_str = "Couldn't parse the settings.jsonc file"

--- a/src/util/tests/test_filesystem.py
+++ b/src/util/tests/test_filesystem.py
@@ -109,7 +109,7 @@ class TestBumpVersion(unittest.TestCase):
     #         self.assertEqual(ver, f[2])
 
 class TestJSONC(unittest.TestCase):
-    def test_parse_json_basic(self):
+    def test_parse_serialization_stream(self):
         s = """{
             "a" : "test_string",
             "b" : 3,
@@ -121,7 +121,7 @@ class TestJSONC(unittest.TestCase):
             }
         }
         """
-        d = util.parse_json(s)
+        d = util.parse_serialization_stream(s)
         self.assertEqual(set(d.keys()), set(['a','b','c','d','e']))
         self.assertEqual(d['a'], "test_string")
         self.assertEqual(d['b'], 3)
@@ -149,7 +149,7 @@ class TestJSONC(unittest.TestCase):
         } // comment 7
 
         """
-        d = util.parse_json(s)
+        d = util.parse_serialization_stream(s)
         self.assertEqual(set(d.keys()), set(['a','b // c','e','f']))
         self.assertEqual(d['a'], 1)
         self.assertEqual(d['b // c'], "// d x ////")
@@ -160,7 +160,7 @@ class TestJSONC(unittest.TestCase):
         s = 'SYNTAX_ERROR\n{"a": 1, "e": false}'
         try:
             flag = False
-            _ = util.parse_json(textwrap.dedent(s))
+            _ = util.parse_serialization_stream(textwrap.dedent(s))
         except json.JSONDecodeError as exc:
             flag = True
             self.assertEqual(exc.lineno, 1)
@@ -171,7 +171,7 @@ class TestJSONC(unittest.TestCase):
         # missing ',' triggers on first " in "e"
         try:
             flag = False
-            _ = util.parse_json(textwrap.dedent(s))
+            _ = util.parse_serialization_stream(textwrap.dedent(s))
         except json.JSONDecodeError as exc:
             flag = True
             self.assertEqual(exc.lineno, 1)
@@ -182,7 +182,7 @@ class TestJSONC(unittest.TestCase):
         # missing ',' triggers on first " in "e"
         try:
             flag = False
-            _ = util.parse_json(textwrap.dedent(s))
+            _ = util.parse_serialization_stream(textwrap.dedent(s))
         except json.JSONDecodeError as exc:
             flag = True
             self.assertEqual(exc.lineno, 2)
@@ -201,7 +201,7 @@ class TestJSONC(unittest.TestCase):
         """
         try:
             flag = False
-            _ = util.parse_json(textwrap.dedent(s))
+            _ = util.parse_serialization_stream(textwrap.dedent(s))
         except json.JSONDecodeError as exc:
             flag = True
             self.assertEqual(exc.lineno, 9)
@@ -219,7 +219,7 @@ class TestJSONC(unittest.TestCase):
         # missing ',' triggers on first " in "e"
         try:
             flag = False
-            _ = util.parse_json(textwrap.dedent(s))
+            _ = util.parse_serialization_stream(textwrap.dedent(s))
         except json.JSONDecodeError as exc:
             flag = True
             self.assertEqual(exc.lineno, 6)


### PR DESCRIPTION
**Description**
- Framework will attempt to read supplied configuration
  files as YAML format first, then falls back to JSON if needed
- Change should be backward-compatible with existing .jsonc files
- Added a new `parse_serialization_stream` function and private
  `_parse_yaml` function
- Renamed existing `parse_json` to a private `_parse_json`
- Updated doc references and unittests

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Sample NOAA_GFDL user config supplied in YAML format

**Checklist:**
- [x ] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [x ] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [ x] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
