### PR TITLE
Fix macos-ci

### DIFF
--- a/.github/workflows/mdtf_tests.yml
+++ b/.github/workflows/mdtf_tests.yml
@@ -74,6 +74,8 @@ jobs:
         echo "Installing XQuartz and libarchive"
         brew install --cask xquartz
         conda install -c conda-forge -n base libarchive
+        ls /Users/runner/miniconda3/pkgs
+        ln -s /Users/runner/miniconda3/pkgs/libarchive*/lib/libarchive.13.dylib /Users/runner/miniconda3/lib/
     - name: Install mamba
       run: | 
         conda install -c conda-forge -n base mamba

--- a/.github/workflows/mdtf_tests.yml
+++ b/.github/workflows/mdtf_tests.yml
@@ -74,8 +74,9 @@ jobs:
         echo "Installing XQuartz and libarchive"
         brew install --cask xquartz
         conda install -c conda-forge -n base libarchive
-        ls /Users/runner/miniconda3/pkgs
+        ls /Users/runner/miniconda3/pkgs/libarchive*/lib
         ln -s /Users/runner/miniconda3/pkgs/libarchive*/lib/libarchive.13.dylib /Users/runner/miniconda3/lib/
+        ls /Users/runner/miniconda3/lib
     - name: Install mamba
       run: | 
         conda install -c conda-forge -n base mamba

--- a/.github/workflows/mdtf_tests.yml
+++ b/.github/workflows/mdtf_tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         # [ubuntu-latest macos-latest]
-        os: [ubuntu-latest]
+        os: [macos-latest]
         # [/usr/share/miniconda3 /Users/runner/miniconda3]
         conda-root: [/usr/share/miniconda3]
         json-file: ["tests/github_actions_test_ubuntu_set1.jsonc","tests/github_actions_test_macos_set1.jsonc"]
@@ -28,22 +28,22 @@ jobs:
         # if experimental is true, other jobs to run if one fails
         experimental: [false]
         exclude:
-          - os: ubuntu-latest
-            conda-root: /Users/runner/miniconda3
-          - os: ubuntu-latest
-            json-file: "tests/github_actions_test_macos_set1.jsonc"
-          - os: ubuntu-latest
-            json-file-set2: "tests/github_actions_test_macos_set2.jsonc"
-          - os: ubuntu-latest
-            json-file-set3: "tests/github_actions_test_macos_set3.jsonc"
-          #- os: macos-latest
-          #  conda-root: /usr/share/miniconda3
-         #- os: macos-latest
-         #   json-file: "tests/github_actions_test_ubuntu_set1.jsonc"
-         # - os: macos-latest
-         #   json-file-set2: "tests/github_actions_test_ubuntu_set2.jsonc"
-         # - os: macos-latest
-         #   json-file-set3: "tests/github_actions_test_ubuntu_set3.jsonc"
+         # - os: ubuntu-latest
+         #   conda-root: /Users/runner/miniconda3
+         # - os: ubuntu-latest
+         #   json-file: "tests/github_actions_test_macos_set1.jsonc"
+         # - os: ubuntu-latest
+        #    json-file-set2: "tests/github_actions_test_macos_set2.jsonc"
+        #  - os: ubuntu-latest
+        #    json-file-set3: "tests/github_actions_test_macos_set3.jsonc"
+          - os: macos-latest
+            conda-root: /usr/share/miniconda3
+          - os: macos-latest
+            json-file: "tests/github_actions_test_ubuntu_set1.jsonc"
+          - os: macos-latest
+            json-file-set2: "tests/github_actions_test_ubuntu_set2.jsonc"
+          - os: macos-latest
+            json-file-set3: "tests/github_actions_test_ubuntu_set3.jsonc"
         #  - conda-root: /usr/share/miniconda3
        #     json-file: "tests/github_actions_test_macos_set1.jsonc"
        #   - conda-root: /Users/runner/minconda3
@@ -69,11 +69,12 @@ jobs:
     - name: Verify miniconda
       run: |
         conda info -a
-    - name: Install XQuartz if macOS
+    - name: Install XQuartz and libarchive if macOS
       if: ${{ matrix.os == 'macos-latest' && matrix.conda-root == '/Users/runner/miniconda3' }}
       run: |
         echo "Installing XQuartz"
         brew install --cask xquartz
+        conda install libarchive -n base -c conda-forge 
     - name: Set environment variables
       run: |
         echo "POD_OUTPUT=$(echo $PWD/../wkdir/GFDL.Synthetic)" >> $GITHUB_ENV

--- a/.github/workflows/mdtf_tests.yml
+++ b/.github/workflows/mdtf_tests.yml
@@ -64,6 +64,7 @@ jobs:
       with:
         miniconda-version: "latest"
         python-version: 3.10.0
+        libarchive-version: "*"
         mamba-version: "*"
         channels: conda-forge,defaults
     - name: Verify miniconda
@@ -74,7 +75,6 @@ jobs:
       run: |
         echo "Installing XQuartz"
         brew install --cask xquartz
-        conda install libarchive -n base -c conda-forge 
     - name: Set environment variables
       run: |
         echo "POD_OUTPUT=$(echo $PWD/../wkdir/GFDL.Synthetic)" >> $GITHUB_ENV

--- a/.github/workflows/mdtf_tests.yml
+++ b/.github/workflows/mdtf_tests.yml
@@ -75,8 +75,8 @@ jobs:
         brew install --cask xquartz
         conda install -c conda-forge -n base libarchive
         echo "DYNLIB_PATH=$(echo /Users/runner/miniconda3/pkgs/libarchive*/lib/libarchive.13.dylib)" >> $GITHUB_ENV
-        ls ${DYNLIB_PATH}
-        ln -s ${DYNLIB_PATH} /usr/local/lib/libarchive.13.dylib
+        ls ${{ DYNLIB_PATH }}
+        ln -s ${{ DYNLIB_PATH }} /usr/local/lib/libarchive.13.dylib
         echo "usr local ls"
         ls -l /usr/local/lib/libarchive.13.dylib
     - name: Install mamba

--- a/.github/workflows/mdtf_tests.yml
+++ b/.github/workflows/mdtf_tests.yml
@@ -74,8 +74,9 @@ jobs:
         echo "Installing XQuartz and libarchive"
         brew install --cask xquartz
         conda install -c conda-forge -n base libarchive
-        ls /Users/runner/miniconda3/pkgs/libarchive*/lib
-        ln -s /Users/runner/miniconda3/pkgs/libarchive*/lib/libarchive.13.dylib /usr/local/lib/libarchive.13.dylib
+        echo "DYNLIB_PATH=$(echo /Users/runner/miniconda3/pkgs/libarchive*/lib/libarchive.13.dylib)" >> $GITHUB_ENV
+        ls ${DYNLIB_PATH}
+        ln -s ${DYNLIB_PATH} /usr/local/lib/libarchive.13.dylib
         echo "usr local ls"
         ls -l /usr/local/lib/libarchive.13.dylib
     - name: Install mamba

--- a/.github/workflows/mdtf_tests.yml
+++ b/.github/workflows/mdtf_tests.yml
@@ -75,8 +75,8 @@ jobs:
         brew install --cask xquartz
         conda install -c conda-forge -n base libarchive
         echo "DYNLIB_PATH=$(echo /Users/runner/miniconda3/pkgs/libarchive*/lib/libarchive.13.dylib)" >> $GITHUB_ENV
-        ls ${{ DYNLIB_PATH }}
-        ln -s ${{ DYNLIB_PATH }} /usr/local/lib/libarchive.13.dylib
+        echo "${DYNLIB_PATH}"
+        ln -s "${DYNLIB_PATH}" /usr/local/lib/libarchive.13.dylib
         echo "usr local ls"
         ls -l /usr/local/lib/libarchive.13.dylib
     - name: Install mamba

--- a/.github/workflows/mdtf_tests.yml
+++ b/.github/workflows/mdtf_tests.yml
@@ -64,8 +64,6 @@ jobs:
       with:
         miniconda-version: "latest"
         python-version: 3.10.0
-        libarchive-version: "*"
-        mamba-version: "*"
         channels: conda-forge,defaults
     - name: Verify miniconda
       run: |
@@ -73,8 +71,12 @@ jobs:
     - name: Install XQuartz and libarchive if macOS
       if: ${{ matrix.os == 'macos-latest' && matrix.conda-root == '/Users/runner/miniconda3' }}
       run: |
-        echo "Installing XQuartz"
+        echo "Installing XQuartz and libarchive"
         brew install --cask xquartz
+        conda install -c conda-forge -n base libarchive
+    - name: Install mamba
+      run: | 
+        conda install -c conda-forge -n base mamba
     - name: Set environment variables
       run: |
         echo "POD_OUTPUT=$(echo $PWD/../wkdir/GFDL.Synthetic)" >> $GITHUB_ENV

--- a/.github/workflows/mdtf_tests.yml
+++ b/.github/workflows/mdtf_tests.yml
@@ -21,13 +21,21 @@ jobs:
         # [ubuntu-latest macos-latest]
         os: [macos-latest]
         # [/usr/share/miniconda3 /Users/runner/miniconda3]
-        conda-root: [/usr/share/miniconda3]
+        conda-root: [/Users/runner/miniconda3]
         json-file: ["tests/github_actions_test_ubuntu_set1.jsonc","tests/github_actions_test_macos_set1.jsonc"]
         json-file-set2: ["tests/github_actions_test_ubuntu_set2.jsonc", "tests/github_actions_test_macos_set2.jsonc"]
         json-file-set3: ["tests/github_actions_test_ubuntu_set3.jsonc", "tests/github_actions_test_macos_set3.jsonc"]
         # if experimental is true, other jobs to run if one fails
         experimental: [false]
         exclude:
+          #- os: macos-latest
+          #  conda-root: /usr/share/miniconda3
+          - os: macos-latest
+            json-file: "tests/github_actions_test_ubuntu_set1.jsonc"
+          - os: macos-latest
+            json-file-set2: "tests/github_actions_test_ubuntu_set2.jsonc"
+          - os: macos-latest
+            json-file-set3: "tests/github_actions_test_ubuntu_set3.jsonc"
          # - os: ubuntu-latest
          #   conda-root: /Users/runner/miniconda3
          # - os: ubuntu-latest
@@ -36,14 +44,6 @@ jobs:
         #    json-file-set2: "tests/github_actions_test_macos_set2.jsonc"
         #  - os: ubuntu-latest
         #    json-file-set3: "tests/github_actions_test_macos_set3.jsonc"
-          - os: macos-latest
-            conda-root: /usr/share/miniconda3
-          - os: macos-latest
-            json-file: "tests/github_actions_test_ubuntu_set1.jsonc"
-          - os: macos-latest
-            json-file-set2: "tests/github_actions_test_ubuntu_set2.jsonc"
-          - os: macos-latest
-            json-file-set3: "tests/github_actions_test_ubuntu_set3.jsonc"
         #  - conda-root: /usr/share/miniconda3
        #     json-file: "tests/github_actions_test_macos_set1.jsonc"
        #   - conda-root: /Users/runner/minconda3

--- a/.github/workflows/mdtf_tests.yml
+++ b/.github/workflows/mdtf_tests.yml
@@ -75,8 +75,9 @@ jobs:
         brew install --cask xquartz
         conda install -c conda-forge -n base libarchive
         ls /Users/runner/miniconda3/pkgs/libarchive*/lib
-        ln -s /Users/runner/miniconda3/pkgs/libarchive*/lib/libarchive.13.dylib /Users/runner/miniconda3/lib/
-        ls /Users/runner/miniconda3/lib
+        ln -s /Users/runner/miniconda3/pkgs/libarchive*/lib/libarchive.13.dylib /usr/local/lib/libarchive.13.dylib
+        echo "usr local ls"
+        ls /usr/local/lib/*
     - name: Install mamba
       run: | 
         conda install -c conda-forge -n base mamba

--- a/.github/workflows/mdtf_tests.yml
+++ b/.github/workflows/mdtf_tests.yml
@@ -77,7 +77,7 @@ jobs:
         ls /Users/runner/miniconda3/pkgs/libarchive*/lib
         ln -s /Users/runner/miniconda3/pkgs/libarchive*/lib/libarchive.13.dylib /usr/local/lib/libarchive.13.dylib
         echo "usr local ls"
-        ls /usr/local/lib/*
+        ls -l /usr/local/lib/libarchive.13.dylib
     - name: Install mamba
       run: | 
         conda install -c conda-forge -n base mamba


### PR DESCRIPTION
**Description**
Try to install libarchive into the base conda env before installing other environments to resolve mamba issue 
ref: https://github.com/mamba-org/mamba/issues/1826
Note that the ubuntu tests are commented out while testing this update

Associated issue #474  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.10 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [ ] The repository contains no extra test scripts or data files
