### PR TITLE
Support for preferred GFDL frepp components

### DIFF
--- a/sites/NOAA_GFDL/gfdl.py
+++ b/sites/NOAA_GFDL/gfdl.py
@@ -504,12 +504,12 @@ class GfdlppDataManager(GFDL_GCP_FileDataSourceBase):
         assert (hasattr(self, 'attrs') and hasattr(self.attrs, 'CASE_ROOT_DIR'))
         return self.attrs.CASE_ROOT_DIR
 
-    def _filter_column(self, df, col_name, func, obj_name):
+    def _filter_column(self, df, col_name, func, obj_name, preferred=None):
         values = list(df[col_name].drop_duplicates())
         if len(values) <= 1:
             # unique value, no need to filter
             return df
-        filter_val = func(values)
+        filter_val = func(values, preferred=preferred)
         self.log.debug("Selected experiment attribute %s='%s' for %s (out of %s).",
             col_name, filter_val, obj_name, values)
         return df[df[col_name] == filter_val]
@@ -541,8 +541,11 @@ class GfdlppDataManager(GFDL_GCP_FileDataSourceBase):
             component with the fewest words (separated by '_'), or, failing that,
             the shortest overall name.
         """
-        def _heuristic_tiebreaker(str_list):
+        def _heuristic_tiebreaker(str_list, preferred=None):
+            """Internal function to resolve multiple possible attributes"""
+
             def _heuristic_tiebreaker_sub(strs):
+                """sub-function to selected the shortest attribute"""
                 min_len = min(len(s.split('_')) for s in strs)
                 strs2 = [s for s in strs if (len(s.split('_')) == min_len)]
                 if len(strs2) == 1:
@@ -550,14 +553,43 @@ class GfdlppDataManager(GFDL_GCP_FileDataSourceBase):
                 else:
                     return min(strs2, key=len)
 
+            # filter by the preferred list if provided
+            if preferred is not None:
+                assert isinstance(preferred, list)
+                str_list = [x for x in preferred if x in str_list]
+
+                # select the first matching value from the preferred list
+                if len(str_list) >= 1:
+                    str_list = [str_list[0]]
+
+            # determine if any of the attributes contain the text `cmip`
             cmip_list = [s for s in str_list if ('cmip' in s.lower())]
+
+            # give preference to attributes that contain the substring `cmip`
             if cmip_list:
                 return _heuristic_tiebreaker_sub(cmip_list)
+
+            # otherwise, select the shortest attribute
             else:
                 return _heuristic_tiebreaker_sub(str_list)
 
         if 'component' in self.col_spec.pod_expt_cols.cols:
-            df = self._filter_column(df, 'component', _heuristic_tiebreaker, obj.name)
+
+            # loop over pods and get the preferred components
+            preferred = []
+            for pod in self.pods.values():
+                for var in pod.varlist.vars:
+                    _component = var.gfdl_component
+                    _component = [] if len(_component) == 0 else str(_component).split(",")
+                    preferred.append(_component)
+
+            # find the intersection of preferred components
+            preferred = list(set.intersection(*map(set,[x for x in preferred if x])))
+            preferred = preferred if len(preferred) >= 0 else None
+
+            # filter the dataframe of possible components
+            df = self._filter_column(df, 'expt_key', _heuristic_tiebreaker, obj.name, preferred=preferred)
+
         # otherwise no-op
         return df
 

--- a/sites/NOAA_GFDL/gfdl.py
+++ b/sites/NOAA_GFDL/gfdl.py
@@ -579,7 +579,7 @@ class GfdlppDataManager(GFDL_GCP_FileDataSourceBase):
             preferred = []
             for pod in self.pods.values():
                 for var in pod.varlist.vars:
-                    _component = var.gfdl_component
+                    _component = var.component
                     if len(_component) > 0:
                         _component = str(_component).split(",")
                         preferred = preferred + _component

--- a/sites/NOAA_GFDL/gfdl.py
+++ b/sites/NOAA_GFDL/gfdl.py
@@ -580,12 +580,16 @@ class GfdlppDataManager(GFDL_GCP_FileDataSourceBase):
             for pod in self.pods.values():
                 for var in pod.varlist.vars:
                     _component = var.gfdl_component
-                    _component = [] if len(_component) == 0 else str(_component).split(",")
-                    preferred.append(_component)
+                    if len(_component) > 0:
+                        _component = str(_component).split(",")
+                        preferred = preferred + _component
 
             # find the intersection of preferred components
-            preferred = list(set.intersection(*map(set,[x for x in preferred if x])))
-            preferred = preferred if len(preferred) >= 0 else None
+            if len(preferred) > 0:
+                # preserves preference order
+                preferred = list(dict.fromkeys(preferred))
+            else:
+                preferred = None
 
             # filter the dataframe of possible components
             df = self._filter_column(df, 'expt_key', _heuristic_tiebreaker, obj.name, preferred=preferred)

--- a/src/data_manager.py
+++ b/src/data_manager.py
@@ -412,6 +412,11 @@ class DataSourceBase(core.MDTFObjectBase, util.CaseLoggerMixin,
             # store but don't deactivate, because preprocessor.edit_request()
             # may supply alternate variables
             v.log.store_exception(chained_exc)
+
+        # copy preferred gfdl post-processing component during translation
+        if hasattr(trans_v,"gfdl_component"):
+            v.gfdl_component = trans_v.gfdl_component
+
         v.stage = diagnostic.VarlistEntryStage.INITED
 
     def variable_dest_path(self, pod, var):

--- a/src/data_manager.py
+++ b/src/data_manager.py
@@ -400,8 +400,8 @@ class DataSourceBase(core.MDTFObjectBase, util.CaseLoggerMixin,
             trans_v = translate.translate(v)
             v.translation = trans_v
             # copy preferred gfdl post-processing component during translation
-            if hasattr(trans_v, "gfdl_component"):
-                v.gfdl_component = trans_v.gfdl_component
+            if hasattr(trans_v, "component"):
+                v.component = trans_v.component
         except KeyError as exc:
             # can happen in normal operation (eg. precip flux vs. rate)
             chained_exc = util.PodConfigEvent((f"Deactivating {v.full_name} due to "

--- a/src/data_manager.py
+++ b/src/data_manager.py
@@ -399,6 +399,9 @@ class DataSourceBase(core.MDTFObjectBase, util.CaseLoggerMixin,
         try:
             trans_v = translate.translate(v)
             v.translation = trans_v
+            # copy preferred gfdl post-processing component during translation
+            if hasattr(trans_v, "gfdl_component"):
+                v.gfdl_component = trans_v.gfdl_component
         except KeyError as exc:
             # can happen in normal operation (eg. precip flux vs. rate)
             chained_exc = util.PodConfigEvent((f"Deactivating {v.full_name} due to "
@@ -412,10 +415,6 @@ class DataSourceBase(core.MDTFObjectBase, util.CaseLoggerMixin,
             # store but don't deactivate, because preprocessor.edit_request()
             # may supply alternate variables
             v.log.store_exception(chained_exc)
-
-        # copy preferred gfdl post-processing component during translation
-        if hasattr(trans_v,"gfdl_component"):
-            v.gfdl_component = trans_v.gfdl_component
 
         v.stage = diagnostic.VarlistEntryStage.INITED
 

--- a/src/data_model.py
+++ b/src/data_model.py
@@ -611,6 +611,7 @@ class DMDependentVariable(_DMDimensionsMixin):
     standard_name: str = util.MANDATORY
     units: src.units.Units = ""  # not MANDATORY since may be set later from var translation
     modifier: str = ""
+    gfdl_component: str = ""
     # dims: from _DMDimensionsMixin
     # scalar_coords: from _DMDimensionsMixin
 

--- a/src/data_model.py
+++ b/src/data_model.py
@@ -611,7 +611,7 @@ class DMDependentVariable(_DMDimensionsMixin):
     standard_name: str = util.MANDATORY
     units: src.units.Units = ""  # not MANDATORY since may be set later from var translation
     modifier: str = ""
-    gfdl_component: str = ""
+    component: str = ""
     # dims: from _DMDimensionsMixin
     # scalar_coords: from _DMDimensionsMixin
 


### PR DESCRIPTION
**Description**

- allows for `gfdl_component` to be specified in a
  fieldlist*.jsonc file
- `gfdl_component` is a comma-separated string of
  GFDL frepp components in preferential order
- Preferred components are honored before the other
  existing heuristics
- Changed "component" to "expt_key" in GFDL
  `resolve_pod_expt` (not sure how this worked before,
  possible bug?)

Associated issue #335

**How Has This Been Tested?**

- Added optional `gfdl_component` to `fieldlist_CMIP.jsonc`:

```
    "sos": {
      "standard_name": "sea_surface_salinity",
      "units": "psu",
      "ndim": 3,
      "gfdl_component": "ocean_monthly_1x1deg"
    },
    "tos": {
      "standard_name": "sea_surface_temperature",
      "units": "degC",
      "ndim": 3,
      "gfdl_component": "ocean_monthly_1x1deg,ocean_monthly"
    },
```
- Ran the example diagnostic and requested tos, sos

**Checklist:**
- [x] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [x] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [x] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [x] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
