### PR TITLE
Fix bug in xr_parser  reconcile_scalar_value_and_coords

### DIFF
--- a/src/xr_parser.py
+++ b/src/xr_parser.py
@@ -974,11 +974,13 @@ class DefaultDatasetParser:
                     our_var.value, new_units = getattr(our_var, attr_name)
                     our_var.units = units.to_cfunits(new_units)
                     self.log.debug("Updated (value, units) of '%s' to (%s, %s).",
-                        our_var.name, our_var.value, our_var.units)
+                                   our_var.name, our_var.value, our_var.units)
                     delattr(our_var, attr_name)
 
-        assert (hasattr(our_var, 'is_scalar') and our_var.is_scalar)
-        assert ds_var.size == 1
+        assert (hasattr(our_var, 'is_scalar') and our_var.is_scalar), \
+            self.log.error('is_scalar att missing and/or is_scalar is false for ', our_var)
+        assert ds_var.size == 1, \
+            self.log.error('size neq 1 for ', our_var)
         # Check equivalence of units: if units inequivalent, raises MetadataEvent
         try:
             _compare_value_and_units(
@@ -1117,9 +1119,9 @@ class DefaultDatasetParser:
                 # size 1.
                 if ds[ds_coord_name].size != 1:
                     self.log.error("Dataset has scalar coordinate '%s' of size %d != 1.",
-                        ds_coord_name, ds[ds_coord_name].size)
+                                   ds_coord_name, ds[ds_coord_name].size)
                 self.reconcile_names(coord, ds, ds_coord_name, overwrite_ours=True)
-                self.reconcile_scalar_value_and_units(our_var, ds[ds_coord_name])
+                self.reconcile_scalar_value_and_units(coord, ds[ds_coord_name])
             else:
                 # scalar coord has presumably been read from Dataset attribute.
                 # At any rate, we only have a PlaceholderScalarCoordinate object,


### PR DESCRIPTION
**Description**
change argument `our_var` to `coord` in xr_parser call to `reconcile_scalar_value_and_coords`. The `our_var` value
may correspond to a `TranslatedVarlistEntry` instance for a dependent variable. Dependent variables do not have the is_static property , while coordinate variables do. `reconcile_scalar_value_and_coords` is only intended to work on coordinate data based on the preceding function calls that only work on `coord` and/or `ds[ds_coord_name]` in the logic block that iterates through coord values in an `our_scalars` array.

add error logging for assertion statements in `reconcile_scalar_value_and_coords`

Associated issue #449

**How Has This Been Tested?**
Tested on RHEL-8 laptop with python 3.10 and prelim version of the stc_vert_wave_coupling POD with daily CanESM5_CMIP_historical_r1i1p1f1 data

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.10 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
