### PR TITLE
Fix for preferred component functionality

### DIFF
--- a/sites/NOAA_GFDL/gfdl.py
+++ b/sites/NOAA_GFDL/gfdl.py
@@ -532,7 +532,8 @@ class GfdlppDataManager(GFDL_GCP_FileDataSourceBase):
         if len(values) <= 1:
             # unique value, no need to filter
             return df
-        filter_val = func(values, preferred=preferred)
+        args = {"preferred": preferred} if preferred is not None else {}
+        filter_val = func(values, **args)
         self.log.debug("Selected experiment attribute %s='%s' for %s (out of %s).",
             col_name, filter_val, obj_name, values)
         return df[df[col_name] == filter_val]


### PR DESCRIPTION
**Description**
Not all functions that are provided _filter_column accept the `preferred` kwarg. This fix only passes the `preferred` argument to the filter function if it is not None.

**How Has This Been Tested?**
Standard CI suite.

**Checklist:**
- [x] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.7 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [x] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [x] The repository contains no extra test scripts or data files
