### PR TITLE
Update preprocessor functions to allow multiple variable coordinates 

### DIFF
--- a/data/fieldlist_NCAR.jsonc
+++ b/data/fieldlist_NCAR.jsonc
@@ -216,6 +216,11 @@
       "units": "K",
       "ndim": 4
     },
+    "SST": {
+      "standard_name": "Potential Temperature",
+      "units": "degC",
+      "ndim": 4
+    },
     // Variables for Convective Transition Diagnostics module:
     // ta: 3D temperature, units = K:
     "T": {

--- a/data/fieldlist_NCAR.jsonc
+++ b/data/fieldlist_NCAR.jsonc
@@ -11,6 +11,8 @@
     // only used for taking slices, unit conversion
     "lon": {"axis": "X", "standard_name": "longitude", "units": "degrees_east"},
     "lat": {"axis": "Y", "standard_name": "latitude", "units": "degrees_north"},
+    "TLONG": {"axis": "X", "standard_name": "array of t-grid longitudes", "units": "degrees_east"},
+    "TLAT": {"axis": "Y", "standard_name": "array of t-grid latitudes", "units": "degrees_north"},
     "plev": {
       "standard_name": "air_pressure",
       "units": "hPa",

--- a/src/data_model.py
+++ b/src/data_model.py
@@ -253,11 +253,11 @@ class DMCoordinate(_DMCoordinateShared):
 class DMLongitudeCoordinate(_DMCoordinateShared):
     """Class to describe a longitude dimension coordinate.
     """
-    name: str = 'lon'
+    name: str = util.MANDATORY
     """Coordinate name."""
     # bounds_var: AbstractDMCoordinateBounds
     # [scalar] value: int or float
-    standard_name: str = 'longitude'
+    standard_name: str = util.MANDATORY
     """Coordinate CF standard name."""
     units: src.units.Units = 'degrees_east'
     """Coordinate units (str or :class:`~src.units.Units`)."""
@@ -268,11 +268,11 @@ class DMLongitudeCoordinate(_DMCoordinateShared):
 class DMLatitudeCoordinate(_DMCoordinateShared):
     """Class to describe a latitude dimension coordinate.
     """
-    name: str = 'lat'
+    name: str = util.MANDATORY
     """Coordinate name; defaults to 'lat'."""
     # bounds_var: AbstractDMCoordinateBounds
     # [scalar] value: int or float
-    standard_name: str = 'latitude'
+    standard_name: str = util.MANDATORY
     """Coordinate CF standard name."""
     units: src.units.Units = 'degrees_north'
     """Coordinate units (str or :class:`~src.units.Units`)."""
@@ -388,6 +388,7 @@ AbstractDMCoordinate.register(DMGenericTimeCoordinate)
 AbstractDMCoordinate.register(DMTimeCoordinate)
 AbstractDMCoordinate.register(DMBoundsDimension)
 
+
 def coordinate_from_struct(d, class_dict=None, **kwargs):
     """Attempt to instantiate the correct :class:`DMCoordinate` class based on
     information in dict *d* (read from JSON file).
@@ -415,11 +416,16 @@ def coordinate_from_struct(d, class_dict=None, **kwargs):
         ax = 'OTHER'
         if 'axis' in d:
             ax = d['axis']
-        elif d.get('standard_name', "") in standard_names:
-            ax = standard_names[d['standard_name']]
+        else:
+            # try to match an axis value (X,Y,T) to the dimension. The standard name of the dimension specified
+            # in the input json file must contain the word "longitude", "latitude", or "time"
+            for k in standard_names.keys():
+                if k in d.get('standard_name', ""):
+                    ax = standard_names[k]
         return util.coerce_to_dataclass(d, class_dict[ax], **kwargs)
     except Exception:
         raise ValueError(f"Couldn't parse coordinate: {repr(d)}")
+
 
 class _DMPlaceholderCoordinateBase(object):
     """Dummy base class for placeholder coordinates. Placeholder coordinates are

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -12,6 +12,7 @@ import numpy as np
 import xarray as xr
 
 import logging
+
 _log = logging.getLogger(__name__)
 
 
@@ -26,9 +27,9 @@ def copy_as_alternate(old_v, data_mgr, **kwargs):
         kwargs['coords'] = (old_v.dims + old_v.scalar_coords)
     new_v = dataclasses.replace(
         old_v,
-        _id=util.MDTF_ID(),                           # assign distinct ID
-        stage=varlistentry_util.VarlistEntryStage.INITED,    # reset state from old_v
-        status=core.ObjectStatus.INACTIVE,      # new VE meant as an alternate
+        _id=util.MDTF_ID(),  # assign distinct ID
+        stage=varlistentry_util.VarlistEntryStage.INITED,  # reset state from old_v
+        status=core.ObjectStatus.INACTIVE,  # new VE meant as an alternate
         requirement=varlistentry_util.VarlistEntryRequirement.ALTERNATE,
         # plus the specific replacements we want to make:
         **kwargs
@@ -58,6 +59,7 @@ def edit_request_wrapper(wrapped_edit_request_func):
        signature of the returned function is that of
        :meth:`PreprocessorFunctionBase.edit_request`.
     """
+
     @functools.wraps(wrapped_edit_request_func)
     def wrapped_edit_request(self, data_mgr, pod):
         new_varlist = []
@@ -108,6 +110,7 @@ def multirun_edit_request_wrapper(multirun_wrapped_edit_request_func):
        signature of the returned function is that of
        :meth:`PreprocessorFunctionBase.edit_request`.
     """
+
     @functools.wraps(multirun_wrapped_edit_request_func)
     def wrapped_edit_request(self, data_mgr):
         for case_name, case_d in data_mgr.cases.items():
@@ -153,6 +156,7 @@ class PreprocessorFunctionBase(abc.ABC):
       function is capable of converting into the format requested by the POD.
     - :meth:`process`, which actually implements the data format conversion.
     """
+
     def __init__(self, data_mgr, *args):
         """Called during Preprocessor's init."""
         pass
@@ -194,6 +198,7 @@ class CropDateRangeFunction(PreprocessorFunctionBase):
     """A PreprocessorFunction which truncates the date range (time axis) of
     the dataset to the user-requested analysis period.
     """
+
     @staticmethod
     def cast_to_cftime(dt, calendar):
         """Workaround to cast a python :py:class:`~datetime.datetime` object *dt*
@@ -206,7 +211,7 @@ class CropDateRangeFunction(PreprocessorFunctionBase):
         # NB "tm_mday" is not a typo
         t = dt.timetuple()
         tt = (getattr(t, attr_) for attr_ in
-            ('tm_year', 'tm_mon', 'tm_mday', 'tm_hour', 'tm_min', 'tm_sec'))
+              ('tm_year', 'tm_mon', 'tm_mday', 'tm_hour', 'tm_min', 'tm_sec'))
         return cftime.datetime(*tt, calendar=calendar)
 
     def edit_request(self, data_mgr, pod):
@@ -228,9 +233,20 @@ class CropDateRangeFunction(PreprocessorFunctionBase):
         t_coord = ds.cf.dim_axes(tv_name).get('T', None)
         if t_coord is None:
             var.log.debug("Exit %s for %s: time-independent.",
-                self.__class__.__name__, var.full_name)
+                          self.__class__.__name__, var.full_name)
             return ds
-        cal = t_coord.attrs['calendar']
+        # time coordinate will be a list if variable has
+        # multiple coordinates/coordinate attributes
+        if isinstance(t_coord, list):
+            cal = t_coord[0].attrs['calendar']
+            t_start = t_coord[0].values[0]
+            t_end = t_coord[0].values[-1]
+            t_size = t_coord[0].size
+        else:
+            cal = t_coord.attrs['calendar']
+            t_start = t_coord.values[0]
+            t_end = t_coord.values[-1]
+            t_size = t_coord.size
         dt_range = var.T.range
         # lower/upper are earliest/latest datetimes consistent with the date we
         # were given, up to the precision that was specified (eg lower for "2000"
@@ -239,9 +255,6 @@ class CropDateRangeFunction(PreprocessorFunctionBase):
         dt_start_upper = self.cast_to_cftime(dt_range.start.upper, cal)
         dt_end_lower = self.cast_to_cftime(dt_range.end.lower, cal)
         dt_end_upper = self.cast_to_cftime(dt_range.end.upper, cal)
-        t_start = t_coord.values[0]
-        t_end = t_coord.values[-1]
-        t_size = t_coord.size
 
         if t_start > dt_start_upper:
             err_str = (f"Error: dataset start ({t_start}) is after "
@@ -253,23 +266,31 @@ class CropDateRangeFunction(PreprocessorFunctionBase):
                        f"requested date range end ({dt_end_lower}).")
             var.log.error(err_str)
             raise IndexError(err_str)
-
-        ds = ds.sel({t_coord.name: slice(dt_start_lower, dt_end_upper)})
+        if isinstance(t_coord, list):
+            ds = ds.sel({t_coord[0].name: slice(dt_start_lower, dt_end_upper)})
+        else:
+            ds = ds.sel({t_coord.name: slice(dt_start_lower, dt_end_upper)})
         new_t = ds.cf.dim_axes(tv_name).get('T')
-        if t_size == new_t.size:
+        if isinstance(new_t, list):
+            nt_size = new_t[0].size
+            nt_values = new_t[0].values
+        else:
+            nt_size = new_t.size
+            nt_values = new_t.values
+        if t_size == nt_size:
             var.log.info(("Requested dates for %s coincide with range of dataset "
                           "'%s -- %s'; left unmodified."),
                          var.full_name,
-                         new_t.values[0].strftime('%Y-%m-%d'),
-                         new_t.values[-1].strftime('%Y-%m-%d'),
+                         nt_values[0].strftime('%Y-%m-%d'),
+                         nt_values[-1].strftime('%Y-%m-%d'),
                          )
         else:
             var.log.info("Cropped date range of %s from '%s -- %s' to '%s -- %s'.",
                          var.full_name,
                          t_start.strftime('%Y-%m-%d'),
                          t_end.strftime('%Y-%m-%d'),
-                         new_t.values[0].strftime('%Y-%m-%d'),
-                         new_t.values[-1].strftime('%Y-%m-%d'),
+                         nt_values[0].strftime('%Y-%m-%d'),
+                         nt_values[-1].strftime('%Y-%m-%d'),
                          tags=util.ObjectLogTag.NC_HISTORY
                          )
         return ds
@@ -299,8 +320,8 @@ class PrecipRateToFluxFunction(PreprocessorFunctionBase):
         # not in CF; here for compatibility with NCAR-CAM
         ("large_scale_precipitation_rate", "large_scale_precipitation_flux")
     ]
-    _rate_d = {tup[0]:tup[1] for tup in _std_name_tuples}
-    _flux_d = {tup[1]:tup[0] for tup in _std_name_tuples}
+    _rate_d = {tup[0]: tup[1] for tup in _std_name_tuples}
+    _flux_d = {tup[1]: tup[0] for tup in _std_name_tuples}
 
     @edit_request_wrapper
     def edit_request(self, v, pod, data_mgr):
@@ -323,15 +344,15 @@ class PrecipRateToFluxFunction(PreprocessorFunctionBase):
             # requested rate, so add alternate for flux
             v_to_translate = copy_as_alternate(
                 v, data_mgr,
-                standard_name = self._rate_d[std_name],
-                units = units.to_cfunits(v.units) * self._liquid_water_density
+                standard_name=self._rate_d[std_name],
+                units=units.to_cfunits(v.units) * self._liquid_water_density
             )
         elif std_name in self._flux_d:
             # requested flux, so add alternate for rate
             v_to_translate = copy_as_alternate(
                 v, data_mgr,
-                standard_name = self._flux_d[std_name],
-                units = units.to_cfunits(v.units) / self._liquid_water_density
+                standard_name=self._flux_d[std_name],
+                units=units.to_cfunits(v.units) / self._liquid_water_density
             )
 
         translate = core.VariableTranslator()
@@ -362,7 +383,7 @@ class PrecipRateToFluxFunction(PreprocessorFunctionBase):
 
         # var.translation.units set by edit_request will have been overwritten by
         # DefaultDatasetParser to whatever they are in ds. Change them back.
-        tv = var.translation # abbreviate
+        tv = var.translation  # abbreviate
         if std_name in self._rate_d:
             # requested rate, received alternate for flux
             new_units = tv.units / self._liquid_water_density
@@ -391,6 +412,7 @@ class ConvertUnitsFunction(PreprocessorFunctionBase):
     `cfunits <https://ncas-cms.github.io/cfunits/index.html>`__; see
     :doc:`src.units`.
     """
+
     def edit_request(self, data_mgr, pod):
         """No-op for this PreprocessorFunction, since no alternate data is needed.
         """
@@ -412,7 +434,7 @@ class ConvertUnitsFunction(PreprocessorFunctionBase):
         # convert coordinate dimensions and bounds
         for c in tv.dim_axes.values():
             if c.axis == 'T':
-                continue # TODO: separate function to handle calendar conversion
+                continue  # TODO: separate function to handle calendar conversion
             dest_c = var.axes[c.axis]
             ds = units.convert_dataarray(
                 ds, c.name, src_unit=None, dest_unit=dest_c.units, log=var.log
@@ -442,6 +464,7 @@ class ConvertUnitsFunction(PreprocessorFunctionBase):
 class RenameVariablesFunction(PreprocessorFunctionBase):
     """Renames dependent variables and coordinates to what's expected by the POD.
     """
+
     def edit_request(self, data_mgr, pod):
         """No-op for this PreprocessorFunction, since no alternate data is needed.
         """
@@ -469,9 +492,9 @@ class RenameVariablesFunction(PreprocessorFunctionBase):
             dest_c = var.axes[c.axis]
             if c.name != dest_c.name:
                 var.log.debug("Rename %s axis of %s from '%s' to '%s'.",
-                    c.axis, var.full_name, c.name, dest_c.name,
-                    tags=util.ObjectLogTag.NC_HISTORY
-                )
+                              c.axis, var.full_name, c.name, dest_c.name,
+                              tags=util.ObjectLogTag.NC_HISTORY
+                              )
                 rename_d[c.name] = dest_c.name
                 c.name = dest_c.name
         # TODO: bounds??
@@ -545,6 +568,7 @@ class ExtractLevelFunction(PreprocessorFunctionBase):
        If a pressure level is requested that isn't present in the data,
        :meth:`process` raises a KeyError.
     """
+
     @edit_request_wrapper
     def edit_request(self, v, pod, data_mgr):
         """Edit the *pod*'s :class:`~src.diagnostic.Varlist` prior to data query.
@@ -565,9 +589,9 @@ class ExtractLevelFunction(PreprocessorFunctionBase):
             # hit this if VE didn't request Z level extraction; do nothing
             return None
 
-        tv = v.translation # abbreviate
+        tv = v.translation  # abbreviate
         if len(tv.scalar_coords) == 0:
-            raise AssertionError # should never get here
+            raise AssertionError  # should never get here
         elif len(tv.scalar_coords) > 1:
             raise NotImplementedError()
         # wraps method in data_model; makes a modified copy of translated var
@@ -581,7 +605,7 @@ class ExtractLevelFunction(PreprocessorFunctionBase):
             )
         new_tv = tv.remove_scalar(
             tv.scalar_coords[0].axis,
-            name = new_tv_name
+            name=new_tv_name
         )
         new_v = copy_as_alternate(v, data_mgr)
         new_v.translation = new_tv
@@ -592,28 +616,28 @@ class ExtractLevelFunction(PreprocessorFunctionBase):
         coordinate and Dataset *ds* is 3D). If so, return the appropriate 2D
         slice of *ds*, otherwise pass through *ds* unaltered.
         """
-        _atol = 1.0e-3 # absolute tolerance for floating-point equality
+        _atol = 1.0e-3  # absolute tolerance for floating-point equality
 
         tv_name = var.name_in_model
         our_z = var.get_scalar('Z')
         if not our_z or not our_z.value:
             var.log.debug("Exit %s for %s: no level requested.",
-                self.__class__.__name__, var.full_name)
+                          self.__class__.__name__, var.full_name)
             return ds
         if 'Z' not in ds[tv_name].cf.dim_axes_set:
             # maybe the ds we received has this level extracted already
             ds_z = ds.cf.get_scalar('Z', tv_name)
             if ds_z is None or isinstance(ds_z, xr_parser.PlaceholderScalarCoordinate):
                 var.log.debug(("Exit %s for %s: %s %s Z level requested but value not "
-                    "provided in scalar coordinate information; assuming correct."),
-                    self.__class__.__name__, var.full_name, our_z.value, our_z.units)
+                               "provided in scalar coordinate information; assuming correct."),
+                              self.__class__.__name__, var.full_name, our_z.value, our_z.units)
                 return ds
             else:
                 # value (on var.translation) has already been checked by
                 # xr_parser.DefaultDatasetParser
                 var.log.debug(("Exit %s for %s: %s %s Z level requested and provided "
-                    "by dataset."),
-                    self.__class__.__name__, var.full_name, our_z.value, our_z.units)
+                               "by dataset."),
+                              self.__class__.__name__, var.full_name, our_z.value, our_z.units)
                 return ds
 
         # final case: Z coordinate present in data, so actually extract the level
@@ -624,14 +648,14 @@ class ExtractLevelFunction(PreprocessorFunctionBase):
             ds_z_value = units.convert_scalar_coord(our_z, ds_z.units, log=var.log)
             ds = ds.sel(
                 {ds_z.name: ds_z_value},
-                method='nearest', # Allow for floating point roundoff in axis values
+                method='nearest',  # Allow for floating point roundoff in axis values
                 tolerance=_atol,
                 drop=False
             )
             var.log.info("Extracted %s %s level from Z axis ('%s') of %s.",
-                ds_z_value, ds_z.units, ds_z.name, var.full_name,
-                tags=util.ObjectLogTag.NC_HISTORY
-            )
+                         ds_z_value, ds_z.units, ds_z.name, var.full_name,
+                         tags=util.ObjectLogTag.NC_HISTORY
+                         )
             # rename translated var to reflect renaming we're going to do
             # recall POD variable name env vars are set on this attribute
             var.translation.name = var.name
@@ -640,11 +664,12 @@ class ExtractLevelFunction(PreprocessorFunctionBase):
         except KeyError:
             # ds.sel failed; level wasn't present in coordinate axis
             raise KeyError((f"Z axis '{ds_z.name}' of {var.full_name} didn't "
-                f"provide requested level ({our_z.value} {our_z.units}).\n"
-                f"(Axis values ({ds_z.units}): {ds_z.values})"))
+                            f"provide requested level ({our_z.value} {our_z.units}).\n"
+                            f"(Axis values ({ds_z.units}): {ds_z.values})"))
         except Exception as exc:
             raise ValueError((f"Caught exception extracting {our_z.value} {our_z.units} "
-                f"level from '{ds_z.name}' coord of {var.full_name}.")) from exc
+                              f"level from '{ds_z.name}' coord of {var.full_name}.")) from exc
+
 
 class ApplyScaleAndOffsetFunction(PreprocessorFunctionBase):
     """If the Dataset has ``scale_factor`` and ``add_offset`` attributes set,
@@ -659,6 +684,7 @@ class ApplyScaleAndOffsetFunction(PreprocessorFunctionBase):
        workarounds for running the package on data with metadata (i.e., units)
        that are known to be incorrect.
     """
+
     def edit_request(self, data_mgr, pod):
         """No-op for this PreprocessorFunction, since no alternate data is needed.
         """
@@ -679,20 +705,21 @@ class ApplyScaleAndOffsetFunction(PreprocessorFunctionBase):
             ds_var *= scale_factor
             del ds_var.attrs['scale_factor']
             var.log.info("Scaled values of '%s' variable in %s by a factor of %f.",
-                tv_name, var.full_name, scale_factor,
-                tags=(util.ObjectLogTag.NC_HISTORY, util.ObjectLogTag.BANNER)
-            )
+                         tv_name, var.full_name, scale_factor,
+                         tags=(util.ObjectLogTag.NC_HISTORY, util.ObjectLogTag.BANNER)
+                         )
 
         if ds_var.attrs.get('add_offset', ''):
             add_offset = float(ds_var.attrs['add_offset'])
             ds_var += add_offset
             del ds_var.attrs['add_offset']
             var.log.info("Added an offset of %f to values of '%s' variable in %s.",
-                add_offset, tv_name, var.full_name,
-                tags=(util.ObjectLogTag.NC_HISTORY, util.ObjectLogTag.BANNER)
-            )
+                         add_offset, tv_name, var.full_name,
+                         tags=(util.ObjectLogTag.NC_HISTORY, util.ObjectLogTag.BANNER)
+                         )
 
         return ds
+
 
 # ==================================================
 
@@ -782,8 +809,8 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         """
         return {
             "engine": "netcdf4",
-            "decode_cf": False,     # all decoding done by DefaultDatasetParser
-            "decode_coords": False, # so disable it here
+            "decode_cf": False,  # all decoding done by DefaultDatasetParser
+            "decode_coords": False,  # so disable it here
             "decode_times": False,
             "use_cftime": False
         }
@@ -824,7 +851,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         Returns:
             xarray Dataset containing the model data requested by *var*.
         """
-        pass # return ds
+        pass  # return ds
 
     def clean_nc_var_encoding(self, var, name, ds_obj):
         """Clean up the ``attrs`` and ``encoding`` dicts of *ds_obj*
@@ -854,19 +881,19 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         attrs_to_delete = set([])
 
         # mark attrs with sentinel value for deletion
-        for k,v in attrs.items():
+        for k, v in attrs.items():
             if v == xr_parser.ATTR_NOT_FOUND:
                 var.log.debug("Caught unset attribute '%s' of '%s'.", k, name)
                 attrs_to_delete.add(k)
         # clean up _FillValue
         old_fillvalue = encoding.get('_FillValue', np.nan)
         if name != var.translation.name \
-            or (self.output_to_ncl and np.isnan(old_fillvalue)):
+                or (self.output_to_ncl and np.isnan(old_fillvalue)):
             encoding['_FillValue'] = None
             attrs['_FillValue'] = None
             attrs_to_delete.add('_FillValue')
         # mark attrs duplicating values in encoding for deletion
-        for k,v in encoding.items():
+        for k, v in encoding.items():
             if k in attrs:
                 if isinstance(attrs[k], bytes):
                     compare_ = False
@@ -889,11 +916,12 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         """Calls :meth:`clean_nc_var_encoding` on all sets of attributes in the
         Dataset *ds*.
         """
+
         def _clean_dict(obj):
             name = getattr(obj, 'name', 'dataset')
             encoding = getattr(obj, 'encoding', dict())
             attrs = getattr(obj, 'attrs', dict())
-            for k,v in encoding.items():
+            for k, v in encoding.items():
                 if k in attrs:
                     if isinstance(attrs[k], bytes):
                         compare_ = False
@@ -901,14 +929,14 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                         compare_ = (attrs[k].lower() != v.lower())
                     elif not isinstance(attrs[k], np.ndarray) and not hasattr(attrs[k], '__iter__'):
                         compare_ = (attrs[k] != v)
-                    elif hasattr(attrs[k], '__iter__') and not isinstance(attrs[k], str)\
+                    elif hasattr(attrs[k], '__iter__') and not isinstance(attrs[k], str) \
                             and not isinstance(attrs[k], bytes):
                         compare_ = (attrs[k].any() != v)
                     else:
                         compare_ = (attrs[k] != v)
                     if compare_ and k.lower() != 'source':
                         _log.warning("Conflict in '%s' attribute of %s: %s != %s.",
-                            k, name, v, attrs[k])
+                                     k, name, v, attrs[k])
                     del attrs[k]
 
         for vv in ds.variables.values():
@@ -975,13 +1003,13 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             ds = self.read_dataset(var)
         except Exception as exc:
             raise util.chain_exc(exc, (f"loading "
-                f"dataset for {var.full_name}."), util.DataPreprocessEvent)
-        var.log.debug("Read %d mb for %s.", ds.nbytes / (1024*1024), var.full_name)
+                                       f"dataset for {var.full_name}."), util.DataPreprocessEvent)
+        var.log.debug("Read %d mb for %s.", ds.nbytes / (1024 * 1024), var.full_name)
         try:
             ds = self.parser.parse(var, ds)
         except Exception as exc:
             raise util.chain_exc(exc, (f"parsing file "
-                f"metadata for {var.full_name}."), util.DataPreprocessEvent)
+                                       f"metadata for {var.full_name}."), util.DataPreprocessEvent)
         return ds
 
     def process_ds(self, var, ds):
@@ -998,7 +1026,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 raise util.chain_exc(exc, (f'Preprocessing on {var.full_name} '
                                            f'failed at {f.__class__.__name__}.'),
                                      util.DataPreprocessEvent
-                )
+                                     )
         return ds
 
     def write_ds(self, var, ds):
@@ -1007,7 +1035,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         implemented by the child class.
         """
         path_str = util.abbreviate_path(var.dest_path, self.WK_DIR, '$WK_DIR')
-        var.log.info("Writing %d mb to %s", ds.nbytes / (1024*1024), path_str)
+        var.log.info("Writing %d mb to %s", ds.nbytes / (1024 * 1024), path_str)
         try:
             ds = self.clean_output_attrs(var, ds)
             ds = self.log_history_attr(var, ds)
@@ -1039,6 +1067,7 @@ class SingleFilePreprocessor(MDTFPreprocessorBase):
     Implemented separately in the event that we (or the user) doesn't want to
     bring in dask as an external dependency.
     """
+
     def read_dataset(self, var):
         """Read a single file Dataset specified by the ``local_data`` attribute of
         *var*, using :meth:`read_one_file`.
@@ -1049,6 +1078,7 @@ class SingleFilePreprocessor(MDTFPreprocessorBase):
 class NullPreprocessor(MDTFPreprocessorBase):
     """A class that skips preprocessing and just symlinks files from the input dir to the wkdir
     """
+
     def __init__(self, data_mgr, pod):
         config = core.ConfigManager()
         self.overwrite_ds = config.get('overwrite_file_metadata', False)
@@ -1119,6 +1149,7 @@ class DaskMultiFilePreprocessor(MDTFPreprocessorBase):
         *var*, wrapping xarray `open_mfdataset()
         <https://xarray.pydata.org/en/stable/generated/xarray.open_mfdataset.html>`__.
         """
+
         def _file_preproc(ds):
             for f in self.file_preproc_functions:
                 ds = f.process(var, ds)
@@ -1129,12 +1160,12 @@ class DaskMultiFilePreprocessor(MDTFPreprocessorBase):
             ds = self.read_one_file(var, var.local_data)
             return _file_preproc(ds)
         else:
-            assert not var.is_static # just to be safe
+            assert not var.is_static  # just to be safe
             var.log.debug("Loaded multi-file dataset of %d files:\n%s",
-                len(var.local_data),
-                '\n'.join(4*' ' + f"'{f}'" for f in var.local_data),
-                tags=util.ObjectLogTag.IN_FILE
-            )
+                          len(var.local_data),
+                          '\n'.join(4 * ' ' + f"'{f}'" for f in var.local_data),
+                          tags=util.ObjectLogTag.IN_FILE
+                          )
             return xr.open_mfdataset(
                 var.local_data,
                 combine="by_coords",
@@ -1143,8 +1174,8 @@ class DaskMultiFilePreprocessor(MDTFPreprocessorBase):
                 # all non-concat'ed vars must be the same; global attrs can differ
                 # from file to file; values in ds are taken from first file
                 compat="equals",
-                join="exact",        # raise ValueError if non-time dims conflict
-                parallel=True,       # use dask
+                join="exact",  # raise ValueError if non-time dims conflict
+                parallel=True,  # use dask
                 preprocess=_file_preproc,
                 **self.open_dataset_kwargs
             )
@@ -1181,7 +1212,6 @@ class MultirunDaskMultiFilePreprocessor(DaskMultiFilePreprocessor):
         # initialize PreprocessorFunctionBase objects
         self.file_preproc_functions = \
             [cls_(data_mgr) for cls_ in self._file_preproc_functions]
-
 
     def edit_request(self, data_mgr, *args):
         """Edit *pod*\'s data request, based on the child class's functionality. If
@@ -1292,7 +1322,7 @@ class MultirunDefaultPreprocessor(MultirunDaskMultiFilePreprocessor):
                 break
 
         path_str = util.abbreviate_path(var.dest_path, wkdir, '$WK_DIR')
-        var.log.info("Writing %d mb to %s", ds.nbytes / (1024*1024), path_str)
+        var.log.info("Writing %d mb to %s", ds.nbytes / (1024 * 1024), path_str)
         try:
             ds = self.clean_output_attrs(var, ds)
             ds = self.log_history_attr(var, ds)
@@ -1361,8 +1391,8 @@ class MultirunPrecipRateToFluxFunction(PrecipRateToFluxFunction):
             # requested rate, so add alternate for flux
             v_to_translate = copy_as_alternate(
                 v, data_mgr,
-                standard_name = self._rate_d[std_name],
-                units = units.to_cfunits(v.units) * self._liquid_water_density
+                standard_name=self._rate_d[std_name],
+                units=units.to_cfunits(v.units) * self._liquid_water_density
             )
         elif std_name in self._flux_d:
             # requested flux, so add alternate for rate
@@ -1377,7 +1407,7 @@ class MultirunPrecipRateToFluxFunction(PrecipRateToFluxFunction):
             new_tv = translate.translate(data_mgr.attrs.convention, v_to_translate)
         except KeyError as exc:
             self.log.debug(('%s edit_request on %s: caught %r when trying to '
-                           'translate \'%s\'; varlist unaltered.'), self.__class__.__name__,
+                            'translate \'%s\'; varlist unaltered.'), self.__class__.__name__,
                            v.full_name, exc, v_to_translate.standard_name)
             return None
         new_v = copy_as_alternate(v, data_mgr)
@@ -1415,6 +1445,7 @@ class MultirunExtractLevelFunction(ExtractLevelFunction):
        from data_mgr parameter with information from the MultirunDiagnostic object
        rather than the pod parameter
     """
+
     @multirun_edit_request_wrapper
     def edit_request(self, v, data_mgr, *args):
         """Edit the *pod*'s :class:`~src.diagnostic.Varlist` prior to data query.
@@ -1435,9 +1466,9 @@ class MultirunExtractLevelFunction(ExtractLevelFunction):
             # hit this if VE didn't request Z level extraction; do nothing
             return None
 
-        tv = v.translation # abbreviate
+        tv = v.translation  # abbreviate
         if len(tv.scalar_coords) == 0:
-            raise AssertionError # should never get here
+            raise AssertionError  # should never get here
         elif len(tv.scalar_coords) > 1:
             raise NotImplementedError()
         # wraps method in data_model; makes a modified copy of translated var

--- a/src/xr_parser.py
+++ b/src/xr_parser.py
@@ -1059,8 +1059,10 @@ class DefaultDatasetParser:
         """
         for coord in ds.cf.axes_values(our_var.name).values():
             # .axes_values() will have thrown TypeError if XYZT axes not all uniquely defined
-            assert isinstance(coord, xr.core.dataarray.DataArray), \
-                "Assertion failed: " + coord + " not found in ds.cf.axes_values"
+            assert isinstance(coord, list), \
+                "Assertion failed: " + coord + " is not a list"
+            assert isinstance(coord[0], xr.DataArray), \
+                "Assertion failed: " + coord[0] + " is not an instance of xarray.DataArray"
 
         # check set of dimension coordinates (array dimensionality) agrees
         our_axes_set = our_var.dim_axes_set

--- a/src/xr_parser.py
+++ b/src/xr_parser.py
@@ -11,7 +11,7 @@ import re
 import warnings
 from abc import ABC
 
-import cftime # believe explict import needed for cf_xarray date parsing?
+import cftime  # believe explict import needed for cf_xarray date parsing?
 import cf_xarray
 import xarray as xr
 import numpy as np
@@ -19,18 +19,19 @@ import numpy as np
 from src import util, units, core
 
 import logging
+
 _log = logging.getLogger(__name__)
 
 # TODO: put together a proper CV for all CF convention attributes
 _cf_calendars = (
     "gregorian",
-    "standard", # synonym for gregorian
+    "standard",  # synonym for gregorian
     "proleptic_gregorian",
     "julian",
     "noleap",
-    "365_day", # synonym for noleap
+    "365_day",  # synonym for noleap
     "all_leap",
-    "366_day", # synonym for all_leap
+    "366_day",  # synonym for all_leap
     "360_day",
     "none"
 )
@@ -59,6 +60,7 @@ class PlaceholderScalarCoordinate():
     units: str = ATTR_NOT_FOUND
     """Units of the coordinate."""
 
+
 # ========================================================================
 # Customize behavior of cf_xarray accessor
 # (https://github.com/xarray-contrib/cf-xarray, https://cf-xarray.readthedocs.io/en/latest/)
@@ -74,10 +76,10 @@ def patch_cf_xarray_accessor(mod):
     `<https://github.com/xarray-contrib/cf-xarray/issues/23>`__.
     """
     _ax_to_coord = {
-        "X": ("longitude", ),
-        "Y": ("latitude", ),
-        "Z": ("vertical", ),
-        "T": ("time", )
+        "X": ("longitude",),
+        "Y": ("latitude",),
+        "Z": ("vertical",),
+        "T": ("time",)
     }
     func_name = "_get_axis_coord"
     old_get_axis_coord = getattr(mod, func_name, None)
@@ -116,6 +118,7 @@ class MDTFCFAccessorMixin(object):
     accessor `extension mechanism
     <http://xarray.pydata.org/en/stable/internals/extending-xarray.html>`__.
     """
+
     @property
     def is_static(self):
         """Returns bool according to whether the Dataset/DataArray has/is a time
@@ -129,7 +132,7 @@ class MDTFCFAccessorMixin(object):
         by :meth:`DefaultDatasetParser.normalize_calendar`). Returns None if
         no time axis.
         """
-        ds = self._obj # abbreviate
+        ds = self._obj  # abbreviate
         t_names = cf_xarray.accessor._get_axis_coord(ds, "T")
         if not t_names:
             return None
@@ -154,7 +157,8 @@ class MDTFCFAccessorMixin(object):
             axes_obj = self._obj
         else:
             # filter Dataset on axes associated with a specific variable
-            assert isinstance(self._obj, xr.core.dataset.Dataset)
+            assert isinstance(self._obj, xr.core.dataset.Dataset), 'Assertion failed:' \
+                                                                   'self._obj not instance of xr.core.dataset.Dataset'
             axes_obj = self._obj[var_name]
         vardict = {
             key: cf_xarray.accessor.apply_mapper(
@@ -176,7 +180,7 @@ class MDTFCFAccessorMixin(object):
         # lat & lon coords
         if len(coords_list) > len(dims_list):
             # subtract the coordinate list from the dimensions list
-            subset_dims = list(set(dims_list)-set(coords_list))
+            subset_dims = list(set(dims_list) - set(coords_list))
             # determine if we have a time dimension to deal with;
             # add back in the time dimension if necessary
             if vardict["T"]:
@@ -231,6 +235,13 @@ class MDTFCFAccessorMixin(object):
                 _log.warning('cf_xarray fix: assuming %s is %s axis for %s',
                              dims_list[0], empty_keys[0], var_name)
                 vardict[empty_keys[0]] = [dims_list[0]]
+            # dimensions can be associated with subset dims only,
+            # as is the case with variables that have coordinates
+            # that differ from their dimensions
+            elif any(subset_dims):
+                for d in dims_list:
+                    if d not in subset_dims:
+                        _log.error(f'Dimension {d} not in subset_dims')
             else:
                 _log.error(("cf_xarray error: couldn't assign %s to axes for %s"
                             "(assigned axes: %s)"), dims_list, var_name, vardict)
@@ -255,6 +266,7 @@ class MDTFCFDatasetAccessorMixin(MDTFCFAccessorMixin):
     `extension mechanism
     <http://xarray.pydata.org/en/stable/internals/extending-xarray.html>`__.
     """
+
     def scalar_coords(self, var_name=None):
         """Return a list of the Dataset variable objects corresponding to scalar
         coordinates on the entire Dataset, or on *var_name* if given. If a
@@ -322,13 +334,8 @@ class MDTFCFDatasetAccessorMixin(MDTFCFAccessorMixin):
                     new_coords.append(dummy_coord)
             if new_coords:
                 if var_name is not None:
-                    # Verify that we only have one coordinate for each axis if
-                    # we're getting axes for a single variable
-                    if len(new_coords) != 1:
-                        raise TypeError(f"More than one {ax} axis found for "
-                                        f"'{var_name}': {new_coords}.")
-                    d[ax] = new_coords[0]
-                else:
+                    # allow multiple coordinates for each axis
+                    # required for data on ocean grids
                     d[ax] = new_coords
         return d
 
@@ -344,6 +351,7 @@ class MDTFDataArrayAccessorMixin(MDTFCFAccessorMixin):
     `extension mechanism
     <http://xarray.pydata.org/en/stable/internals/extending-xarray.html>`__.
     """
+
     def dim_axes(self):
         """Map axes labels to the (unique) coordinate variable name,
         instead of a list of names as in cf_xarray. Filter on dimension coordinates
@@ -379,6 +387,7 @@ with warnings.catch_warnings():
         'ignore', category=xr.core.extensions.AccessorRegistrationWarning
     )
 
+
     @xr.register_dataset_accessor("cf")
     class MDTFCFDatasetAccessor(
         MDTFCFDatasetAccessorMixin, cf_xarray.accessor.CFDatasetAccessor, ABC
@@ -388,6 +397,7 @@ with warnings.catch_warnings():
         cf_xarray Dataset accessor.
         """
         pass
+
 
     @xr.register_dataarray_accessor("cf")
     class MDTFCFDataArrayAccessor(
@@ -399,6 +409,7 @@ with warnings.catch_warnings():
         """
         pass
 
+
 # ========================================================================
 
 
@@ -408,6 +419,7 @@ class DefaultDatasetParser:
 
     Top-level methods are :meth:`parse` and :meth:`get_unmapped_names`.
     """
+
     def __init__(self, data_mgr, pod):
         """Constructor.
 
@@ -421,9 +433,9 @@ class DefaultDatasetParser:
         self.overwrite_ds = config.get('overwrite_file_metadata', False)
         self.guess_names = False
 
-        self.fallback_cal = 'proleptic_gregorian' # CF calendar used if no attribute found
+        self.fallback_cal = 'proleptic_gregorian'  # CF calendar used if no attribute found
         self.attrs_backup = dict()
-        self.log = pod.log # temporary
+        self.log = pod.log  # temporary
 
     def setup(self, data_mgr, pod):
         """Hook for use by child classes (currently unused) to do additional
@@ -461,18 +473,19 @@ class DefaultDatasetParser:
         Returns:
             Element of *options* matching *attr_name*.
         """
+
         def str_munge(s):
             # for case-insensitive comparison function: make string lowercase
             # and drop non-alphanumeric chars
             return re.sub(r'[^a-z0-9]+', '', s.lower())
 
         if comparison_func is None:
-            comparison_func = (lambda x,y: x == y)
+            comparison_func = (lambda x, y: x == y)
         options = util.to_iter(options)
         test_count = sum(comparison_func(opt, attr_name) for opt in options)
         if test_count > 1:
             self.log.debug("Found multiple values of '%s' set for '%s'.",
-                attr_name, attr_desc)
+                           attr_name, attr_desc)
         if test_count >= 1:
             return attr_name
         munged_opts = [
@@ -482,8 +495,8 @@ class DefaultDatasetParser:
         if sum(tup[0] for tup in munged_opts) == 1:
             guessed_attr = [tup[1] for tup in munged_opts if tup[0]][0]
             self.log.debug("Correcting '%s' to '%s' as the intended value for '%s'.",
-                attr_name, guessed_attr, attr_desc,
-                tags=util.ObjectLogTag.NC_HISTORY)
+                           attr_name, guessed_attr, attr_desc,
+                           tags=util.ObjectLogTag.NC_HISTORY)
             return guessed_attr
         # Couldn't find a match
         if default is not None:
@@ -525,7 +538,7 @@ class DefaultDatasetParser:
                 try:
                     k = self.guess_attr(
                         key_name, key_startswith, d.keys(),
-                        comparison_func=(lambda x,y: x.startswith(y))
+                        comparison_func=(lambda x, y: x.startswith(y))
                     )
                 except KeyError:
                     k = None
@@ -563,6 +576,7 @@ class DefaultDatasetParser:
         <https://xarray.pydata.org/en/stable/generated/xarray.decode_cf.html>`__
         or the cf_xarray accessor.
         """
+
         def strip_(v):
             # strip leading, trailing whitespace from all string-valued attributes
             return v.strip() if isinstance(v, str) else v
@@ -594,6 +608,7 @@ class DefaultDatasetParser:
         attributes defined in the netCDF file. Restore them from the backups
         made in :meth:`munge_ds_attrs`, but only if the attribute was deleted.
         """
+
         def _restore_one(name, attrs_d):
             backup_d = self.attrs_backup.get(name, dict())
             for k, v in backup_d.items():
@@ -606,7 +621,7 @@ class DefaultDatasetParser:
                                 # log warning but still update attrs
                                 self.log.warning("%s: discrepancy for attr '%s': '%s' != '%s'.",
                                                  name, k, vv, attrs_d[k])
-                    elif hasattr(v, '__iter__') and not isinstance(v, str) and v.any() not in attrs_d[k]\
+                    elif hasattr(v, '__iter__') and not isinstance(v, str) and v.any() not in attrs_d[k] \
                             or v != attrs_d[k]:
                         self.log.warning("%s: discrepancy for attr '%s': '%s' != '%s'.",
                                          name, k, v, attrs_d[k])
@@ -682,13 +697,13 @@ class DefaultDatasetParser:
         if var_name is not None:
             # success, narrowed down to one guess
             self.log.info(("Selecting '%s' as the intended dependent variable name "
-                "for '%s' (expected '%s')."), var_name, var.name, ds_var_name,
-                tags=util.ObjectLogTag.BANNER)
+                           "for '%s' (expected '%s')."), var_name, var.name, ds_var_name,
+                          tags=util.ObjectLogTag.BANNER)
             var.translation.name = var_name
         else:
             # give up; too ambiguous to guess
             raise util.MetadataError(("Couldn't guess intended dependent variable "
-                f"name: expected {ds_var_name}, received {list(ds.variables)}."))
+                                      f"name: expected {ds_var_name}, received {list(ds.variables)}."))
 
     def normalize_metadata(self, var, ds):
         """Normalize name, standard_name and units attributes after decode_cf
@@ -713,7 +728,7 @@ class DefaultDatasetParser:
     # --- Methods for comparing Dataset attrs against our record  ---
 
     def compare_attr(self, our_attr_tuple, ds_attr_tuple, comparison_func=None,
-        fill_ours=True, fill_ds=False, overwrite_ours=None):
+                     fill_ours=True, fill_ds=False, overwrite_ours=None):
         """Worker function to compare two attributes (on *our_var*, the
         framework's record, and on *ds*, the "ground truth" of the dataset) and
         update one in the event of disagreement.
@@ -742,7 +757,7 @@ class DefaultDatasetParser:
         our_var, our_attr_name, our_attr = our_attr_tuple
         ds_var, ds_attr_name, ds_attr = ds_attr_tuple
         if comparison_func is None:
-            comparison_func = (lambda x,y: x == y)
+            comparison_func = (lambda x, y: x == y)
         # told to update our metadata, but only do so if we weren't told to
         # ignore ds's metadata and the metadata is actually present on ds
         fill_ours = (fill_ours and ds_attr is not ATTR_NOT_FOUND)
@@ -751,15 +766,15 @@ class DefaultDatasetParser:
         if self.overwrite_ds:
             # user set CLI option to force overwrite of ds from our_var
             fill_ds = True
-            fill_ours = True       # only if missing on our_var & present on ds
-            overwrite_ours = False # overwrite conflicting data on ds from our_var
+            fill_ours = True  # only if missing on our_var & present on ds
+            overwrite_ours = False  # overwrite conflicting data on ds from our_var
 
         if ds_attr is ATTR_NOT_FOUND or (not ds_attr):
             # ds_attr wasn't defined
             if fill_ds:
                 # update ds with our value
                 self.log.info("No %s for '%s' found in dataset; setting to '%s'.",
-                    ds_attr_name, ds_var.name, str(our_attr))
+                              ds_attr_name, ds_var.name, str(our_attr))
                 ds_var.attrs[ds_attr_name] = str(our_attr)
                 return
             else:
@@ -801,10 +816,10 @@ class DefaultDatasetParser:
                 else:
                     msg_addon = ''
                 self.log.info(("Changing attribute '%s' for dataset variable '%s' "
-                    "from '%s' to our value '%s'%s."),
-                    ds_attr_name, ds_var.name, ds_attr, our_attr, msg_addon,
-                    tags=util.ObjectLogTag.NC_HISTORY
-                )
+                               "from '%s' to our value '%s'%s."),
+                              ds_attr_name, ds_var.name, ds_attr, our_attr, msg_addon,
+                              tags=util.ObjectLogTag.NC_HISTORY
+                              )
                 ds_var.attrs[ds_attr_name] = str(our_attr)
                 return
         else:
@@ -856,7 +871,7 @@ class DefaultDatasetParser:
             if self.guess_names:
                 # attempt to match on standard_name attribute if present in data
                 ds_names = [v.name for v in ds.variables \
-                    if v.attrs.get('standard_name', "") == our_var.standard_name]
+                            if v.attrs.get('standard_name', "") == our_var.standard_name]
                 if len(ds_names) == 1:
                     # success, narrowed down to one guess
                     self.log.info(("Selecting '%s' as the intended name for '%s' "
@@ -864,7 +879,7 @@ class DefaultDatasetParser:
                                   our_var.standard_name, ds_var_name,
                                   tags=util.ObjectLogTag.BANNER)
                     ds_var_name = ds_names[0]
-                    overwrite_ours = True # always overwrite for this case
+                    overwrite_ours = True  # always overwrite for this case
                 else:
                     # failure
                     raise util.MetadataError(f"Variable name '{ds_var_name}' not "
@@ -940,7 +955,7 @@ class DefaultDatasetParser:
         (*our_var*) with what's set in the xarray.Dataset (*ds_var*). If there's a
         discrepancy, log an error but change the entry in *our_var*.
         """
-        attr_name = '_scalar_coordinate_value' # placeholder
+        attr_name = '_scalar_coordinate_value'  # placeholder
 
         def _compare_value_only(our_var, ds_var):
             # may not have units info on ds_var, so only compare the numerical
@@ -996,7 +1011,7 @@ class DefaultDatasetParser:
         try:
             _compare_value_and_units(
                 our_var, ds_var,
-                comparison_func=(lambda x,y: units.units_equal(x,y, rtol=1.0e-5))
+                comparison_func=(lambda x, y: units.units_equal(x, y, rtol=1.0e-5))
             )
         except util.MetadataEvent as exc:
             self.log.warning("%s %r.", util.exc_descriptor(exc), exc)
@@ -1018,17 +1033,17 @@ class DefaultDatasetParser:
         # Inherit standard_name from our_coord if not present (regardless of
         # skip_std_name), overwriting metadata on bounds if different
         self.reconcile_attr(our_coord, bounds, 'standard_name',
-            fill_ours=False, fill_ds=True, overwrite_ours=False
-        )
+                            fill_ours=False, fill_ds=True, overwrite_ours=False
+                            )
         # Inherit units from our_coord if not present (regardless of skip_units),
         # overwriting metadata on bounds if different
         self.reconcile_attr(our_coord, bounds, 'units',
-            comparison_func=units.units_equal,
-            fill_ours=False, fill_ds=True, overwrite_ours=False
-        )
+                            comparison_func=units.units_equal,
+                            fill_ours=False, fill_ds=True, overwrite_ours=False
+                            )
         if our_coord.name != bounds.name:
             self.log.debug("Updating %s for '%s' to value '%s' from dataset.",
-                'bounds', our_coord.name, bounds.name)
+                           'bounds', our_coord.name, bounds.name)
         our_coord.bounds_var = bounds
 
     def reconcile_dimension_coords(self, our_var, ds):
@@ -1045,7 +1060,7 @@ class DefaultDatasetParser:
         for coord in ds.cf.axes_values(our_var.name).values():
             # .axes_values() will have thrown TypeError if XYZT axes not all uniquely defined
             assert isinstance(coord, xr.core.dataarray.DataArray), \
-            "Assertion failed: " + coord + " not found in ds.cf.axes_values"
+                "Assertion failed: " + coord + " not found in ds.cf.axes_values"
 
         # check set of dimension coordinates (array dimensionality) agrees
         our_axes_set = our_var.dim_axes_set
@@ -1104,16 +1119,16 @@ class DefaultDatasetParser:
         if len(our_axes) != 0 and len(ds_axes) == 0:
             # warning but not necessarily an error if coordinate dims agree
             self.log.debug(("Dataset did not provide any scalar coordinate "
-                "information, expected %s."), list(zip(our_names, our_axes)))
+                            "information, expected %s."), list(zip(our_names, our_axes)))
         elif our_axes != ds_axes:
             self.log.warning(("Conflict in scalar coordinates for %s: expected ",
-                "%s; dataset has %s."),
-                our_var.name,
-                list(zip(our_names, our_axes)), list(zip(ds_names, ds_axes))
-            )
+                              "%s; dataset has %s."),
+                             our_var.name,
+                             list(zip(our_names, our_axes)), list(zip(ds_names, ds_axes))
+                             )
         for coord in our_scalars:
             if coord.axis not in ds_var.cf.axes():
-                continue # already logged
+                continue  # already logged
             ds_coord_name = ds_var.cf.axes().get(coord.axis)
             if ds_coord_name in ds:
                 # scalar coord is present in Dataset as a dimension coordinate of
@@ -1128,8 +1143,8 @@ class DefaultDatasetParser:
                 # At any rate, we only have a PlaceholderScalarCoordinate object,
                 # which only gives us the name. Assume everything else OK.
                 self.log.warning(("Dataset only records scalar coordinate '%s' as "
-                    "a name attribute; assuming value and units are correct."),
-                    ds_coord_name)
+                                  "a name attribute; assuming value and units are correct."),
+                                 ds_coord_name)
                 self.reconcile_name(coord, ds_coord_name, overwrite_ours=True)
 
     def reconcile_variable(self, var, ds):
@@ -1138,7 +1153,7 @@ class DefaultDatasetParser:
         coordinates in *translated_var* (our expectation, based on the DataSource's
         naming convention) with attributes actually present in the Dataset *ds*.
         """
-        tv = var.translation # abbreviate
+        tv = var.translation  # abbreviate
         # check name, std_name, units on variable itself
         self.reconcile_names(tv, ds, tv.name, overwrite_ours=None)
         self.reconcile_units(tv, ds[tv.name])
@@ -1156,6 +1171,7 @@ class DefaultDatasetParser:
         Sets the "calendar" attr on the time coordinate, if it exists, in order
         to be read by the calendar property defined in the cf_xarray accessor.
         """
+
         def _get_calendar(d):
             self.normalize_calendar(d)
             return d.get('calendar', None)
@@ -1165,7 +1181,7 @@ class DefaultDatasetParser:
             return  # assume static data
         elif len(t_coords) > 1:
             self.log.error("Found multiple time axes. Ignoring all but '%s'.",
-                t_coords[0].name)
+                           t_coords[0].name)
         t_coord = t_coords[0]
 
         # normal case: T axis has been parsed into cftime Datetime objects, and
@@ -1178,7 +1194,7 @@ class DefaultDatasetParser:
             cftime_cal = _get_calendar(ds.attrs)
         if not cftime_cal:
             self.log.error("No calendar associated with '%s' found; using '%s'.",
-                t_coord.name, self.fallback_cal)
+                           t_coord.name, self.fallback_cal)
             cftime_cal = self.fallback_cal
         t_coord.attrs['calendar'] = self.guess_attr(
             'calendar', cftime_cal, _cf_calendars, default=self.fallback_cal)
@@ -1310,6 +1326,7 @@ class MultirunDefaultDatasetParser(DefaultDatasetParser):
 
     Top-level methods are :meth:`parse` and :meth:`get_unmapped_names`.
     """
+
     def __init__(self, data_mgr):
         """Constructor.
 


### PR DESCRIPTION


**Description**
* update axes_values and _old_axes_dict xr_parser methods to allow for multiple variable coordinates associated with a dimension, and for the dimensions to differ from said coordinates

* allow time coordinates in CropDateRangeFunction process method to be lists in the event that a variable has multiple dimension coordinates
*  add Potential Temperature SST variable to NCAR fieldlist

Associated issue #465 

**How Has This Been Tested?**
Tested on Linux RHEL8 OS w/Python 3.10

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.10 or above (preferred; required if funded by a CPO grant), NCL, or R
- [x] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [x] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [x] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [x] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [x] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [x] I have provided the code to generate digested data files from raw data files
- [x] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [x] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
