### PR TITLE
fix bug in module_config.yml

### DIFF
--- a/templates/module_config.yml
+++ b/templates/module_config.yml
@@ -5,7 +5,6 @@
 # List of POD(s) to run
 pod_list:
   - "example_multicase"
-  - "MJO_suite"
 
 # list of module(s) to run
 module_list:
@@ -15,7 +14,7 @@ module_list:
         "--in_data": "../inputdata/mdtf_test_data/CMIP_Synthetic_r1i1p1f1_gr1_19800101-19841231/day/CMIP_Synthetic_r1i1p1f1_gr1_19800101-19841231.psl.day.nc"
         "--timefilter": "6hr"
         "--searchbymin": "psl"
-        "--out": "../wkdir/tempestextremes.dat"      
+        "--out": "../wkdir/tempestextremes.dat"
 
 # Case list entries (must be unique IDs for each simulation)
 case_list:
@@ -28,8 +27,8 @@ case_list:
   "CMIP_Synthetic_r1i1p1f1_gr1_19850101-19891231" :
     model: "test"
     convention: "CMIP"
-    startdate: "19850101"
-    enddate: "19850101"
+    startdate: "19850101000000"
+    enddate: "19891231000000"
 
 ### Data location settings ###
 # Required: full or relative path to ESM-intake catalog header file
@@ -41,7 +40,7 @@ OBS_DATA_ROOT: "../inputdata/obs_data"
 # Final output is also written here if the OUTPUT_DIR is not defined.
 WORK_DIR: "../wkdir"
 # Optional: Location to write final output if you don't want it in the wkdir
-OUTPUT_DIR: ""
+OUTPUT_DIR: "../wkdir"
 ### Environment Settings ###
 # Required: Location of the Anaconda/miniconda installation to use for managing
 # dependencies (path returned by running `conda info --base`.)
@@ -49,9 +48,9 @@ conda_root: ""
 # Optional: Directory containing the framework-specific conda environments. This should
 # be equal to the "--env_dir" flag passed to conda_env_setup.sh. If left
 # blank, the framework will look for its environments in conda_root/envs
-conda_env_root": ""
+conda_env_root: ""
 # Location of micromamba executable; REQUIRED if using micromamba
-micromamba_exe": ""
+micromamba_exe: ""
 ### Data type settings ###
 # set to true to handle data files > 4 GB
 large_file: False


### PR DESCRIPTION
**Description**

-fix issue preventing MDTF from launching using this yml 

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
ran on my thin client

**Checklist:**
- [ x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [ ] The repository contains no extra test scripts or data files
