### PR TITLE
Slight csh fixes for error handling for GFDL frepp wrapper

### DIFF
--- a/sites/NOAA_GFDL/mdtf_gfdl.csh
+++ b/sites/NOAA_GFDL/mdtf_gfdl.csh
@@ -196,16 +196,18 @@ ${REPO_DIR}/mdtf_framework.py -f ${input_jsonc} --site NOAA_GFDL -v
 
 
 ##workaround ends
-pkg_status=$?
-echo "mdtf_gfdl.csh: MDTF finish; exit={$pkg_status}"
+set pkg_status = $status
+echo "mdtf_gfdl.csh: MDTF finish; exit=$pkg_status"
 
 # ----------------------------------------------------
 # copy/link output files to website directory, if requested
 
 if ( ! $?WEBSITE_OUTPUT_DIR ) then
     exit $pkg_status
-else if ( "$WEBSITE_OUTPUT_DIR" == "" )
-    exit $pkg_status
+else
+    if ( "$WEBSITE_OUTPUT_DIR" == "" ) then
+        exit $pkg_status
+    else
 endif
 
 # test for write access -- don't trust -w test


### PR DESCRIPTION
**Description**
The GFDL frepp wrapper works, but the error handling after running MDTF has two small problems.
1. Cshell sets variables with "set var = value" and does not accept the Bourne shell "var=value"
2. Cshell parses the "else if" clause even if the first case is true. bash/sh does not do this. (https://unix.stackexchange.com/questions/197497/how-to-check-if-string-is-blank-in-tcsh)

**How Has This Been Tested?**
While testing the FRE Canopy prototype using the mdtf wrapper in the trunk, I encountered the pkg_status variable error and an "empty if" error that were resolved by these changes.

**Checklist:**
- [ ] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.10 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [ ] The repository contains no extra test scripts or data files
