### PR TITLE
add nc-time-axis to python3 yaml

### DIFF
--- a/src/conda/env_base.yml
+++ b/src/conda/env_base.yml
@@ -12,7 +12,7 @@ dependencies:
 - numpy=1.19
 # - scipy=1.5.2
 - netCDF4=1.5.8
-- cftime>=1.5
+- cftime>=1.6
 - xarray=0.16
 - matplotlib=3.3
 # - cartopy=0.18

--- a/src/conda/env_base.yml
+++ b/src/conda/env_base.yml
@@ -12,7 +12,7 @@ dependencies:
 - numpy=1.19
 # - scipy=1.5.2
 - netCDF4=1.5.4
-- cftime=1.2
+- cftime>=1.5
 - xarray=0.16
 - matplotlib=3.3
 # - cartopy=0.18

--- a/src/conda/env_base.yml
+++ b/src/conda/env_base.yml
@@ -20,7 +20,7 @@ dependencies:
 - pint=0.16
 - dask=2.30
 # additions dec 2020
-- cfunits=3.3.1
+- cfunits>=3.3.4
 - intake=0.6
 - intake-esm=2020.11.4
 # bump version 0.3.1 -> 0.4 feb 2021

--- a/src/conda/env_base.yml
+++ b/src/conda/env_base.yml
@@ -11,8 +11,8 @@ dependencies:
 - ghostscript
 - numpy=1.19
 # - scipy=1.5.2
-- netCDF4=1.5.8
-- cftime>=1.6
+- netCDF4=1.5.4
+- cftime=1.2
 - xarray=0.16
 - matplotlib=3.3
 # - cartopy=0.18
@@ -20,7 +20,7 @@ dependencies:
 - pint=0.16
 - dask=2.30
 # additions dec 2020
-- cfunits>=3.3.4
+- cfunits=3.3.1
 - intake=0.6
 - intake-esm=2020.11.4
 # bump version 0.3.1 -> 0.4 feb 2021

--- a/src/conda/env_base.yml
+++ b/src/conda/env_base.yml
@@ -11,7 +11,7 @@ dependencies:
 - ghostscript
 - numpy=1.19
 # - scipy=1.5.2
-- netCDF4=1.5.4
+- netCDF4=1.5.8
 - cftime>=1.5
 - xarray=0.16
 - matplotlib=3.3

--- a/src/conda/env_python3_base.yml
+++ b/src/conda/env_python3_base.yml
@@ -11,7 +11,7 @@ dependencies:
 - numpy=1.19
 - scipy=1.5.2
 - netCDF4=1.5.8
-- cftime=1.2
+- cftime>=1.5
 - xarray=0.16
 - matplotlib=3.3
 - pandas<1.3

--- a/src/conda/env_python3_base.yml
+++ b/src/conda/env_python3_base.yml
@@ -28,6 +28,7 @@ dependencies:
 - pcmdi_metrics=2.2.2
 - h5py=3.6.0
 - intake-xarray=0.6.0
+- nc-time-axis=v1.41
 - pip=22.0.4
 - pip:
     - cmocean

--- a/src/conda/env_python3_base.yml
+++ b/src/conda/env_python3_base.yml
@@ -28,7 +28,7 @@ dependencies:
 - pcmdi_metrics=2.2.2
 - h5py=3.6.0
 - intake-xarray=0.6.0
-- nc-time-axis=v1.4.1
+- nc-time-axis=1.4.1
 - pip=22.0.4
 - pip:
     - cmocean

--- a/src/conda/env_python3_base.yml
+++ b/src/conda/env_python3_base.yml
@@ -11,7 +11,7 @@ dependencies:
 - numpy=1.19
 - scipy=1.5.2
 - netCDF4=1.5.8
-- cftime>=1.5
+- cftime>=1.6
 - xarray=0.16
 - matplotlib=3.3
 - pandas<1.3

--- a/src/conda/env_python3_base.yml
+++ b/src/conda/env_python3_base.yml
@@ -28,7 +28,7 @@ dependencies:
 - pcmdi_metrics=2.2.2
 - h5py=3.6.0
 - intake-xarray=0.6.0
-- nc-time-axis=v1.41
+- nc-time-axis=v1.4.1
 - pip=22.0.4
 - pip:
     - cmocean


### PR DESCRIPTION
**Description**
Add nc-time-axis conda package to the python3 env yaml
Associated issue #383 

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.7 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [x] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [x] The repository contains no extra test scripts or data files
