### PR TITLE
Remove OM4labs and dependencies from MDTF base yaml

### DIFF
--- a/src/conda/env_base.yml
+++ b/src/conda/env_base.yml
@@ -26,16 +26,3 @@ dependencies:
 # bump version 0.3.1 -> 0.4 feb 2021
 - cf_xarray=0.4.0
 - subprocess32
-- pcmdi_metrics=2.2.2
-- h5py=3.6.0
-- pip=22.0.4
-- pip:
-    - cmocean
-    - regionmask
-    - git+https://github.com/raphaeldussin/static_downsampler
-    - git+https://github.com/jkrasting/xcompare
-    - git+https://github.com/raphaeldussin/xoverturning
-    - git+https://github.com/jkrasting/xwavelet
-    - git+https://github.com/jetesdal/xwmt
-    - git+https://github.com/raphaeldussin/om4labs
-

--- a/src/conda/env_python3_base.yml
+++ b/src/conda/env_python3_base.yml
@@ -25,3 +25,15 @@ dependencies:
 - esmpy=8.2.0
 - gsw=3.3
 - metpy=1.1
+- pcmdi_metrics=2.2.2
+- h5py=3.6.0
+- pip=22.0.4
+- pip:
+    - cmocean
+    - regionmask
+    - git+https://github.com/raphaeldussin/static_downsampler
+    - git+https://github.com/jkrasting/xcompare
+    - git+https://github.com/raphaeldussin/xoverturning
+    - git+https://github.com/jkrasting/xwavelet
+    - git+https://github.com/jetesdal/xwmt
+    - git+https://github.com/raphaeldussin/om4labs


### PR DESCRIPTION
**Description**
Move OM4labs packages and dependencies from env_base.yml to env_python3_base.yml

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [ ] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [ ] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
