### PR TITLE
fix logic core.parse_pod_list so that example string is matched exact…

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -967,10 +967,13 @@ class MDTFFramework(MDTFObjectBase):
         for arg in args:
             if arg == 'all':
                 # add all PODs except example PODs
-                pods.extend([p for p in pod_data if not p.startswith('example')])
+                pods.extend([p for p in pod_data if not p.lower().startswith('example')])
             elif arg == 'example' or arg == 'examples':
                 # add example PODs
-                pods.extend([p for p in pod_data if p.startswith('example')])
+                if self.multirun:
+                    pods.extend([p for p in pod_data if p.lower() == 'example_multicase'])
+                else:
+                    pods.extend([p for p in pod_data if p.lower() == 'example'])
             elif arg in pod_info_tuple.realm_data:
                 # realm_data: realm name -> list of POD names
                 # add all PODs for this realm


### PR DESCRIPTION
…ly if single_run mode is specified


**How Has This Been Tested?**
Tested on RHEL8 with python 3.10

**Checklist:**
- [x] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.10 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [x] The repository contains no extra test scripts or data files
