### PR TITLE
bump cartopy to v 0.21.0 to try and resolve issues with naturalearth

### DIFF
--- a/diagnostics/temp_extremes_distshape/TempExtDistShape_CircComps_util.py
+++ b/diagnostics/temp_extremes_distshape/TempExtDistShape_CircComps_util.py
@@ -20,19 +20,15 @@
 # ======================================================================
 
 # Import standard Python packages
-import os
 import numpy
 from netCDF4 import Dataset,num2date
 from datetime import datetime, timedelta
 import cftime
-import matplotlib
 import matplotlib.pyplot as mplt
 from matplotlib import cm
 import matplotlib.colors as mcolors
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes
-from mpl_toolkits.axes_grid1 import make_axes_locatable
 import cartopy
-import cartopy.crs as ccrs
 from scipy import signal
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
@@ -253,11 +249,12 @@ def Plot_Circ_Comp_Lags(model_netcdf_filename,lon_var,figstep,plotcol,lon,lat,ta
     else:
         axes[figstep,plotcol].text(0.92, 0.92,'t=-'+str(lag), bbox=dict(facecolor='white', alpha=0.8),fontsize=14,style='italic',transform=axes[figstep,plotcol].transAxes,zorder=6)
 
-    ### Adjust for inserting colorbar
+    # Adjust for inserting colorbar
     divider2 = make_axes_locatable(axes[figstep,plotcol])
-    cax2 = divider2.append_axes(position="bottom",size="3%",pad=0.1,map_projection=cartopy.crs.PlateCarree())
-    cax2.outline_patch.set_visible(False)
-    axes[figstep,plotcol].set_aspect('equal')
+    cax2 = divider2.append_axes(position="bottom", size="3%", pad=0.1, map_projection=cartopy.crs.PlateCarree())
+    #cax2.outline_patch.set_visible(False) # deprecated, but not sure how to replace.
+    # Omission doesn't seem to affect plot
+    axes[figstep, plotcol].set_aspect('equal')
     return t1
 
 

--- a/src/conda/env_python3_base.yml
+++ b/src/conda/env_python3_base.yml
@@ -15,7 +15,7 @@ dependencies:
 - xarray>=0.20
 - matplotlib=3.3
 - pandas<1.3
-- cartopy=0.20.0
+- cartopy=0.21.0
 - cython>=0.29
 - pint=0.16
 - dask=2021.03.0


### PR DESCRIPTION
**Description**
Running into issues with natural earth downloads timing out in mixed_layer_depth and seaice_suite PODs as described [here](https://github.com/SciTools/cartopy/issues/1298) . Testing to see if upgrading cartopy will resolve this.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [ ] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [ ] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.8 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] The repository contains no extra test scripts or data files
