### PR TITLE
Toggle control of coordinate renaming via `rename_coords` attribute

### DIFF
--- a/src/data_manager.py
+++ b/src/data_manager.py
@@ -403,6 +403,8 @@ class DataSourceBase(core.MDTFObjectBase, util.CaseLoggerMixin,
             # copy preferred gfdl post-processing component during translation
             if hasattr(trans_v, "component"):
                 v.component = trans_v.component
+            if hasattr(trans_v,"rename_coords"):
+                v.rename_coords = trans_v.rename_coords
         except KeyError as exc:
             # can happen in normal operation (eg. precip flux vs. rate)
             chained_exc = util.PodConfigEvent((f"Deactivating {v.full_name} due to "

--- a/src/data_model.py
+++ b/src/data_model.py
@@ -673,6 +673,7 @@ class DMDependentVariable(_DMDimensionsMixin):
     modifier: str = ""
     component: str = ""
     associated_files: str = ""
+    rename_coords: bool = True
     # dims: from _DMDimensionsMixin
     # scalar_coords: from _DMDimensionsMixin
 

--- a/src/diagnostic.py
+++ b/src/diagnostic.py
@@ -796,9 +796,12 @@ class Diagnostic(core.MDTFObjectBase, util.PODLoggerMixin):
             try:
                 self.pod_env_vars.update(var.env_vars)
             except util.WormKeyError as exc:
-                raise util.WormKeyError((f"{var.full_name} defines coordinate names "
-                    f"that conflict with those previously set. (Tried to update "
-                    f"{self.pod_env_vars} with {var.env_vars}.)")) from exc
+                if var.rename_coords is False:
+                    pass
+                else:
+                    raise util.WormKeyError((f"{var.full_name} defines coordinate names "
+                        f"that conflict with those previously set. (Tried to update "
+                        f"{self.pod_env_vars} with {var.env_vars}.)")) from exc
         for var in self.iter_children(status_neq=core.ObjectStatus.SUCCEEDED):
             # define env vars for varlist entries without data. Name collisions
             # are OK in this case.

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -408,8 +408,15 @@ class RenameVariablesFunction(PreprocessorFunctionBase):
             rename_d[tv.name] = var.name
             tv.name = var.name
 
+        # if `rename_coords` is False, only process the time coordinate
+        dim_axes = list(tv.dim_axes.values())
+        if tv.rename_coords is False:
+            dim_axes = [
+                x for x in dim_axes if isinstance(x,diagnostic.VarlistTimeCoordinate)
+            ]
+
         # rename coords
-        for c in tv.dim_axes.values():
+        for c in dim_axes:
             dest_c = var.axes[c.axis]
             if c.name != dest_c.name:
                 var.log.debug("Rename %s axis of %s from '%s' to '%s'.",
@@ -418,7 +425,7 @@ class RenameVariablesFunction(PreprocessorFunctionBase):
                 )
                 rename_d[c.name] = dest_c.name
                 c.name = dest_c.name
-        # TODO: bounds??
+        ## TODO: bounds??
 
         # rename scalar coords
         for c in tv.scalar_coords:


### PR DESCRIPTION
**Description**
This PR address issue #371 and allows for more control over the preprocessor when it comes to renaming coordinate variables.

**How Has This Been Tested?**
Basic CI suite along with an `om4labs` POD branch that is currently in development.

**Checklist:**
- [x] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [x] My branch is up-to-date with the NOAA-GFDL develop branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.7 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] If applicable, I've added a .yml file to src/conda, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [x] The repository contains no extra test scripts or data files
