### PR TITLE
fix bug in xr_parser.reconcile_dimension_coords

### DIFF
--- a/src/xr_parser.py
+++ b/src/xr_parser.py
@@ -1044,7 +1044,8 @@ class DefaultDatasetParser:
         """
         for coord in ds.cf.axes_values(our_var.name).values():
             # .axes_values() will have thrown TypeError if XYZT axes not all uniquely defined
-            assert isinstance(coord, xr.core.dataarray.DataArray)
+            assert isinstance(coord, xr.core.dataarray.DataArray), \
+            "Assertion failed: " + coord + " not found in ds.cf.axes_values"
 
         # check set of dimension coordinates (array dimensionality) agrees
         our_axes_set = our_var.dim_axes_set
@@ -1070,7 +1071,7 @@ class DefaultDatasetParser:
 
         for c_name in ds_var.dims:
             if ds[c_name].size == 1:
-                if c_name == ds_axes['Z']:
+                if 'Z' in ds_axes.keys() and c_name == ds_axes['Z']:
                     # mis-identified scalar coordinate
                     self.log.warning(("Dataset has dimension coordinate '%s' of size "
                                       "1 not identified as scalar coord."), c_name)


### PR DESCRIPTION
**Description**
* add check for Z axis is ds_axes.keys before comparing other axes with length 1

* add error message to assertion statement in xr_parser.reconcile_dimension_coords

Associated issue #460 

**How Has This Been Tested?**
Tested with RHEL 8, Python 3.10, CI
**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.10 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
