### PR TITLE
Fix temp_extremes_distshape POD

### DIFF
--- a/diagnostics/temp_extremes_distshape/TempExtDistShape_FreqDist_util.py
+++ b/diagnostics/temp_extremes_distshape/TempExtDistShape_FreqDist_util.py
@@ -186,7 +186,8 @@ def Gaussfit_Est(T2Manom_data,lat,lon,statind,statlats,statlons,citynames,binwid
 # -----  monthstr are seasons associated with each cityname
 # -----  statind is city index from loop calling function for each specified location
 # -----  plotrows and plotcols are rows and columns of subplots to figure
-def Gaussfit_Plot(fig,bin_centers,bin_counts,bin_centers_gauss,gauss_fit,Tanom_stat,ptile,citynames,monthstr,statind,plotrows,plotcols):
+def Gaussfit_Plot(fig, bin_centers, bin_counts, bin_centers_gauss, gauss_fit, Tanom_stat, ptile,
+                  citynames, monthstr, statind, plotrows, plotcols):
     ax=fig.add_subplot(int(str(plotrows)+str(plotcols)+str(statind+1)))
     ax.scatter(bin_centers,bin_counts,color='blue',marker='o',facecolors='none',s=13)
     ax.plot(bin_centers_gauss,gauss_fit,color='blue',linewidth=1)
@@ -194,12 +195,9 @@ def Gaussfit_Plot(fig,bin_centers,bin_counts,bin_centers_gauss,gauss_fit,Tanom_s
     ax.set_xlim(-mxval-numpy.nanstd(Tanom_stat),mxval+numpy.nanstd(Tanom_stat))
     ax.set_ylim(bin_counts[0]-numpy.true_divide(bin_counts[0],10),1.05)
     ax.set_yscale('log')
-    for tick in ax.xaxis.get_major_ticks():
-        tick.label.set_fontsize(11) 
-    for tick in ax.yaxis.get_major_ticks():
-        tick.label.set_fontsize(11)
+    ax.tick_params(labelsize=11)
     ax.set_title(citynames[statind],fontdict={'fontsize': 14, 'fontweight': 'heavy'})
-    ax.text(0.91, 0.92, monthstr[statind],fontsize=10,transform=ax.transAxes,weight='bold')
+    ax.text(0.91, 0.92, monthstr[statind], fontsize=10, transform=ax.transAxes, weight='bold')
 
     ### Plot binned values exceeding the percentile threshold as open circles and the rest filled
     pthresh=numpy.nanpercentile(Tanom_stat,ptile,interpolation='midpoint')


### PR DESCRIPTION
**Description**
Remove deprecated axis font size parameter specs from temp_extremes_distshape plot routine

**How Has This Been Tested?**
RHEL8, python 3.11

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
