### PR TITLE
Fixes for cesm catalog builder and MJO_suite settings file

### DIFF
--- a/diagnostics/MJO_suite/settings.jsonc
+++ b/diagnostics/MJO_suite/settings.jsonc
@@ -13,23 +13,22 @@
     "runtime_requirements": {
       "python3": [],
       "ncl": ["contributed", "gsn_code", "gsn_csm", "shea_util", "diagnostics_cam"]
-    }
-  },
+    } 
+  }, //setttings
   "data": {
     "frequency": "day"
-  },
+  }, //data
   "dimensions": {
-    "dimensions": {
     "lat": {
-             "standard_name": "latitude",
-             "units": "degrees_north",
-             "axis": "Y"
-           },
+      "standard_name": "latitude",
+      "units": "degrees_north",
+      "axis": "Y"
+    },
     "lon": {
-             "standard_name": "longitude",
-             "units": "degrees_east",
-             "axis": "X"
-           },
+      "standard_name": "longitude",
+      "units": "degrees_east",
+      "axis": "X"
+    },
     "lev": {
       "standard_name": "air_pressure",
       "units": "hPa",
@@ -37,7 +36,7 @@
       "axis": "Z"
     },
     "time": {"standard_name": "time"}
-  },
+  }, //dimensions
   "varlist": {
     "rlut": {
       "standard_name": "toa_outgoing_longwave_flux",
@@ -79,5 +78,5 @@
       "dimensions": ["time", "lat", "lon"],
       "scalar_coordinates": {"lev": 850}
     }
-  }
+  } //dimensions
 }

--- a/src/pod_setup.py
+++ b/src/pod_setup.py
@@ -59,6 +59,7 @@ class PodObject(util.MDTFObjectBase, util.PODLoggerMixin, PodBaseClass):
         self.pod_env_vars = os.environ.copy()
         self.pod_env_vars['RGB'] = os.path.join(runtime_config.CODE_ROOT, 'shared', 'rgb')
         self.pod_env_vars['CONDA_ROOT'] = os.path.expandvars(runtime_config.conda_root)
+        self.pod_env_vars['CONDA_ENV_ROOT'] = os.path.expandvars(runtime_config.conda_env_root)
         if any(runtime_config.micromamba_exe):
             self.pod_env_vars['MICROMAMBA_EXE'] = runtime_config.micromamba_exe
         else:
@@ -144,14 +145,16 @@ class PodObject(util.MDTFObjectBase, util.PODLoggerMixin, PodBaseClass):
                 if any(v):
                     pod_env = k
                     break
+                
             pod_pkgs = runtime_reqs[pod_env]
 
             if "python" not in pod_env:
                 env_name = '_MDTF_' + pod_env.upper() + '_base'
             else:
                 env_name = '_MDTF_' + pod_env.lower() + '_base'
-            conda_root = self.pod_env_vars['CONDA_ROOT']
-            e = os.path.join(conda_root, 'envs', env_name)
+
+            conda_env_root = self.pod_env_vars['CONDA_ENV_ROOT']
+            e = os.path.join(conda_env_root,  env_name)
 
             env_dir = util.resolve_path(e,
                                         env_vars=self.pod_env_vars,

--- a/tools/catalog_builder/catalog_builder.py
+++ b/tools/catalog_builder/catalog_builder.py
@@ -265,7 +265,7 @@ class CatalogCESM(CatalogBase):
             file_parse_method = parse_cesm_timeseries
         # see https://github.com/ncar-xdev/ecgtools/blob/main/ecgtools/parsers/cesm.py
         # for more parsing methods
-        self.cb.build(file_parse_method)
+        self.cb = self.cb.build(parsing_func=file_parse_method) 
 
 
 def load_config(config):
@@ -315,7 +315,8 @@ def main(config: str):
 
     print("Time to build catalog:", timedelta(seconds=end_time - start_time))
     # save the catalog
-    print('Saving catalog to', conf['output_filename'] + ".csv")
+    print('Saving catalog to', conf['output_dir'],'/',conf['output_filename'] + ".csv")
+
     cat_obj.call_save(output_dir=conf['output_dir'],
                       output_filename=conf['output_filename']
                       )


### PR DESCRIPTION
**Description**
Fix a few small bugs:
- catalog builder in cesm mode
- MJO_suite POD settings file 
- pod_setup.py assuming envs were under CONDA_ROOT

**How Has This Been Tested?**
Run on my local machine with MJO_suite activated, envs not under CONDA_ROOT, and (tried) to build catalog in cesm mode (that still fails on my files but that is my files' fault, not the builder!)

**Checklist:**
- [x ] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [x ] The repository contains no extra test scripts or data files
