### PR TITLE
define _tags kwarg as an 'extra' kwarg

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -888,12 +888,12 @@ class MDTFFramework(MDTFObjectBase):
 
         if cli_obj.config.get('disable_preprocessor', False):
             _log.warning(("User disabled metadata checks and unit conversion in "
-                "preprocessor."), tags=util.ObjectLogTag.BANNER)
+                "preprocessor."),  extra={'tags': {util.ObjectLogTag.BANNER}})
         if cli_obj.config.get('overwrite_file_metadata', False):
             _log.warning(("User chose to overwrite input file metadata with "
                 "framework values (convention = '%s')."),
                 cli_obj.config.get('convention', ''),
-                tags=util.ObjectLogTag.BANNER
+                extra={'tags': {util.ObjectLogTag.BANNER}}
             )
         # check this here, otherwise error raised about missing caselist is not informative
         try:


### PR DESCRIPTION
**Description**
Resolve error when `_tags` argument is passed to logger:
```
TypeError: _log() got an unexpected keyword argument 'tags'
```
by defining it as a nested 'extra' keyword argument as explained [here](https://forum.sentry.io/t/how-to-add-tags-to-python-logging/323/4)
Associated issue #352 
**How Has This Been Tested?**
Tested with Python 3.7 on Linux OS with latest main branch updates using `--disable-preprocessor` option
**Checklist:**
- [x] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [x] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.7 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [x] The repository contains no extra test scripts or data files
