### PR TITLE
Am5 fixes

### DIFF
--- a/data/fieldlist_GFDL.jsonc
+++ b/data/fieldlist_GFDL.jsonc
@@ -14,6 +14,7 @@
     "lat": {"axis": "Y", "standard_name": "latitude", "units": "degrees_north"},
     "plev": {
       "standard_name": "air_pressure",
+      "long_name": "",
       "units": "hPa",
       "positive": "down",
       "axis": "Z"
@@ -47,6 +48,7 @@
   "variables" : {
     "ucomp": {
       "standard_name": "eastward_wind",
+      "long_name":"",
       "realm": "atmos",
       "units": "m s-1",
       "scalar_coord_templates": {"plev": "u{value}"},
@@ -54,6 +56,7 @@
     },
     "vcomp": {
       "standard_name": "northward_wind",
+      "long_name":"",
       "realm": "atmos",
       "units": "m s-1",
       "scalar_coord_templates": {"plev": "v{value}"},
@@ -61,6 +64,7 @@
     },
     "hght": {
       "standard_name": "geopotential_height",
+      "long_name":"",
       "realm": "atmos",
       "units": "m",
       "scalar_coord_templates": {"plev": "hght{value}"},
@@ -68,12 +72,14 @@
     },
     "sphum": {
       "standard_name": "specific_humidity",
+      "long_name":"",
       "realm": "atmos",
       "units": "1",
       "ndim": 4
     },
     "omega": {
       "standard_name": "lagrangian_tendency_of_air_pressure",
+      "long_name":"",
       "realm": "atmos",
       "units": "Pa s-1", // need to verify
       "scalar_coord_templates": {"plev": "omega{value}"},
@@ -82,12 +88,14 @@
     "t_surf": {
       // "skin temperature", analogue of ts
       "standard_name": "surface_temperature",
+      "long_name":"",
       "realm": "atmos",
       "units": "K",
       "ndim": 3
     },
     "precip": {
       "standard_name": "precipitation_flux",
+      "long_name":"",
       "realm": "atmos",
       "units": "kg m-2 s-1",
       "ndim": 3
@@ -102,30 +110,35 @@
       // CMIP6 equivalent = tas, temp at 2m ref height
       "standard_name": "air_temperature",
       "realm": "atmos",
+      "long_name": "temperature at 2 m",
       "units": "K",
       "ndim": 3,
       "modifier": "atmos_height"
     },
     "ps": {
       "standard_name": "surface_air_pressure",
+      "long_name": "surface pressure",
       "realm": "atmos",
       "units": "Pa", // need to verify
       "ndim": 3
     },
     "tau_x": {
       "standard_name": "surface_downward_eastward_stress",
+      "long_name": "zonal wind stress",
       "realm": "atmos",
       "units": "Pa", // need to verify
       "ndim": 3
     },
     "tau_y": {
       "standard_name": "surface_downward_northward_stress",
+      "long_name": "meridional wind stress",
       "realm": "atmos",
       "units": "Pa", // need to verify
       "ndim": 3
     },
     "slp": {
       "standard_name": "air_pressure_at_mean_sea_level",
+      "long_name": "sea level pressure",
       "realm": "atmos",
       "units": "Pa", // need to verify
       "ndim": 3
@@ -133,90 +146,105 @@
     // radiative fluxes:
     "swup_sfc": {
       "standard_name": "surface_upwelling_shortwave_flux_in_air",
+      "long_name": "",
       "realm": "atmos",
       "units": "W m-2", // need to verify
       "ndim": 3
     },
     "swdn_sfc": {
       "standard_name": "surface_downwelling_shortwave_flux_in_air",
+      "long_name": "",
       "realm": "atmos",
       "units": "W m-2", // need to verify
       "ndim": 3
     },
     "swdn_toa": {
       "standard_name": "toa_incoming_shortwave_flux",
+      "long_name": "",
       "realm": "atmos",
       "units": "W m-2", // need to verify
       "ndim": 3
     },
     "swup_toa": {
       "standard_name": "toa_outgoing_shortwave_flux",
+      "long_name": "",
       "realm": "atmos",
       "units": "W m-2", // need to verify
       "ndim": 3
     },
     "lwup_sfc": {
       "standard_name": "surface_upwelling_longwave_flux_in_air",
+      "long_name": "",
       "realm": "atmos",
       "units": "W m-2", // need to verify
       "ndim": 3
     },
     "lwdn_sfc": {
       "standard_name": "surface_downwelling_longwave_flux_in_air",
+      "long_name": "",
       "realm": "atmos",
       "units": "W m-2", // need to verify
       "ndim": 3
     },
     "olr": {
       "standard_name": "toa_outgoing_longwave_flux",
+      "long_name": "",
       "realm": "atmos",
       "units": "W m-2",
       "ndim": 3
     },
     "shflx": {
       "standard_name": "sensible_heat_flux",
+      "long_name": "",
       "realm" : "atmos",
       "units": "W m-2",
       "ndim": 3
     },
     "hfls": {
       "standard_name": "surface_upward_latent_heat_flux",
+      "long_name": "",
       "realm": "atmos",
       "units": "W m-2",
       "ndim": 3
     },
     "lwflx": {
       "standard_name": "net_longwave_flux",
+      "long_name":"",
       "realm": "atmos",
       "units": "W m-2",
       "ndim": 3
     },
     "olr_clr": {
       "standard_name": "clearsky_outgoing_longwave_radiation",
+      "long_name": "",
       "realm": "atmos",
       "units": "W m-2",
       "ndim": 3
     },
     "swdn_sfc_ad_clr": {
       "standard_name": "clear_sky_outgoing_longwave_radiation",
+      "long_name": "",
       "realm": "atmos",
       "units": "W m-2",
       "ndim": 3
     },
     "swdn_sfc_clr": {
       "standard_name": "clear_sky_SW_flux_down_at_surface_without_aerosol",
+      "long_name": "",
       "realm": "atmos",
       "units": "W m-2",
       "ndim": 3
     },
     "swdn_toa_clr": {
       "standard_name": "clear_sky_SW_flux_down_at_TOA",
+      "long_name": "",
       "realm": "atmos",
       "units": "W m-2",
       "ndim": 3
     },
     "swup_sfc_ad_clr": {
       "standard_name": "clearsky_SW_flux_up_at_surface_without_aerosol",
+      "long_name": "",
       "realm": "atmos",
       "units": "W m-2",
       "ndim": 3
@@ -241,24 +269,28 @@
     },
     "lwdn_sfc_clr": {
       "standard_name": "clea_rsky_LW_flux_down_at_surface",
+      "long_name": "",
       "realm": "atmos",
       "units": "W m-2",
       "ndim": 3
     },
     "lwsfc_ad_clr": {
       "standard_name": "clear_sky_Net_LW_flux_at_surface_without_aerosol",
+      "long_name": "",
       "realm": "atmos",
       "units": "W m-2",
       "ndim": 3
     },
     "lwtoa_ad_clr": {
       "standard_name": "clear_sky_Net_LW_flux_at_TOA_without_aerosol",
+      "long_name": "",
       "realm": "atmos",
       "units": "W m-2",
       "ndim": 3
     },
     "lwup_sfc_clr": {
       "standard_name": "clear_sky_LW_flux_up_at_surface",
+      "long_name": "",
       "realm": "atmos",
       "units": "W m-2",
       "ndim": 3
@@ -276,6 +308,7 @@
     // },
     "salt": {
       "standard_name": "sea_water_salinity",
+      "long_name": "",
       "realm": "ocean",
       "units": "psu",
       "ndim": 4
@@ -296,6 +329,7 @@
     // Variables for Convective Transition Diagnostics module:
     "temp": {
       "standard_name": "air_temperature",
+      "long_name": "",
       "realm": "atmos",
       "units": "K",
       "ndim": 4
@@ -303,6 +337,7 @@
     "WVP": {
       // column integral; over the whole column?
       "standard_name": "atmosphere_mass_content_of_water_vapor",
+      "long_name": "",
       "realm": "atmos",
       "units": "kg m-2",
       "ndim": 3
@@ -310,11 +345,13 @@
     // Variables for SM_ET_coupling module
     // "mrsos": {
     //   "standard_name": "mass_content_of_water_in_soil_layer",
+    //   "long_name": "",
     //   "units": "kg m-2",
     //   "ndim": 3
     // },
     // "evspsbl": {
     //   "standard_name": "water_evapotranspiration_flux",
+    //   "long_name": "",
     //   "units": "kg m-2 s-1",
     //   "ndim": 3
     // }

--- a/src/data_model.py
+++ b/src/data_model.py
@@ -116,6 +116,13 @@ class AbstractDMDependentVariable(abc.ABC):
         """Whether the variable has time dependence (bool)."""
         pass
 
+    @property
+    @abc.abstractmethod
+    def long_name(self):
+        """Optional variable long_name used if standard_name attribute is not defined (str).
+        """
+        pass
+
 
 class AbstractDMCoordinateBounds(AbstractDMDependentVariable):
     """Defines interface (set of attributes) for :class:`DMCoordinateBounds`
@@ -662,6 +669,7 @@ class DMDependentVariable(_DMDimensionsMixin, AbstractDMDependentVariable):
     """
     name: str = util.MANDATORY
     standard_name: str = util.MANDATORY
+    long_name: str =""
     realm: str = ""
     units: src.units.Units = ""  # not MANDATORY since may be set later from var translation
     modifier: str = ""

--- a/src/varlist_util.py
+++ b/src/varlist_util.py
@@ -170,6 +170,7 @@ class VarlistEntry(VarlistEntryBase, util.MDTFObjectBase, data_model.DMVariable,
     env_var: str = dc.field(default="", compare=False)
     path_variable: str = dc.field(default="", compare=False)
     realm: str = dc.field(default="", compare=False)
+    long_name: str = dc.field(default="", compare=False)
     dest_path: str = ""
     requirement: VarlistEntryRequirement = dc.field(
         default=VarlistEntryRequirement.REQUIRED, compare=False


### PR DESCRIPTION
**Description**
* add long_name attribute to GFDL field list
* add long_name attribute to VarlistEntry and TranslatedVarlistEntry classes to use if standard_name is not defined
* refine catalog query criteria in preprocessor

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
RHEL8 Linux
**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
