### PR TITLE
update cartopy version in python3 conda environment file

### DIFF
--- a/src/conda/env_python3_base.yml
+++ b/src/conda/env_python3_base.yml
@@ -15,7 +15,7 @@ dependencies:
 - xarray=0.16
 - matplotlib=3.3
 - pandas<1.3
-- cartopy>=0.21.0
+- cartopy=0.20.0
 - pint=0.16
 - dask=2021.03.0
 - numba=0.53.1

--- a/src/conda/env_python3_base.yml
+++ b/src/conda/env_python3_base.yml
@@ -15,7 +15,7 @@ dependencies:
 - xarray=0.16
 - matplotlib=3.3
 - pandas<1.3
-- cartopy=0.19
+- cartopy>=0.21.0
 - pint=0.16
 - dask=2021.03.0
 - numba=0.53.1


### PR DESCRIPTION
**Description**
Update cartopy to v 0.21 or later to solve issue related to http timeout
Associated issue #405  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.7 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [x] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [x] The repository contains no extra test scripts or data files
