### PR TITLE
Bug fixes for ModelDataPathManager, preprocessor user_pp_scripts att, and runtime_config.yml

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -896,7 +896,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             xarray_ds = func.execute(func, v, xarray_ds, **kwargs)
             # append custom preprocessing scripts
 
-        if any([s for s in self.user_pp_scripts]):
+        if self.user_pp_scripts and len(self.user_pp_scripts) > 0:
             for s in self.user_pp_scripts:
                 script_name, script_ext = os.path.splitext(s)
                 full_module_name = "user_scripts." + script_name
@@ -1262,6 +1262,7 @@ class DaskMultiFilePreprocessor(MDTFPreprocessorBase):
     <https://xarray.pydata.org/en/stable/generated/xarray.open_mfdataset.html>`__.
     """
     module_root: str = ""
+    user_pp_scripts: list
 
     def __init__(self,
                  model_paths: util.ModelDataPathManager,
@@ -1272,6 +1273,8 @@ class DaskMultiFilePreprocessor(MDTFPreprocessorBase):
         if any([s for s in config.user_pp_scripts]):
             self.add_user_pp_scripts(config)
             self.module_root = os.path.join(config.CODE_ROOT, "user_scripts")
+        else:
+            self.user_pp_scripts = None
 
     def add_user_pp_scripts(self, runtime_config: util.NameSpace):
         self.user_pp_scripts = [s for s in runtime_config.user_pp_scripts]

--- a/src/util/path_utils.py
+++ b/src/util/path_utils.py
@@ -124,11 +124,11 @@ class ModelDataPathManager(PathManagerBase):
 
         if hasattr(config, "MODEL_DATA_ROOT"):
             self.MODEL_DATA_ROOT = self._init_path('MODEL_DATA_ROOT', config, env=env)
-            self.MODEL_DATA_DIR = dict()
-            self.MODEL_OUTPUT_DIR = dict()
-            self.MODEL_WORK_DIR = dict()
         else:
             self.MODEL_DATA_ROOT = ""
+        self.MODEL_DATA_DIR = dict()
+        self.MODEL_OUTPUT_DIR = dict()
+        self.MODEL_WORK_DIR = dict()
 
     def setup_data_paths(self, case_list: NameSpace):
         # define directory paths for multirun mode

--- a/templates/runtime_config.yml
+++ b/templates/runtime_config.yml
@@ -5,21 +5,20 @@
 # List of POD(s) to run
 pod_list:
   - "example_multicase"
-  - "MJO_suite"
 
 # Case list entries (must be unique IDs for each simulation)
 case_list:
   "CMIP_Synthetic_r1i1p1f1_gr1_19800101-19841231" :
     model: "test"
     convention: "CMIP"
-    startdate: "19800101:000000"
-    enddate: "19841231:000000"
+    startdate: "19800101120000"
+    enddate: "19841231000000"
 
   "CMIP_Synthetic_r1i1p1f1_gr1_19850101-19891231" :
     model: "test"
     convention: "CMIP"
-    startdate: "19850101:000000"
-    enddate: "19891231:000000"
+    startdate: "19850101000000"
+    enddate: "19891231000000"
 
 ### Data location settings ###
 # Required: full or relative path to ESM-intake catalog header file
@@ -31,17 +30,17 @@ OBS_DATA_ROOT: "../inputdata/obs_data"
 # Final output is also written here if the OUTPUT_DIR is not defined.
 WORK_DIR: "../wkdir"
 # Optional: Location to write final output if you don't want it in the wkdir
-OUTPUT_DIR: ""
+OUTPUT_DIR: "../wkdir"
 ### Environment Settings ###
 # Required: Location of the Anaconda/miniconda installation to use for managing
 # dependencies (path returned by running `conda info --base`.)
-conda_root": ""
+conda_root: "/Users/jess/micromamba"
 # Optional: Directory containing the framework-specific conda environments. This should
 # be equal to the "--env_dir" flag passed to conda_env_setup.sh. If left
 # blank, the framework will look for its environments in conda_root/envs
-conda_env_root": ""
+conda_env_root: "/Users/jess/micromamba/envs"
 # Location of micromamba executable; REQUIRED if using micromamba
-micromamba_exe: ""
+micromamba_exe: "/Users/jess/.local/bin/micromamba"
 ### Data type settings ###
 # set to true to handle data files > 4 GB
 large_file: False


### PR DESCRIPTION

**Description**
* fix logic in ModelDataPathManager where MODEL_DATA_ROOT and related dicts are initialized
* initialize user_pp_scripts attribute in DaskMultiFilePreprocessor, set user_pp_scripts to None if no scripts are defined in the config, and add check for non-zero-length user_pp_scripts to preprocessor
*  fix date string def in runtime_config.yml


Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Tested with MacOS Sonoma M1 machine with Python 3.11

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
