### PR TITLE
add start_time and end_time attrs to catalog_builder.py

### DIFF
--- a/tools/catalog_builder/catalog_builder.py
+++ b/tools/catalog_builder/catalog_builder.py
@@ -73,6 +73,8 @@ def parse_gfdl_pp_ts(file_name: str):
         cell_methods = ""
         cell_measures = ""
         time_range = split[1]
+        start_time = time_range.split('-')[0]
+        end_time = time_range.split('-')[1]
         variable_id = split[2]
         source_type = ""
         member_id = ""
@@ -141,6 +143,8 @@ def parse_gfdl_pp_ts(file_name: str):
                 'grid_label': grid_label,
                 'units': units,
                 'time_range': time_range,
+                'start_time': start_time,
+                'end_time': end_time,
                 'chunk_freq': chunk_freq,
                 'standard_name': standard_name,
                 'long_name': long_name,


### PR DESCRIPTION
**Description**
add the following attrs to the GFDL parser:
- end_time
- start_time

**Checklist:**
- [ ] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [ ] The repository contains no extra test scripts or data files
