### PR TITLE
bump package versions in doc requirements and env_dev yaml file

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,7 @@
 # these requirements are only used by readthedocs.org to build documentation.
 # For local documentation builds, use the _MDTF_dev conda environment at
 # /src/conda/env_dev.yml.
-sphinx==3.1.2
-recommonmark==0.6
+sphinx>=5.2
+recommonmark>=0.7
 mock
+jinja2>=2.10

--- a/src/conda/env_dev.yml
+++ b/src/conda/env_dev.yml
@@ -12,17 +12,18 @@ dependencies:
 - cftime=1.2
 - xarray=0.16
 - matplotlib=3.3
-- cartopy=0.18
+- cartopy=0.20.0
 - pandas<1.3
 - pint=0.16
-- dask=2.30
+- dask=2021.03.0
 # additional development tools
 - jupyter
-- jupyterlab
-- sphinx=3.1.2
-- recommonmark=0.6
-- pylint
+- jupyterlab>=3.4
+- sphinx>=5.2
+- recommonmark>=0.7
+- pylint>=2.4
 - doc8
+- jinja2>=2.10
 # additions dec 2020
 - cfunits=3.3.1
 - intake=0.6


### PR DESCRIPTION


**Description**
bump sphinx, recommonmark versions in doc requirements.txt add jinija2 specs to requirements.txt
Outdated packages, specifically jinja2, are causing the readthedocs build to fail when running conf.py.

**How Has This Been Tested?**
Ran conf.py using the updated test environment specified by env_dev.yml

**Checklist:**
- [x] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.7 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [x] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [x] The repository contains no extra test scripts or data files
