### PR TITLE
remove old conda envs if found on build

### DIFF
--- a/src/conda/conda_env_setup.sh
+++ b/src/conda/conda_env_setup.sh
@@ -166,8 +166,15 @@ if [ "$make_envs" = "true" ]; then
         else
             conda_prefix="${_CONDA_ENV_ROOT}/${env_name}"
         fi
+	echo "$conda_prefix"
+	if [ -d "$conda_prefix" ]; then
+		# remove conda env of same name
+		echo "Removing previous conda env ${env_name}..."
+		conda remove -q -y -n "$env_name" --all
+		echo "... previous env ${env_name} removed."
+	fi
         echo "Creating conda env ${env_name} in ${conda_prefix}..."
-        "$_INSTALL_EXE" env create --force -q -p="$conda_prefix" -f="$env_file"
+        "$_INSTALL_EXE" env create -q -p="$conda_prefix" -f="$env_file" 
         echo "... conda env ${env_name} created."
     done
     "$_INSTALL_EXE" clean -aqy


### PR DESCRIPTION
**Description**
Edited conda_env_setup.sh to resolve an issue with the `--force` flag while using mamba. Added an if statement that will use conda to remove envs that have the same name as the one to be created.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Built MDTF multiple times using this shell script and everything worked all fine!

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [ ] The repository contains no extra test scripts or data files
