### PR TITLE
Fix for undefined associated_files attribute

### DIFF
--- a/src/data_manager.py
+++ b/src/data_manager.py
@@ -963,7 +963,7 @@ class DataframeQueryDataSourceBase(DataSourceBase, metaclass=util.MDTFABCMeta):
             group = self.check_group_daterange(group, expt_key=expt_key, log=var.log)
             if group.empty:
                 var.log.debug('Expt_key %s eliminated by _check_group_daterange',
-                    expt_key)
+                              expt_key)
                 continue
             group = self._query_group_hook(group)
             if group.empty:
@@ -971,7 +971,7 @@ class DataframeQueryDataSourceBase(DataSourceBase, metaclass=util.MDTFABCMeta):
                 continue
             d_key = self.data_key(group, expt_key=expt_key)
             var.log.debug('Query found <expt_key=%s, %s> for %s',
-                expt_key, d_key, var.full_name)
+                          expt_key, d_key, var.full_name)
             var.data[expt_key] = d_key
 
             if not isinstance(var.associated_files, dict):
@@ -983,11 +983,12 @@ class DataframeQueryDataSourceBase(DataSourceBase, metaclass=util.MDTFABCMeta):
             # class that inherits ` DataframeQueryDataSourceBase` can define this
             # method to populate the `VarlistEntry.associated_files` attribute.
             # Otherwise this attribute is set to an empty dictionary here.
-            if hasattr(self, "query_associated_files"):
-                try:
-                    var.associated_files[expt_key] = self.query_associated_files(d_key)
-                except Exception as exc:
-                    var.log.debug(f"Unable to query associated files: {exc}")
+            if not hasattr(self, "query_associated_files") or not var.associated_files:
+                continue
+            try:
+                var.associated_files[expt_key] = self.query_associated_files(d_key)
+            except Exception as exc:
+                var.log.debug(f"Unable to query associated files: {exc}")
 
     def _query_error_handler(self, msg, d_key, log=_log):
         """Log debugging message or raise an exception, depending on if we're


### PR DESCRIPTION
**Description**
Add a check for an empty var.associated_files data frame before setting the expt_key entry to data_manager.query_dataset. 

Associated issue #386 

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.7 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [x] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [x] The repository contains no extra test scripts or data files
