### PR TITLE
replace softlinks with copying in rename_input_files.py

### DIFF
--- a/tools/rename_input_files/doc/rename_input_files.rst
+++ b/tools/rename_input_files/doc/rename_input_files.rst
@@ -1,3 +1,5 @@
+.. _ref-rename-input-files:
+
 rename_input_files.py
 =====================
 
@@ -15,17 +17,17 @@ Input
 -----
 Configuration yaml file with the directory containing the input data,
 the directory where the output will be written, the CASENAME to use for the output file names,
-the file names that will be linked,
-and the frequencies and variable names to use in the new symlinked file names
+the file names for the copied data,
+and the frequencies and variable names to use in the new file names
 
 The file `config_template.yml` shows how to define the *casename* and *frequency*
 parameters, the paths to the original input data and the output directory where the
-modified file names will be linked, the names of the files to change, and the corresponding
+modified file names will be copied, the names of the files to change, and the corresponding
 variable names that will be substituted in the modfied file names.
 
 Output
 ------
-Symbolic links to the desired files in the directory `[outputDir]/[CASENAME]/[freq]`
+Copies of the desired files to the directory `[outputDir]/[CASENAME]/[freq]`
 with the format `<CASENAME>.<freq>.<variable name>.nc`
 
 Required packages:
@@ -37,3 +39,4 @@ environment:
 - pyyaml
 - click
 - pathlib
+- shutil

--- a/tools/rename_input_files/rename_input_files.py
+++ b/tools/rename_input_files/rename_input_files.py
@@ -15,15 +15,17 @@
 # the directory where the output will be written, the CASENAME to use for the output file names,
 # the file names that will be linked,
 # and the frequencies and variable names to use in the new symlinked file names
-# Output: symlinks to the desired files in the directory [outputDir]/[CASENAME]/[freq]
+# Output: Copies renamed files to the directory [outputDir]/[CASENAME]/[freq]
 # with the format <CASENAME>.<freq>.<variable name>.nc
 
 
 import os
+import shutil
 import sys
 import yaml
 import click
 from pathlib import Path
+
 
 
 @click.command()
@@ -60,7 +62,7 @@ def append_new_filenames(file_list=list, casename=str):
         f['new_name'] = '.'.join([casename, f['var'], f['freq'], 'nc'])
 
 
-# symlink files in inputFilePath to LocalFile-formatted outputFilePath
+# Copy in inputFilePath to LocalFile-formatted outputFilePath
 def link_files(input_dir_path=str, output_dir_path=str, file_list=list):
 
     for f in file_list:
@@ -68,11 +70,11 @@ def link_files(input_dir_path=str, output_dir_path=str, file_list=list):
         assert os.path.isfile(f['inpath']), f['inpath'] + " not found. Check file name and path for errors."
         f['outpath'] = os.path.join(output_dir_path, f['freq'])
         Path(f['outpath']).mkdir(parents=True, exist_ok=True)
-        # Create a symbolic link pointing inpath to outpath
+        # Copy renamed file to destination
         newfilepath = os.path.join(f['outpath'], f['new_name'])
         if not os.path.isfile(newfilepath):
-            os.symlink(f['inpath'], newfilepath)
-        assert os.path.isfile(newfilepath),  f'Unable to symlink {newfilepath}.' \
+            shutil.copy(f['inpath'], newfilepath)
+        assert os.path.isfile(newfilepath),  f'Unable to copy {newfilepath}.' \
                                              f' Check to ensure that you have write permission to' + f['outpath']
 
 


### PR DESCRIPTION
**Description**
switch soft linking of new files to creating copies to avoid issues with framework ingesting files in no_pp mode

update rename input files doc to reflect changes in script

**Checklist:**
- [x] I have reviewed my own code to ensure that if follows the [POD development guidelines](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/dev_guidelines.html)
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.10 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [x] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [x] The repository contains no extra test scripts or data files
