### PR TITLE
Update CM4_proto_diag_table.txt

### DIFF
--- a/sites/NOAA_GFDL/CM4_proto_diag_table.txt
+++ b/sites/NOAA_GFDL/CM4_proto_diag_table.txt
@@ -32,7 +32,7 @@
 "dynamics",      "temp",   "temp",           "atmos_month",   "all",  .true.,  "none", 2
 "dynamics",      "sphum",  "sphum",          "atmos_month",   "all",  .true.,  "none", 2
 "moist",         "pr",      "pr",            "atmos_month",   "all",  .true.,  "none", 2
-"moist",         "prw",     "pw",            "atmos_month",   "all",  .true.,  "none", 2
+"moist",         "prw",     "prw",            "atmos_month",   "all",  .true.,  "none", 2
 "flux",          "evspsbl", "evspsbl",       "atmos_month",   "all",  .true.,  "none", 2
 "flux",          "psl",     "psl",           "atmos_month",   "all",  .true.,  "none", 2
 "flux",          "t_surf",  "t_surf",        "atmos_month",   "all",  .true.,  "none", 2
@@ -62,7 +62,7 @@
 "land",        "geolat_t",   "geolat_t",    "land_month_cmip", "all", .false., "none", 1
 "cmor_land",   "mrsos",      "mrsos",       "land_month_cmip",    "all",  .true.,  "none", 2
 
---------------------------------------------------------------------------------------------------
+#--------------------------------------------------------------------------------------------------
 #-- Daily Data
 #--------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
There are two typos in the CM4_proto_diag_table.txt that are fixed. 
L35, "pw" should be "prw"
L65, missing # at the beginning

**Description**
There are two typos in the CM4_proto_diag_table.txt that are fixed. thanks to @Wen-hao-Dong 

Associated issue #374 

**How Has This Been Tested?**
@Wen-hao-Dong's GFDL internal testing. 

**Checklist:**
- [x] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [ ] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.7 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
