### PR TITLE
Fix multirun extract level function bug

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -1447,7 +1447,7 @@ class MultirunExtractLevelFunction(ExtractLevelFunction):
             new_tv_name = v.name
         else:
             new_tv_name = core.VariableTranslator().from_CF_name(
-                data_mgr.attrs.convention, v.standard_name, new_ax_set
+                data_mgr.convention, v.standard_name, new_ax_set
             )
         new_tv = tv.remove_scalar(
             tv.scalar_coords[0].axis,


### PR DESCRIPTION


**Description**
Fix convention argument passed to from_CF_name call by preprocessor.MultirunExtractLevelFunction

Associated issue #456 

**How Has This Been Tested?**

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.10 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
