### PR TITLE
Frepp wrapper for MDTF

### DIFF
--- a/sites/NOAA_GFDL/mdtf_frepp_template.jsonc
+++ b/sites/NOAA_GFDL/mdtf_frepp_template.jsonc
@@ -1,0 +1,137 @@
+// Configuration for MDTF-diagnostics driver script.
+//
+// All text to the right of an unquoted "//" is a comment and ignored, as well
+// as blank lines (JSONC quasi-standard.)
+//
+// Copy this file and customize the setting values as needed. Pass it to the
+// framework at the end of the command line (positionally) or with the
+// -f/--config-file flag.
+//
+{
+  // The cases below correspond to the different test data sets.
+  //
+  // Note that the mdtf package does not yet handle multiple cases.
+  //
+  "case_list" : [
+    {
+      "CASENAME" : "CASENAME1",
+      "model" : "MODEL1",
+      "convention" : "CONVENTION1",
+      "experiment" : "CASENAME1",
+      "FIRSTYR" : FIRSTYR1,
+      "LASTYR" : LASTYR1,
+      "CASE_ROOT_DIR" : "PPDIR1/",
+      "pod_list": [
+              POD_LIST
+      ]
+    }
+  ],
+  // PATHS ---------------------------------------------------------------------
+  // Location of input and output data. If a relative path is given, it's
+  // resolved relative to the MDTF-diagnostics code directory.
+  // set this to somewhere writeable with sufficient space for copies of input data
+  //"MDTF_TMPDIR": "/net2/jml/tmp",
+  // Parent directory containing results from different models.
+  "MODEL_DATA_ROOT": "$MDTF_TMPDIR/inputdata/model",
+
+  // Site-specific installation of observational data used by individual PODs.
+  // This will be GCP'ed locally if running on PPAN.
+  //"OBS_DATA_REMOTE": "/home/oar.gfdl.mdtf/mdtf/inputdata/obs_data",
+  "OBS_DATA_REMOTE": "/archive/wnd/MDTF-GFDL/inputdata/obs_data",
+
+  // Parent directory containing observational data used by individual PODs.
+  "OBS_DATA_ROOT": "$MDTF_TMPDIR/inputdata/obs_data",
+
+  // Working directory.
+  "WORKING_DIR": "$MDTF_TMPDIR/wkdir",
+
+  // Directory to write output files. Defaults to working directory if blank.
+  //"OUTPUT_DIR": "$MDTF_TMPDIR/mdtf_out",
+  "OUTPUT_DIR": "OUTPUTDIR1",
+
+  // GFDL ----------------------------------------------------------------------
+  // Settings specific to operation at GFDL.
+
+  // If running on GFDL PPAN, set $MDTF_TMPDIR to this location and
+  // create temp files here. Must be accessible via gcp.
+  "GFDL_PPAN_TEMP": "$TMPDIR",
+
+  // If running on a GFDL workstation, set $MDTF_TMPDIR to this location
+  // and create temp files here. Must be accessible via gcp.
+  //"GFDL_WS_TEMP": "$MDTF_TMPDIR",
+  "GFDL_WS_TEMP": "/archive/$USER/tmp",
+
+  // Set flag to run framework in 'online' mode, processing data as part of the
+  // FRE pipeline. Normally this is done by calling the mdtf_gfdl.csh wrapper
+  // script from the XML.
+  "frepp": false,
+
+  // Set flag search entire /pp/ directory for model data; default is to
+  // restrict to model component passed by FRE. Ignored if --frepp is not set.
+  "ignore_component": false,
+
+  // DATA ----------------------------------------------------------------------
+  // Settings affecting the framework's retrieval of model data.
+
+  // Method used to fetch model data.
+  "data_manager": "GFDL_PP",
+
+  // Time (in seconds) to wait before giving up on transferring a data file to
+  // the local filesystem. Set to zero to disable.
+  "file_transfer_timeout": 900,
+
+  // Set to true to retain local temp directories of downloaded data.
+  "keep_temp": false,
+
+  // RUNTIME -------------------------------------------------------------------
+  // Settings affecting the runtime environment of the PODs.
+  "environment_manager": "conda",
+
+  // Path to the Anaconda installation. Only used if environment_manager='Conda'.
+  // Set equal to "" to use conda from your system's $PATH.
+  "conda_root": "/home/oar.gfdl.mdtf/miniconda3",
+
+  // Root directory for Anaconda environment installs. Only used if
+  // environment_manager = 'Conda'. Set equal to '' to install in your system's
+  // default location.
+  "conda_env_root": "/home/oar.gfdl.mdtf/miniconda3/envs",
+
+  // Root directory for python virtual environments. Only used if
+  // environment_manager = 'Virtualenv'. Set equal to '' to install in your
+  // system's default location.
+  "venv_root": "./envs/venv",
+
+  // Root directory for R packages requested by PODs. Only used if
+  // environment_manager = 'Virtualenv'. Set equal to '' to install in your
+  // system library.
+  "r_lib_root": "./envs/r_libs",
+
+  // OUTPUT --------------------------------------------------------------------
+  // Settings affecting what output is generated.
+
+  // Set flag to have PODs save postscript figures in addition to bitmaps.
+  "save_ps": false,
+
+  // Set flag to have PODs save netCDF files of processed data.
+  "save_nc": false,
+
+  // Set flag to save HTML and bitmap plots in a .tar file.
+  "make_variab_tar": false,
+
+  // Set flag to overwrite results in OUTPUT_DIR; otherwise results saved under
+  // a unique name.
+  "overwrite": false,
+
+  // DEBUG ---------------------------------------------------------------------
+  // Settings used in debugging.
+
+  // Log verbosity level.
+  "verbose": 1,
+
+  // Set flag for framework test. Data is fetched but PODs are not run.
+  "test_mode": false,
+
+  // Set flag for framework test. No external commands are run and no remote
+  // data is copied. Implies test_mode.
+  "dry_run": false
+}

--- a/sites/NOAA_GFDL/mdtf_frepp_template.jsonc
+++ b/sites/NOAA_GFDL/mdtf_frepp_template.jsonc
@@ -66,6 +66,9 @@
   // script from the XML.
   "frepp": false,
 
+// Allow the framework to pull files/variables from multiple components
+"any_components": true,
+
   // Set flag search entire /pp/ directory for model data; default is to
   // restrict to model component passed by FRE. Ignored if --frepp is not set.
   "ignore_component": false,

--- a/sites/NOAA_GFDL/mdtf_gfdl.csh
+++ b/sites/NOAA_GFDL/mdtf_gfdl.csh
@@ -190,7 +190,7 @@ end if
 
 if (! -d $PP_DIR) then 
   echo "QUIT if PP_DIR is not valid"
- 
+end if
 echo "Running ${REPO_DIR}/mdtf_framework.py -f ${input_jsonc} --site NOAA_GFDL -v "
 ${REPO_DIR}/mdtf_framework.py -f ${input_jsonc} --site NOAA_GFDL -v
 

--- a/sites/NOAA_GFDL/mdtf_gfdl.csh
+++ b/sites/NOAA_GFDL/mdtf_gfdl.csh
@@ -186,6 +186,7 @@ gcp -cd $input_jsonc ${out_dir}/
 
 if (! -d $in_data_dir) then
   echo "QUIT if in_data_dir is not valid"
+end if
 
 if (! -d $PP_DIR) then 
   echo "QUIT if PP_DIR is not valid"

--- a/sites/NOAA_GFDL/mdtf_gfdl.csh
+++ b/sites/NOAA_GFDL/mdtf_gfdl.csh
@@ -157,11 +157,8 @@ wipetmp
 
 ## run the command
 echo "mdtf_gfdl.csh: conda activate"
-#throws errors source "${REPO_DIR}/src/conda/conda_init.sh" -q "/home/oar.gfdl.mdtf/miniconda3"
 source /home/oar.gfdl.mdtf/miniconda3/etc/profile.d/conda.csh
 conda activate _MDTF_base
-
-conda activate "${CONDA_ROOT}/envs/_MDTF_base"
 
 echo "mdtf_gfdl.csh: MDTF start"
 

--- a/sites/NOAA_GFDL/mdtf_gfdl.csh
+++ b/sites/NOAA_GFDL/mdtf_gfdl.csh
@@ -25,11 +25,24 @@ set dataendyr
 set datachunk
 set staticfile
 set fremodule
+set conv = GFDL
+set model = "modelname"
+
+# Please enter the POD lists below. This gets filled in to the MDTF input json automatically if using frepp
+#this is tested with one POD only at this time
+
+set pod_list = '"EOF_500hPa"'
+
 set script_path
 
 ## set paths to site installation
 set CONDA_ROOT="/home/oar.gfdl.mdtf/miniconda3"
 set REPO_DIR="/home/oar.gfdl.mdtf/mdtf/MDTF-diagnostics"
+
+#YOUR mdtf-frepp template jsonc should be in ${TEMPLATE_DIR}/sites/NOAA_GFDL/mdtf_frepp_template.jsonc
+ 
+set TEMPLATE_DIR = $REPO_DIR  
+
 set OBS_DATA_DIR="/home/oar.gfdl.mdtf/mdtf/inputdata/obs_data"
 # output is always written to $out_dir; set a path below to GCP a copy of output
 # for purposes of serving from a website
@@ -144,26 +157,47 @@ wipetmp
 
 ## run the command
 echo "mdtf_gfdl.csh: conda activate"
-source "${REPO_DIR}/src/conda/conda_init.sh" -q "/home/oar.gfdl.mdtf/miniconda3"
+#throws errors source "${REPO_DIR}/src/conda/conda_init.sh" -q "/home/oar.gfdl.mdtf/miniconda3"
+source /home/oar.gfdl.mdtf/miniconda3/etc/profile.d/conda.csh
+conda activate _MDTF_base
+
 conda activate "${CONDA_ROOT}/envs/_MDTF_base"
 
 echo "mdtf_gfdl.csh: MDTF start"
 
-"${REPO_DIR}/mdtf_framework.py" \
---site="NOAA_GFDL" \
-$frepp_flag:q \
---MODEL_DATA_ROOT "${INPUT_DIR}/model" \
---OBS_DATA_ROOT "${INPUT_DIR}/obs_data" \
---WORKING_DIR "$WK_DIR" \
---OUTPUT_DIR "$out_dir" \
---data_manager "GFDL_PP" \
---environment_manager "GFDL_conda" \
---CASENAME "$descriptor" \
---CASE_ROOT_DIR "$PP_DIR" \
---FIRSTYR $yr1 \
---LASTYR $yr2 \
-$passed_args:q
+###### workaround to create input json based on a template json and the frepp template variables ####
+set template_jsonc = ${TEMPLATE_DIR}/sites/NOAA_GFDL/mdtf_frepp_template.jsonc
 
+gcp -cd $template_jsonc $WK_DIR/
+echo "A copy of the input json can be found in outputdir as well ${out_dir}/" #TODO move under corresponding exp directory
+
+
+set input_jsonc = ${WK_DIR}/mdtf_frepp_template.jsonc
+
+sed -i 's/CASENAME1/'${descriptor}'/g' $input_jsonc
+sed -i 's/MODEL1/'${model}'/g' $input_jsonc
+sed -i 's|PPDIR1|'{$PP_DIR}'|' $input_jsonc
+sed -i 's/FIRSTYR1/'${yr1}'/g' $input_jsonc
+sed -i 's/LASTYR1/'${yr2}'/g' $input_jsonc
+sed -i 's|OUTPUTDIR1|'${out_dir}'|' $input_jsonc
+sed -i 's/CONVENTION1/'${conv}'/g' $input_jsonc
+sed -i 's/POD_LIST/'${pod_list}'/g' $input_jsonc
+
+echo "Filled in input settings json and using this for the MDTF run $input_jsonc"
+
+gcp -cd $input_jsonc ${out_dir}/
+
+if (! -d $in_data_dir) then
+  echo "QUIT if in_data_dir is not valid"
+
+if (! -d $PP_DIR) then 
+  echo "QUIT if PP_DIR is not valid"
+ 
+echo "Running ${REPO_DIR}/mdtf_framework.py -f ${input_jsonc} --site NOAA_GFDL -v "
+${REPO_DIR}/mdtf_framework.py -f ${input_jsonc} --site NOAA_GFDL -v
+
+
+##workaround ends 
 pkg_status=$?
 echo "mdtf_gfdl.csh: MDTF finish; exit={$pkg_status}"
 


### PR DESCRIPTION
**Description**

GFDL MDTF FREPP wrapper script update, includes a gfdl mdtf frepp template jsonc.

Associated issue #349  

**How Has This Been Tested?**
Yes

**Checklist:**
- [ ] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [ ] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [ ] The script are written in Python 3.6 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
