### PR TITLE
Add stc eddy heat fluxes POD to CI

### DIFF
--- a/.github/workflows/mdtf_tests.yml
+++ b/.github/workflows/mdtf_tests.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - stc_eddy_heat_fluxes_ci
   pull_request:
     branches:
       - main

--- a/.github/workflows/mdtf_tests.yml
+++ b/.github/workflows/mdtf_tests.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - stc_eddy_heat_fluxes_ci
   pull_request:
     branches:
       - main
@@ -175,6 +176,7 @@ jobs:
         curl --verbose --ipv4 --connect-timeout 8 --max-time 1200 --retry 128 --ftp-ssl --ftp-pasv -u "anonymous:anonymous" ftp://ftp.gfdl.noaa.gov/perm/oar.gfdl.mdtf/ocn_surf_flux_diag_obs_data.tar --output ocn_surf_flux_diag_obs_data.tar
         #curl --verbose --ipv4 --connect-timeout 8 --max-time 1200 --retry 128 --ftp-ssl --ftp-pasv -u "anonymous:anonymous" ftp://ftp.gfdl.noaa.gov/perm/oar.gfdl.mdtf/albedofb_obs_data.tar --output albedofb_obs_data.tar
         curl --verbose --ipv4 --connect-timeout 8 --max-time 1200 --retry 128 --ftp-ssl --ftp-pasv -u "anonymous:anonymous" ftp://ftp.gfdl.noaa.gov/perm/oar.gfdl.mdtf/seaice_suite_obs_data.tar --output seaice_suite_obs_data.tar
+        curl --verbose --ipv4 --connect-timeout 8 --max-time 1200 --retry 128 --ftp-ssl --ftp-pasv -u "anonymous:anonymous" ftp://ftp.gfdl.noaa.gov/perm/oar.gfdl.mdtf/stc_eddy_heat_fluxes_obs_data.tar --output stc_eddy_heat_fluxes_obs_data.tar
         echo "Untarring set 3 CMIP standard test files"
         tar -xvf temp_extremes_distshape_obs_data.tar
         tar -zxvf tropical_pacific_sea_level_obs_data.tar.gz
@@ -182,10 +184,11 @@ jobs:
         tar -xvf ocn_surf_flux_diag_obs_data.tar
         # tar -xvf albedofb_obs_data.tar
         tar -xvf seaice_suite_obs_data.tar
+        tar -xvf stc_eddy_heat_fluxes_obs_data.tar
         # clean up tarballs
         rm -f *.tar
         rm -f *.tar.gz
-    - name: Run diagnostic tests set 3
+    - name: Run CMIP diagnostic tests set 3
       run: |
         conda activate _MDTF_base
         # run the test PODs

--- a/tests/github_actions_test_macos_set3.jsonc
+++ b/tests/github_actions_test_macos_set3.jsonc
@@ -15,7 +15,8 @@
           "tropical_pacific_sea_level",
           "ocn_surf_flux_diag",
           "mixed_layer_depth",
-          "seaice_suite"
+          "seaice_suite",
+          "stc_eddy_heat_fluxes"
           // "albedofb"
       ]
     }

--- a/tests/github_actions_test_ubuntu_set3.jsonc
+++ b/tests/github_actions_test_ubuntu_set3.jsonc
@@ -14,7 +14,8 @@
          "tropical_pacific_sea_level",
          "ocn_surf_flux_diag",
          "mixed_layer_depth",
-         "seaice_suite"
+         "seaice_suite",
+         "stc_eddy_heat_fluxes"
          // "albedofb"
       ]
     }


### PR DESCRIPTION
**Description**
Add the STC Eddy Heat Fluxes POD to the Github Actions CMIP test suite

**How Has This Been Tested?**
Tested with Python 3.7, Linux CentOS 8

**Checklist:**
- [x] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.7 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [x] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [x] The repository contains no extra test scripts or data files
