### PR TITLE
initial submodule (TempestExtremes) support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodules/tempestextremes"]
+	path = submodules/tempestextremes
+	url = https://github.com/amberchen122/tempestextremes/

--- a/doc/sphinx/ref_submodules.rst
+++ b/doc/sphinx/ref_submodules.rst
@@ -1,0 +1,63 @@
+Running Submodules
+===============================
+Functions from external packages can be called by MDTF with their inclusion in the json or yml file supplied to the framework.
+
+Inclusion in JSON file
+------------------------------
+The following block in your JSON or yml file is required for the submodule to launch:
+
+.. code-block:: js
+
+  "module_list":
+   {
+     "${MODULE_NAME}":
+       {
+         "${FUNCTION_NAME}":
+	   {
+	     "${FUNCTION_ARGS}":
+               {
+                 "arguments go here"
+               }
+           }
+       }
+   },
+
+Where, ${MODULE_NAME} is the name for the package you want to launch a function from, ${FUNCTION_NAME} is the function you want to call, and ${FUNCTION_ARGS} is the arguments to be passed to the function.
+
+TempestExtremes Example
+------------------------
+As an example, we will build and run TempestExtremes (TE) from MDTF. First, clone the latest TE with a python wrapper. As of writing, this can be found 'here <https://github.com/amberchen122/tempestextremes/>'_
+In the cloned directory, it can be built using the commands:
+
+.. code-block::
+
+   python setup.py build_ext
+   python setup.py install
+
+Now, in our JSON file we can call the function DetectNodes by including the following:
+
+.. code-block:: js
+
+   "module_list":
+     {
+     "TempestExtremes":
+       {
+         "DetectNodes":
+	   {
+	     "args":
+               {
+                 "--in_data":"./test/cn_files/outCSne30_test2.nc",
+                 "--timefilter":"6hr",
+                 "--out":"out1.dat",
+                 "--searchbymin":"MSL",
+		 "--closedcontourcmd": "PRMSL_L101,200.,4,0;TMP_L100,-0.4,8.0,1.1",
+                 "--mergedist":"6.0",
+                 "--outputcmd": "MSL,min,0;_VECMAG(VAR_10U,VAR_10V),max,2;ZS,min,0",
+                 "--latname":"lat",
+                 "--lonname":"lon"
+               }
+           }
+       }
+   },
+
+Multiple packages can be ran if they are nested in "module_list". Multiple functions can be called or even the same one again.

--- a/doc/sphinx/ref_submodules.rst
+++ b/doc/sphinx/ref_submodules.rst
@@ -14,7 +14,7 @@ The following block in your JSON or yml file is required for the submodule to la
        {
          "${FUNCTION_NAME}":
 	   {
-	     "${FUNCTION_ARGS}":
+	     "args":
                {
                  "arguments go here"
                }

--- a/doc/sphinx/ref_toc.rst
+++ b/doc/sphinx/ref_toc.rst
@@ -9,3 +9,4 @@ Framework reference
    ref_conventions
    ref_data
    ref_envvars
+   ref_submodules

--- a/mdtf_framework.py
+++ b/mdtf_framework.py
@@ -184,6 +184,14 @@ def main(ctx, configfile: str, verbose: bool = False) -> int:
         for k, v in pods[pod_name].runtime_requirements.items():
             if not hasattr(pod_runtime_reqs, k):
                 pod_runtime_reqs[k] = v
+    # run module(s)
+    if "module_list" in ctx.config:
+        for module in ctx.config.module_list:
+            module_obj = __import__(module)
+            for function in ctx.config.module_list[module]:
+                args = ctx.config.module_list[module][function].args
+                func = getattr(module_obj, function)
+                func(args)
     # read the subset of data for the cases and date range(s) and preprocess the data
     cat_subset = data_pp.process(cases, ctx.config, model_paths.MODEL_WORK_DIR)
     # write the preprocessed files

--- a/src/conda/env_base.yml
+++ b/src/conda/env_base.yml
@@ -29,3 +29,4 @@ dependencies:
 - pyyaml=6.0.1
 - click=8.1.7
 - ghostscript=10.02.1
+- pybind11=2.12.0

--- a/templates/module_config.jsonc
+++ b/templates/module_config.jsonc
@@ -1,0 +1,142 @@
+// This a template for configuring MDTF to run PODs that analyze multi-run/ensemble data
+//
+// Copy this file, rename it, and customize the settings as needed
+// Pass your file to the framework using the -f/--input-file flag.
+// Any other explicit command line options will override what's listed here.
+//
+// All text to the right of an unquoted "//" is a comment and ignored, as well
+// as blank lines (JSONC quasi-standard.)
+//
+// Remove your test config file, or any changes you make to this template if you do not rename it,
+// from your remote repository before you submit a PR for review.
+// To generate CMIP synthetic data in the example dataset, run the following:
+// > mamba env create --force -q -f ./src/conda/_env_synthetic_data.yml
+// > conda activate _MDTF_synthetic_data
+// > pip install mdtf-test-data
+// > cd <root directory>/mdtf
+// > mkdir mdtf_test_data && cd mdtf_test_data
+// > mdtf_synthetic.py -c CMIP --startyear 1980 --nyears 5
+// > mdtf_synthetic.py -c CMIP --startyear 1985 --nyears 5
+// Note that MODEL_DATA_ROOT assumes that mdtf_test_data is one directory above MDTF-diagnostics
+// in this sample config file
+{
+  // Run each ensemble on the example POD.
+  // Add other PODs that work on ensemble datasets to the pod_list as needed
+  "pod_list" : [
+      //"example"
+     "example_multicase"
+   ],
+  "module_list": 
+   {
+     "TempestExtremes":
+       { 
+         "DetectNodes":
+	   {
+	     "args":
+               {
+                 "--in_data":"./test/cn_files/outCSne30_test2.nc",
+                 "--timefilter":"6hr",
+                 "--out":"out1.dat",
+                 "--searchbymin":"MSL",
+		 "--closedcontourcmd": "PRMSL_L101,200.,4,0;TMP_L100,-0.4,8.0,1.1",
+                 "--mergedist":"6.0",
+                 "--outputcmd": "MSL,min,0;_VECMAG(VAR_10U,VAR_10V),max,2;ZS,min,0",
+                 "--latname":"lat",
+                 "--lonname":"lon"
+               }
+           }
+       }
+   },
+   // Each case corresponds to a different simulation/output dataset
+   // startdate, enddate: either YYYY-MM-DD, YYYYMMDD:HHMMSS, or YYYY-MM-DD:HHMMSS
+   "case_list":
+    {
+      "CMIP_Synthetic_r1i1p1f1_gr1_19800101-19841231":
+        {
+          "model": "test",
+          "convention": "CMIP",
+          "startdate": "19800101120000",
+          "enddate": "19841231000000"
+        }
+      ,
+      "CMIP_Synthetic_r1i1p1f1_gr1_19850101-19891231":
+        {
+          "model": "test",
+          "convention": "CMIP",
+          "startdate": "19850101",
+          "enddate": "19891231"
+        }
+    },
+  // PATHS ---------------------------------------------------------------------
+  // Location of supporting data downloaded when the framework was installed.
+  // If a relative path is given, it's resolved relative to the MDTF-diagnostics
+  // code directory. Environment variables (eg, $HOME) can be referenced with a
+  // "$" and will be expended to their current values when the framework runs.
+  // Full or relative path to model data ESM-intake catalog header file
+
+  "DATA_CATALOG": "./diagnostics/example_multicase/esm_catalog_CMIP_synthetic_r1i1p1f1_gr1.json",
+
+  // Backwards compatibility
+  "MODEL_DATA_ROOT": "../inputdata/mdtf_test_data",
+  // Parent directory containing observational data used by individual PODs.
+  "OBS_DATA_ROOT": "../inputdata/obs_data",
+
+  // Working directory.
+  "WORK_DIR": "../wkdir",
+
+  // Directory to write output. The results of each run of the framework will be
+  // put in a subdirectory of this directory. Defaults to WORKING_DIR if blank.
+  "OUTPUT_DIR": "../wkdir",
+
+  // Location of the Anaconda/miniconda or micromamba installation to use for managing
+  // dependencies (path returned by running `conda info --base` or `micromamba info`.)
+  //"conda_root": "/net/jml/miniconda3",
+  "conda_root": "/home/jacob.mims/miniconda3",
+
+  // Directory containing the framework-specific conda environments. This should
+  // be equal to the "--env_dir" flag passed to conda_env_setup.sh. If left
+  // blank, the framework will look for its environments in conda_root/envs
+  //"conda_env_root": "/net/jml/miniconda3/envs",
+  "conda_env_root": "/home/jacob.mims/miniconda3/envs",
+
+  // Location of the micromamba executable. Required if using micromamba
+  "micromamba_exe": "",
+
+  // SETTINGS ------------------------------------------------------------------
+  // Any command-line option recognized by the mdtf script (type `mdtf --help`)
+  // can be set here, in the form "flag name": "desired setting".
+
+  // Settings affecting what output is generated:
+  // Set to true to run the preprocessor; default true:
+  "run_pp": true,
+  // Set to true to perform data translation; default false:
+  "translate_data": true,
+  // Set to true to have PODs save postscript figures in addition to bitmaps.
+  "save_ps": false,
+
+  // Set to true for files > 4 GB
+  "large_file": false,
+
+  // If true, leave pp data in OUTPUT_DIR after preprocessing; if false, delete pp data after PODs
+  // run to completion
+  "save_pp_data": true,
+
+  // Set to true to save HTML and bitmap plots in a .tar file.
+  "make_variab_tar": false,
+
+  // Generate html output for multiple figures per case
+  "make_multicase_figure_html": false,
+
+  // Set to true to overwrite results in OUTPUT_DIR; otherwise results saved
+  // under a unique name.
+  "overwrite": false,
+
+  // List with custom preprocessing script(s) to run on data
+  // Place these scripts in the user_scripts directory of your copy of the MDTF-diagnostics repository
+  "user_pp_scripts" : ["example_pp_script.py"],
+
+  // Settings used in debugging:
+
+  // Log verbosity level.
+  "verbose": 1
+}

--- a/templates/module_config.jsonc
+++ b/templates/module_config.jsonc
@@ -34,15 +34,10 @@
 	   {
 	     "args":
                {
-                 "--in_data":"./test/cn_files/outCSne30_test2.nc",
-                 "--timefilter":"6hr",
-                 "--out":"out1.dat",
-                 "--searchbymin":"MSL",
-		 "--closedcontourcmd": "PRMSL_L101,200.,4,0;TMP_L100,-0.4,8.0,1.1",
-                 "--mergedist":"6.0",
-                 "--outputcmd": "MSL,min,0;_VECMAG(VAR_10U,VAR_10V),max,2;ZS,min,0",
-                 "--latname":"lat",
-                 "--lonname":"lon"
+                "--in_data":"../inputdata/mdtf_test_data/CMIP_Synthetic_r1i1p1f1_gr1_19800101-19841231/day/CMIP_Synthetic_r1i1p1f1_gr1_19800101-19841231.psl.day.nc",
+                "--timefilter":"6hr",
+                "--searchbymin":"psl",
+                "--out":"../wkdir/tempestextremes.dat"
                }
            }
        }
@@ -91,13 +86,13 @@
   // Location of the Anaconda/miniconda or micromamba installation to use for managing
   // dependencies (path returned by running `conda info --base` or `micromamba info`.)
   //"conda_root": "/net/jml/miniconda3",
-  "conda_root": "/home/jacob.mims/miniconda3",
+  "conda_root": "",
 
   // Directory containing the framework-specific conda environments. This should
   // be equal to the "--env_dir" flag passed to conda_env_setup.sh. If left
   // blank, the framework will look for its environments in conda_root/envs
   //"conda_env_root": "/net/jml/miniconda3/envs",
-  "conda_env_root": "/home/jacob.mims/miniconda3/envs",
+  "conda_env_root": "",
 
   // Location of the micromamba executable. Required if using micromamba
   "micromamba_exe": "",

--- a/templates/module_config.yml
+++ b/templates/module_config.yml
@@ -1,0 +1,80 @@
+# Runtime yaml configuration file template for the MDTF-diagnostics package
+# Create a copy of this file for personal use, and pass it to the framework
+# with the -f | --configfile flag
+
+# List of POD(s) to run
+pod_list:
+  - "example_multicase"
+  - "MJO_suite"
+
+# list of module(s) to run
+module_list:
+  "TempestExtremes":
+    "DetectNodes":
+      "args":
+        "--in_data": "../inputdata/mdtf_test_data/CMIP_Synthetic_r1i1p1f1_gr1_19800101-19841231/day/CMIP_Synthetic_r1i1p1f1_gr1_19800101-19841231.psl.day.nc"
+        "--timefilter": "6hr"
+        "--searchbymin": "psl"
+        "--out": "../wkdir/tempestextremes.dat"      
+
+# Case list entries (must be unique IDs for each simulation)
+case_list:
+  "CMIP_Synthetic_r1i1p1f1_gr1_19800101-19841231" :
+    model: "test"
+    convention: "CMIP"
+    startdate: "19800101120000"
+    enddate: "19841231000000"
+
+  "CMIP_Synthetic_r1i1p1f1_gr1_19850101-19891231" :
+    model: "test"
+    convention: "CMIP"
+    startdate: "19850101"
+    enddate: "19850101"
+
+### Data location settings ###
+# Required: full or relative path to ESM-intake catalog header file
+DATA_CATALOG: "./diagnostics/example_multicase/esm_catalog_CMIP_synthetic_r1i1p1f1_gr1.json"
+# Optional: Parent directory containing observational data used by individual PODs.
+# If defined, the framework assumes observational data is in OBS_DATA_ROOT/[POD_NAME]
+OBS_DATA_ROOT: "../inputdata/obs_data"
+# Required: Working directory location. Temporary files are written here.
+# Final output is also written here if the OUTPUT_DIR is not defined.
+WORK_DIR: "../wkdir"
+# Optional: Location to write final output if you don't want it in the wkdir
+OUTPUT_DIR: ""
+### Environment Settings ###
+# Required: Location of the Anaconda/miniconda installation to use for managing
+# dependencies (path returned by running `conda info --base`.)
+conda_root: ""
+# Optional: Directory containing the framework-specific conda environments. This should
+# be equal to the "--env_dir" flag passed to conda_env_setup.sh. If left
+# blank, the framework will look for its environments in conda_root/envs
+conda_env_root": ""
+# Location of micromamba executable; REQUIRED if using micromamba
+micromamba_exe": ""
+### Data type settings ###
+# set to true to handle data files > 4 GB
+large_file: False
+### Output Settings ###
+# Set to true to have PODs save postscript figures in addition to bitmaps.
+save_ps: False
+# If true, leave pp data in OUTPUT_DIR after preprocessing; if false, delete pp data after PODs
+# run to completion
+save_pp_data: True
+# Set to true to perform data translation; default is True:
+translate_data: True
+# Set to true to save HTML and bitmap plots in a .tar file.
+make_variab_tar: False
+# Set to true to overwrite results in OUTPUT_DIR; otherwise results saved
+# under a unique name.
+overwrite: False
+# Generate html output for multiple figures per case
+"make_multicase_figure_html": False
+### Developer settings ###
+# Set to True to run the preprocessor
+run_pp: True
+# Additional custom preprocessing scripts to run on data
+# place these scripts in the MDTF-diagnostics/user_scripts directory
+# The framework will run the specified scripts whether run_pp is set to True or False
+user_pp_scripts:
+  - ""


### PR DESCRIPTION
**Description**
Adds initial support for launching submodules (e.g. TempestExtremes) that have a python wrapper. It also adds an example json file on how to define what functions one would like to call from the submodule.

Associated issue #516 

**How Has This Been Tested?**
This was built using the entire MDTF on my thin client and demoed to @wrongkindofdoctor, while the TempestExtremes wrapper was built and ran on both my thin client and PPAN.

**Checklist:**
- [ x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
