### PR TITLE
add checks and default values for parameters that may be optionally s…

### DIFF
--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -291,16 +291,28 @@ class HTMLOutputManager(AbstractOutputManager,
     _PodOutputManagerClass = HTMLPodOutputManager
     _html_file_name = 'index.html'
     multi_case_figure: bool = False
+    make_variab_tar: bool = False
+    overwrite: bool = False
+    file_overwrite: bool = False
     WORK_DIR: str = ""
     CODE_ROOT: str = ""
     OUT_DIR: str = ""
 
     def __init__(self, pod, config):
         try:
-            self.make_variab_tar = config['make_variab_tar']
-            self.overwrite = config['overwrite']
+            if hasattr(config, 'make_variab_tar'):
+                self.make_variab_tar = config['make_variab_tar']
+            else:
+                self.make_variab_tar = False
+            if hasattr(config, 'overwrite'):
+                self.overwrite = config['overwrite']
+            else:
+                self.overwrite = False
             self.file_overwrite = self.overwrite  # overwrite both config and .tar
-            self.multi_case_figure = config['make_multicase_figure_html']
+            if hasattr(config, 'make_multicase_figure_html'):
+                self.multi_case_figure = config['make_multicase_figure_html']
+            else:
+                self.multi_case_figure = False
         except KeyError as exc:
             self.log.exception("Caught %r", exc)
 


### PR DESCRIPTION


**Description**
add checks and default values for parameters that may be optionally set at runtime
Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [ ] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [ ] The repository contains no extra test scripts or data files
