### PR TITLE
bump python to version 3.8 in conda env config files and mdtf_test yaml

### DIFF
--- a/.github/workflows/mdtf_tests.yml
+++ b/.github/workflows/mdtf_tests.yml
@@ -61,7 +61,7 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         miniconda-version: "latest"
-        python-version: 3.7
+        python-version: 3.8
         mamba-version: "*"
         channels: conda-forge,defaults
     - name: Verify miniconda

--- a/src/conda/_env_synthetic_data.yml
+++ b/src/conda/_env_synthetic_data.yml
@@ -9,7 +9,7 @@ dependencies:
 - netCDF4=1.5.8
 - cftime=1.3.0
 - xarray>=2022.06.0
-- setuptools >= 49.1
+- setuptools>=49.1
 - esmf=8.2.0
 - esmpy=8.2.0
 - xesmf=0.6.2

--- a/src/conda/conda_init.sh
+++ b/src/conda/conda_init.sh
@@ -9,7 +9,7 @@
 # NOTE this has only been tested with conda 4.7.10 and later; I know earlier
 # versions had things in different places.
 
-# parse aruments manually
+# parse arguments manually
 _TEMP_CONDA_ROOT=""
 _TEMP_CONDA_EXE=""
 _v=1

--- a/src/conda/env_NCL_base.yml
+++ b/src/conda/env_NCL_base.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge # NOTE: critical to give highest priority to conda-forge
 - defaults
 dependencies:
-- python=3.7
+- python=3.8
 # - ncl=6.5 # has a font rendering issue fixed in 6.6
 # - openblas=0.3.4 # otherwise ncl 6.5 installs but doesn't function on macs
 - ncl=6.6.2

--- a/src/conda/env_R_base.yml
+++ b/src/conda/env_R_base.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-- python=3.7
+- python=3.8
 - r-base
 - r-akima
 - r-colorramps

--- a/src/conda/env_base.yml
+++ b/src/conda/env_base.yml
@@ -7,7 +7,7 @@ dependencies:
 # specify up to minor version number to provide a consistent environment for POD developers
 # versions are current as of Jul 2020
 # see https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/pkg-specs.html
-- python=3.7
+- python=3.8
 - ghostscript
 - numpy=1.19
 # - scipy=1.5.2

--- a/src/conda/env_convective_transition_diag.yml
+++ b/src/conda/env_convective_transition_diag.yml
@@ -3,15 +3,15 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-- python=3.7
-- numpy=1.19
-- scipy=1.5.2
+- python=3.8
+- numpy=1.22.3
+- scipy=1.5.3
 - netCDF4=1.5.4
-- cftime=1.2
-- xarray=0.16
-- matplotlib=3.3
+- cftime=1.3.0
+- xarray>=0.20
+- matplotlib>=3.3
 - pandas<1.3
-- cartopy=0.18
-- numba = 0.51.2
-- networkx = 2.3
+- cartopy=0.20.0
+- numba=0.51.2
+- networkx=2.3
 - jupyterlab

--- a/src/conda/env_dev.yml
+++ b/src/conda/env_dev.yml
@@ -5,9 +5,9 @@ channels:
 - defaults
 dependencies:
 # contents of python3_base
-- python=3.7
+- python=3.8
 - numpy=1.19
-- scipy=1.5.2
+- scipy=1.5.3
 - netCDF4=1.5.4
 - cftime=1.2
 - xarray=0.16

--- a/src/conda/env_precip_buoy_diag.yml
+++ b/src/conda/env_precip_buoy_diag.yml
@@ -3,12 +3,12 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-- python=3.7
-- cython=0.29.21
-- xarray=0.16.2
-- numpy=1.18.5
+- python=3.8
+- cython>=0.29
+- xarray>=0.20
+- numpy=1.22.3
 - scipy=1.5.3
 - matplotlib=3.3.3
 - numba=0.52
-- pandas
-- dask
+- pandas<1.3
+- dask=2021.03.0

--- a/src/conda/env_python3_base.yml
+++ b/src/conda/env_python3_base.yml
@@ -7,9 +7,9 @@ dependencies:
 # versions are current as of Jul 2020
 # see https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/pkg-specs.
 
-- python=3.7
+- python=3.8
 - numpy=1.19
-- scipy=1.5.2
+- scipy=1.5.3
 - netCDF4=1.5.8
 - cftime>=1.6
 - xarray>=0.20
@@ -30,7 +30,7 @@ dependencies:
 - h5py=3.6.0
 - intake-xarray=0.6.0
 - nc-time-axis=1.4.1
-- pyyaml >=6.0
+- pyyaml>=6.0
 - pip=22.0.4
 - pip:
     - cmocean


### PR DESCRIPTION
**Description**
* fix typo in conda_init.sh
* bump other package versions in yamls to be consistent with base env

**How Has This Been Tested?**
Tested env builds with with Python 3.8 on CentOS 8 system
**Checklist:**
- [x] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.7 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
