### PR TITLE
bump intake-esm version in base yaml

### DIFF
--- a/src/conda/env_base.yml
+++ b/src/conda/env_base.yml
@@ -24,7 +24,7 @@ dependencies:
 - ecgtools=2023.7.13
 - cfunits=3.3.6
 - intake=0.7.0
-- intake-esm=2023.07.07
+- intake-esm=2023.11.10
 - subprocess32=3.5.4
 - pyyaml=6.0.1
 - click=8.1.7


### PR DESCRIPTION
**Description**
Update intake-esm to v 2023.11.10 in env_base.yml


**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
