### PR TITLE
stop the macos tests in the ci

### DIFF
--- a/.github/workflows/mdtf_tests.yml
+++ b/.github/workflows/mdtf_tests.yml
@@ -18,8 +18,10 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        conda-root: [/usr/share/miniconda3, /Users/runner/miniconda3]
+        # [ubuntu-latest macos-latest]
+        os: [ubuntu-latest]
+        # [/usr/share/miniconda3 /Users/runner/miniconda3]
+        conda-root: [/usr/share/miniconda3]
         json-file: ["tests/github_actions_test_ubuntu_set1.jsonc","tests/github_actions_test_macos_set1.jsonc"]
         json-file-set2: ["tests/github_actions_test_ubuntu_set2.jsonc", "tests/github_actions_test_macos_set2.jsonc"]
         json-file-set3: ["tests/github_actions_test_ubuntu_set3.jsonc", "tests/github_actions_test_macos_set3.jsonc"]
@@ -34,26 +36,26 @@ jobs:
             json-file-set2: "tests/github_actions_test_macos_set2.jsonc"
           - os: ubuntu-latest
             json-file-set3: "tests/github_actions_test_macos_set3.jsonc"
-          - os: macos-latest
-            conda-root: /usr/share/miniconda3
-          - os: macos-latest
-            json-file: "tests/github_actions_test_ubuntu_set1.jsonc"
-          - os: macos-latest
-            json-file-set2: "tests/github_actions_test_ubuntu_set2.jsonc"
-          - os: macos-latest
-            json-file-set3: "tests/github_actions_test_ubuntu_set3.jsonc"
-          - conda-root: /usr/share/miniconda3
-            json-file: "tests/github_actions_test_macos_set1.jsonc"
-          - conda-root: /Users/runner/minconda3
-            json-file: "tests/github_actions_test_ubuntu_set1.jsonc"
-          - conda-root: /usr/share/miniconda3
-            json-file-set2: "tests/github_actions_test_macos_set2.jsonc"
-          - conda-root: /Users/runner/minconda3
-            json-file-set2: "tests/github_actions_test_ubuntu_set2.jsonc"
-          - conda-root: /usr/share/miniconda3
-            json-file-set3: "tests/github_actions_test_macos_set3.jsonc"
-          - conda-root: /Users/runner/minconda3
-            json-file-set3: "tests/github_actions_test_ubuntu_set3.jsonc"
+          #- os: macos-latest
+          #  conda-root: /usr/share/miniconda3
+         #- os: macos-latest
+         #   json-file: "tests/github_actions_test_ubuntu_set1.jsonc"
+         # - os: macos-latest
+         #   json-file-set2: "tests/github_actions_test_ubuntu_set2.jsonc"
+         # - os: macos-latest
+         #   json-file-set3: "tests/github_actions_test_ubuntu_set3.jsonc"
+        #  - conda-root: /usr/share/miniconda3
+       #     json-file: "tests/github_actions_test_macos_set1.jsonc"
+       #   - conda-root: /Users/runner/minconda3
+       #     json-file: "tests/github_actions_test_ubuntu_set1.jsonc"
+         # - conda-root: /usr/share/miniconda3
+         #   json-file-set2: "tests/github_actions_test_macos_set2.jsonc"
+         # - conda-root: /Users/runner/minconda3
+        #    json-file-set2: "tests/github_actions_test_ubuntu_set2.jsonc"
+         # - conda-root: /usr/share/miniconda3
+         #   json-file-set3: "tests/github_actions_test_macos_set3.jsonc"
+         # - conda-root: /Users/runner/minconda3
+         #   json-file-set3: "tests/github_actions_test_ubuntu_set3.jsonc"
       max-parallel: 2
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION


**Description**
comment out macos tests because of mamba failure.
I'll re-implement them once I find a solution

```
/Users/runner/miniconda3/condabin/mamba create --name test python=3.10.0
  Warning: Traceback (most recent call last):
    File "/Users/runner/miniconda3/condabin/mamba", line 7, in <module>
  
  Traceback (most recent call last):
    File "/Users/runner/miniconda3/condabin/mamba", line 7, in <module>
  Warning:     from mamba.mamba import main
    File "/Users/runner/miniconda3/lib/python3.11/site-packages/mamba/mamba.py", line 49, in <module>
      import libmambapy as api
    File "/Users/runner/miniconda3/lib/python3.11/site-packages/libmambapy/__init__.py", line 7, in <module>
      raise e
    File "/Users/runner/miniconda3/lib/python3.11/site-packages/libmambapy/__init__.py", line 4, in <module>
  
      from mamba.mamba import main
    File "/Users/runner/miniconda3/lib/python3.11/site-packages/mamba/mamba.py", line 49, in <module>
      import libmambapy as api
    File "/Users/runner/miniconda3/lib/python3.11/site-packages/libmambapy/__init__.py", line 7, in <module>
      raise e
    File "/Users/runner/miniconda3/lib/python3.11/site-packages/libmambapy/__init__.py", line 4, in <module>
  Warning:     from libmambapy.bindings import *  # noqa: F401,F403
  
      from libmambapy.bindings import *  # noqa: F401,F403
  Warning:     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ImportError: dlopen(/Users/runner/miniconda3/lib/python3.11/site-packages/libmambapy/bindings.cpython-311-darwin.so, 0x0002): Library not loaded: '@rpath/libarchive.13.dylib'
    Referenced from: '/Users/runner/miniconda3/lib/libmamba.2.0.0.dylib'
    Reason: tried: '/Users/runner/miniconda3/lib/libarchive.13.dylib' (no such file), '/Users/runner/miniconda3/lib/python3.11/site-packages/libmambapy/../../../libarchive.13.dylib' (no such file), '/Users/runner/miniconda3/lib/python3.11/site-packages/libmambapy/../../../libarchive.13.dylib' (no such file), '/Users/runner/miniconda3/bin/../lib/libarchive.13.dylib' (no such file), '/Users/runner/miniconda3/bin/../lib/libarchive.13.dylib' (no such file), '/usr/local/lib/libarchive.13.dylib' (no such file), '/usr/lib/libarchive.13.dylib' (no such file)
```
  
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ImportError: dlopen(/Users/runner/miniconda3/lib/python3.11/site-packages/libmambapy/bindings.cpython-311-darwin.so, 0x0002): Library not loaded: '@rpath/libarchive.13.dylib'
    Referenced from: '/Users/runner/miniconda3/lib/libmamba.2.0.0.dylib'
    Reason: tried: '/Users/runner/miniconda3/lib/libarchive.13.dylib' (no such file), '/Users/runner/miniconda3/lib/python3.11/site-packages/libmambapy/../../../libarchive.13.dylib' (no such file), '/Users/runner/miniconda3/lib/python3.11/site-packages/libmambapy/../../../libarchive.13.dylib' (no such file), '/Users/runner/miniconda3/bin/../lib/libarchive.13.dylib' (no such file), '/Users/runner/miniconda3/bin/../lib/libarchive.13.dylib' (no such file), '/usr/local/lib/libarchive.13.dylib' (no such file), '/usr/lib/libarchive.13.dylib' (no such file)


Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [ ] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.10 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [ ] The repository contains no extra test scripts or data files
