### PR TITLE
add sphinx build action on pull request

### DIFF
--- a/.github/workflows/sphinx_action.yml
+++ b/.github/workflows/sphinx_action.yml
@@ -1,0 +1,14 @@
+name: sphinx_action
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "doc/"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -19,7 +19,6 @@ This site contains documentation for the MDTF Diagnostics framework. The code is
    sphinx/ref_toc
    sphinx/pod_toc
    sphinx/site_toc
-   sphinx/dev_toc
    sphinx/tools_toc
    sphinx/fmwk_toc
 

--- a/doc/sphinx/dev_cheatsheet.rst
+++ b/doc/sphinx/dev_cheatsheet.rst
@@ -25,14 +25,11 @@ Creating and submitting a POD
          - POD output files are written to the following locations by the framework:
             - Postscript files: ``${WORK_DIR}/[POD NAME]/[model,obs]/PS``
             - Other files, including PNG plots: ``${WORK_DIR}/[POD NAME]/[model,obs]``
-         - Set the "OUTPUT_DIR" option in default_tests.jsonc to write output files to a different location;
-"OUTPUT_DIR" defaults to "WORK_DIR" if it is not defined.
+         - Set the "OUTPUT_DIR" option in default_tests.jsonc to write output files to a different location; "OUTPUT_DIR" defaults to "WORK_DIR" if it is not defined.
          - Output figure locations:  
             - PNG files should be placed directly in ``$WORK_DIR/obs/`` and ``$WORK_DIR/model/``
-            - If a POD chooses to save vector-format figures, they should be written into the ``$WORK_DIR/obs/PS`` and ``$WORK_DIR/model/PS`` directories.
-Files in these locations will be converted by the framework to PNG, so use those names in the html file.
-            - If a POD uses matplotlib, it is recommended to write as figures as EPS instead of PS because
-of potential bugs
+            - If a POD chooses to save vector-format figures, they should be written into the ``$WORK_DIR/obs/PS`` and ``$WORK_DIR/model/PS`` directories. Files in these locations will be converted by the framework to PNG, so use those names in the html file.
+            - If a POD uses matplotlib, it is recommended to write as figures as EPS instead of PS because of potential bugs
    
    - Modify html files to point to the figure names
 
@@ -44,27 +41,20 @@ Notes:
 ------
 - **Make sure that WORK_DIR and OUTPUT_DIR have enough space to hold data for your POD(s) AND any PODs included in the package.**
 - Defining POD variables
-   - Add variables to the ``varlist`` block in the ``MDTF-diagnostics/diagnostics/[POD name]/settings.jsonc``
-and define the following:
-      - the variable name: the short name that will generate the corresponding ``${ENV_VAR}``
-(e.g., "zg500" generates the ``${ENV_VAR}`` "zg500_var")
+   - Add variables to the ``varlist`` block in the ``MDTF-diagnostics/diagnostics/[POD name]/settings.jsonc`` and define the following:
+      - the variable name: the short name that will generate the corresponding ``${ENV_VAR}`` (e.g., "zg500" generates the ``${ENV_VAR}`` "zg500_var")
       - the standard name with a corresponding entry in the appropriate fieldlist file(s)  
       - variable units
       - variable dimensions (e.g., [time, lat, lon])
-      _ variable realm (e.g., atmos, ocean ice, land)
-      - scalar coordinates for variables defined on a specific atmospheric pressure level (e.g. ``{"lev": 250}``
-for a field on the 250-hPa p level).
-   - If your variable is not in the necessary fieldlist file(s), add them to the file(s),
-or open an issue on GitHub requesting that the framework team add them.
-Once the files are updated, merge the changes from the main branch into your POD branch.
+      - variable realm (e.g., atmos, ocean ice, land)
+      - scalar coordinates for variables defined on a specific atmospheric pressure level (e.g. ``{"lev": 250}`` for a field on the 250-hPa p level).
+   
+   - If your variable is not in the necessary fieldlist file(s), add them to the file(s), or open an issue on GitHub requesting that the framework team add them. Once the files are updated, merge the changes from the main branch into your POD branch.
    - Note that the variable name and the standard name must be unique fieldlist entries
+
 - Environment variables
-   - To define an environment variable specific to your POD, add a ``"pod_env_vars"`` block to the ``"settings"``
-block in your POD's ``settings.jsonc`` file and define the desired variables
-   - Reference an environment variable associated with a specific case in Python by calling ``os.environ[case_env_file]``,
-reading the file contents into a Python dictionary, and getting value associated with the first case (assuming variable
-names and coordinates are identical for each case), e.g.
-``tas_var = [case['tas_var'] for case in case_list.values()][0]``. See ``example_multicase.py`` for more information.
+   - To define an environment variable specific to your POD, add a ``"pod_env_vars"`` block to the ``"settings"`` block in your POD's ``settings.jsonc`` file and define the desired variables
+   - Reference an environment variable associated with a specific case in Python by calling ``os.environ[case_env_file]``, reading the file contents into a Python dictionary, and getting value associated with the first case (assuming variable names and coordinates are identical for each case), e.g. ``tas_var = [case['tas_var'] for case in case_list.values()][0]``. See ``example_multicase.py`` for more information.
    - NCL code can reference environment variables by calling ``getenv("VARIABLE NAME")``  
    - Framework-specific environment variables include:
       - case_env_file: path to yaml file with case-specific environment variables:

--- a/doc/sphinx/dev_start.rst
+++ b/doc/sphinx/dev_start.rst
@@ -137,6 +137,7 @@ Recall how the framework finds a proper Conda environment for a POD. First, it s
 
       % cd $CODE_ROOT
       % ./src/conda/conda_env_setup.sh --env $your_POD_short_name --conda_root $CONDA_ROOT --env_dir $CONDA_ENV_DIR
+
    Or, if using micromamba:
 
    .. code-block:: console


### PR DESCRIPTION
**Description**
Simple implementation of ammaraskar's Github action. Upon each pull request, this action will run and build the sphinx documentation.  Warnings will be then flagged in inline comments viewable in the files changed section of the PR. This PR also includes cleanup of various files.



**How Has This Been Tested?**
Action was ran several times in forked repository. It warned about intentional errors.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
