### PR TITLE
Refactor translator

### DIFF
--- a/data/fieldlist_CESM.jsonc
+++ b/data/fieldlist_CESM.jsonc
@@ -9,11 +9,26 @@
   "models": ["CAM4", "CESM2", "CESM"], // others?
   "coords" : {
     // only used for taking slices, unit conversion
-    "lon": {"axis": "X", "standard_name": "longitude", "units": "degrees_east"},
-    "lat": {"axis": "Y", "standard_name": "latitude", "units": "degrees_north"},
-    "TLONG": {"axis": "X", "standard_name": "array of t-grid longitudes", "units": "degrees_east"},
-    "TLAT": {"axis": "Y", "standard_name": "array of t-grid latitudes", "units": "degrees_north"},
-
+    "lon": {
+      "axis": "X",
+      "standard_name": "longitude",
+      "units": "degrees_east"
+    },
+    "lat": {
+       "axis": "Y",
+       "standard_name": "latitude",
+       "units": "degrees_north"
+    },
+    "TLONG": {
+      "axis": "X",
+      "standard_name": "array of t-grid longitudes",
+      "units": "degrees_east"
+    },
+    "TLAT": {
+      "axis": "Y",
+      "standard_name": "array of t-grid latitudes",
+      "units": "degrees_north"
+    },
     "plev": {
       "standard_name": "air_pressure",
       "units": "hPa",
@@ -31,20 +46,12 @@
       "units": "centimeters",
       "positive": "down",
       "axis": "Z"
-   },
-    "time": {"axis": "T", "standard_name": "time", "units": "days"}
-  },
-  "aux_coords": {
-    // "deptho": {
-    //   "standard_name": "sea_floor_depth_below_geoid",
-    //   "units": "m",
-    //   "ndim": 2
-    // },
-    // "thkcello": {
-    //   "standard_name": "cell_thickness",
-    //   "units": "m",
-    //   "ndim": 3
-    // }
+    },
+    "time": {
+      "axis": "T",
+      "standard_name": "time",
+      "units": "days"
+    }
   },
   "variables" : {
     "U": {

--- a/data/fieldlist_CMIP.jsonc
+++ b/data/fieldlist_CMIP.jsonc
@@ -14,19 +14,19 @@
     },
     "$ref": "./cmip6-cmor-tables/Tables/CMIP6_coordinate.json"
    },
-  "aux_coords": {
+  "variables" : {
     "deptho": {
       "standard_name": "sea_floor_depth_below_geoid",
       "units": "m",
+      "realm": "ocean",
       "ndim": 2
     },
     "thkcello": {
       "standard_name": "cell_thickness",
       "units": "m",
+      "realm": "ocean",
       "ndim": 3
-    }
-  },
-  "variables" : {
+    },
     "ua": {
       "standard_name": "eastward_wind",
       "realm": "atmos",

--- a/data/fieldlist_GFDL.jsonc
+++ b/data/fieldlist_GFDL.jsonc
@@ -10,8 +10,16 @@
     // only used for taking slices, unit conversion
     // 'PLACEHOLDER' prefix indicates that coordinate names are to be set based
     // on their values in model data
-    "lon": {"axis": "X", "standard_name": "longitude", "units": "degrees_east"},
-    "lat": {"axis": "Y", "standard_name": "latitude", "units": "degrees_north"},
+    "lon": {
+      "axis": "X",
+      "standard_name": "longitude",
+      "units": "degrees_east"
+    },
+    "lat": {
+      "axis": "Y",
+      "standard_name": "latitude",
+      "units": "degrees_north"
+    },
     "plev": {
       "standard_name": "air_pressure",
       "long_name": "",
@@ -31,26 +39,17 @@
       "positive": "down",
       "axis": "Z"
     },
-    "time": {"axis": "T", "standard_name": "time", "units": "days"}
-  },
-  "aux_coords": {
-      "band":{
-         "standard_name": "",
-         "long_name": "spectral band",
-         "units": "1",
-         "ndim": 1
-      }
-
-    // "deptho": {
-    //   "standard_name": "sea_floor_depth_below_geoid",
-    //   "units": "m",
-    //   "ndim": 2
-    // },
-    // "thkcello": {
-    //   "standard_name": "cell_thickness",
-    //   "units": "m",
-    //   "ndim": 3
-    // }
+    "time": {
+      "axis": "T",
+      "standard_name": "time",
+      "units": "days"
+    },
+    "band": {
+      "standard_name": "spectral_band",
+      "long_name": "spectral band",
+      "units": "1",
+      "axis": ""
+    }
   },
   "variables" : {
     "areacello": {
@@ -58,6 +57,18 @@
       "realm": "ocean",
       "units": "m2",
       "ndim": 2
+    },
+    "deptho": {
+      "standard_name": "sea_floor_depth_below_geoid",
+      "units": "m",
+      "realm": "ocean",
+      "ndim": 2
+    },
+    "thkcello": {
+      "standard_name": "cell_thickness",
+      "units": "m",
+      "realm": "ocean",
+      "ndim": 3
     },
     "zos": {
       "standard_name": "sea_surface_height_above_geoid",

--- a/data/fieldlist_GFDL.jsonc
+++ b/data/fieldlist_GFDL.jsonc
@@ -20,6 +20,30 @@
       "standard_name": "latitude",
       "units": "degrees_north"
     },
+    "yh": {
+      "axis": "Y",
+      "standard_name": "h_point_nominal_longitude",
+      "long_name": "h point nominal latitude",
+      "units": "degrees_north"
+    },
+    "xq": {
+      "axis": "X",
+      "standard_name": "x_point_nominal_latitude",
+      "long_name": "x point nominal latitude",
+      "units": "degrees_north"
+    },
+    "yh": {
+      "axis": "Y",
+      "standard_name": "h_point_nominal_longitude",
+      "long_name": "h point nominal longitude",
+      "units": "degrees_north"
+    },
+    "yq": {
+      "axis": "Y",
+      "standard_name": "q_point_nominal_longitude",
+      "long_name": "q point nominal longitude",
+      "units": "degrees_north"
+    },
     "plev": {
       "standard_name": "air_pressure",
       "long_name": "",
@@ -39,6 +63,20 @@
       "positive": "down",
       "axis": "Z"
     },
+    "z_i": {
+      "standard_name": "depth_at_interface",
+      "long_name": "depth at interface",
+      "units": "m",
+      "positive": "down",
+      "axis": "Z"
+    },
+    "z_l": {
+      "standard_name": "depth_at_cell_center",
+      "long_name": "depth at cell center",
+      "units": "m",
+      "positive": "down",
+      "axis": "Z"
+    },
     "time": {
       "axis": "T",
       "standard_name": "time",
@@ -48,7 +86,13 @@
       "standard_name": "spectral_band",
       "long_name": "spectral band",
       "units": "1",
-      "axis": ""
+      "axis": "N"
+    },
+    "nv": {
+      "standard_name": "vertex_number",
+      "long_name": "vertex number",
+      "units": "1",
+      "axis": "N"
     }
   },
   "variables" : {

--- a/data/fieldlist_GFDL.jsonc
+++ b/data/fieldlist_GFDL.jsonc
@@ -96,6 +96,9 @@
     }
   },
   "variables" : {
+    "$ref": "./gfdl-cmor-tables/gfdl_to_cmip6_vars.json",
+    "$ref": "./gfdl-cmor-tables/gfdl_to_cmip5_vars.json",
+
     "areacello": {
       "standard_name": "cell_area",
       "realm": "ocean",

--- a/src/data_model.py
+++ b/src/data_model.py
@@ -136,8 +136,10 @@ class AbstractDMCoordinateBounds(AbstractDMDependentVariable):
 
 # ------------------------------------------------------------------------------
 
+# MOM6 grid coordinate docs: https://mom6-analysiscookbook.readthedocs.io/en/latest/notebooks/getting_started.html
 
-_AXIS_NAMES = ('X', 'Y', 'Z', 'T')
+
+_AXIS_NAMES = ('X', 'Y', 'Z', 'T', 'N')
 _ALL_AXIS_NAMES = _AXIS_NAMES + ('BOUNDS', 'OTHER')
 
 
@@ -234,6 +236,7 @@ class DMCoordinate(_DMCoordinateShared, AbstractDMCoordinate):
     units: src.units.Units = util.MANDATORY
     """Coordinate units (str or :class:`~src.units.Units`)."""
     axis: str = 'OTHER'
+    long_name: str = ''
 
 
 @util.mdtf_dataclass
@@ -250,6 +253,7 @@ class DMXCoordinate(_DMCoordinateShared, AbstractDMCoordinate):
     """Coordinate units (str or :class:`~src.units.Units`)."""
     axis: str = 'X'
     """Coordinate axis identifier. Always 'X' for this coordinate."""
+    long_name: str = ''
 
 
 @util.mdtf_dataclass
@@ -266,6 +270,7 @@ class DMYCoordinate(_DMCoordinateShared, AbstractDMCoordinate):
     """Coordinate units (str or :class:`~src.units.Units`)."""
     axis: str = 'Y'
     """Coordinate axis identifier. Always 'Y' for this coordinate."""
+    long_name: str = ''
 
 
 @util.mdtf_dataclass
@@ -279,11 +284,12 @@ class DMVerticalCoordinate(_DMCoordinateShared, AbstractDMCoordinate):
     # [scalar] value: int, float, or str
     standard_name: str = util.MANDATORY
     """Coordinate CF standard name."""
-    units: src.units.Units = "1" # dimensionless vertical coords OK
+    units: src.units.Units = "1"  # dimensionless vertical coords OK
     """Coordinate units (str or :class:`~src.units.Units`)."""
     axis: str = 'Z'
     """Coordinate axis identifier. Always 'Z' for this coordinate."""
     positive: str = util.MANDATORY
+    long_name: str = ''
 
 
 @util.mdtf_dataclass
@@ -369,6 +375,23 @@ class DMTimeCoordinate(DMGenericTimeCoordinate, AbstractDMCoordinate):
         raise NotImplementedError
 
 
+@util.mdtf_dataclass
+class DMGenericCoordinate(_DMCoordinateShared, AbstractDMCoordinate):
+    """Applies to collections of variables with generic coordinates in other
+       dimensions (e.g., soil layer, vertex number, radiation band)
+    """
+    name: str = ""
+    """Coordinate name"""
+    # bounds_var: AbstractDMCoordinateBounds
+    # [scalar] value: int or float
+    standard_name: str = ""
+    """Coordinate CF standard name."""
+    units: src.units.Units = ""
+    """Coordinate units (str or :class:`~src.units.Units`)."""
+    axis: str = "N"
+    """Coordinate long name"""
+    long_name: str = ""
+
 # Use the "register" method, instead of inheritance, to associate these classes
 # with their corresponding abstract interfaces, because Python dataclass fields
 # aren't recognized as implementing an abc.abstractmethod.
@@ -378,6 +401,7 @@ AbstractDMCoordinate.register(DMYCoordinate)
 AbstractDMCoordinate.register(DMVerticalCoordinate)
 AbstractDMCoordinate.register(DMParametricVerticalCoordinate)
 AbstractDMCoordinate.register(DMGenericTimeCoordinate)
+AbstractDMCoordinate.register(DMGenericCoordinate)
 AbstractDMCoordinate.register(DMTimeCoordinate)
 AbstractDMCoordinate.register(DMBoundsDimension)
 
@@ -398,6 +422,7 @@ def coordinate_from_struct(d: collections.OrderedDict, class_dict=None, **kwargs
             'Y': DMYCoordinate,
             'Z': DMVerticalCoordinate,
             'T': DMGenericTimeCoordinate,
+            'N': DMGenericCoordinate,
             'OTHER': DMCoordinate
         }
     try:
@@ -436,6 +461,7 @@ class DMPlaceholderCoordinate(_DMCoordinateShared, _DMPlaceholderCoordinateBase)
     """Coordinate units (str or :class:`~src.units.Units`)."""
     axis: str = 'OTHER'
     """Coordinate axis identifier ('X', 'Y', etc.)"""
+    long_name: str = NotImplemented
 
 
 @util.mdtf_dataclass
@@ -454,6 +480,7 @@ class DMPlaceholderXCoordinate(_DMCoordinateShared, _DMPlaceholderCoordinateBase
     """Coordinate units (str or :class:`~src.units.Units`)."""
     axis: str = 'X'
     """Coordinate axis identifier ('X', 'Y', etc.)"""
+    long_name: str = NotImplemented
 
 
 @util.mdtf_dataclass
@@ -472,6 +499,7 @@ class DMPlaceholderYCoordinate(_DMCoordinateShared, _DMPlaceholderCoordinateBase
     """Coordinate units (str or :class:`~src.units.Units`)."""
     axis: str = 'Y'
     """Coordinate axis identifier ('X', 'Y', etc.)"""
+    long_name: str = NotImplemented
 
 
 @util.mdtf_dataclass
@@ -491,6 +519,8 @@ class DMPlaceholderZCoordinate(_DMCoordinateShared, _DMPlaceholderCoordinateBase
     axis: str = 'Z'
     """Coordinate axis identifier ('X', 'Y', etc.)"""
     positive: str = NotImplemented
+
+    long_name: str = NotImplemented
 
 
 @util.mdtf_dataclass
@@ -513,6 +543,25 @@ class DMPlaceholderTCoordinate(_DMCoordinateShared, _DMPlaceholderCoordinateBase
     """CF standard calendar for time data."""
     range: typing.Any = None
     """Date range of coordinate."""
+
+
+@util.mdtf_dataclass
+class DMPlaceholderNCoordinate(_DMCoordinateShared, _DMPlaceholderCoordinateBase):
+    """Dummy base class for placeholder N axis coordinates. Placeholder coordinates are
+    only used in instantiating :class:`~src.core.FieldlistEntry` objects: they're
+    replaced by the appropriate translated coordinates when that object is used
+    to create a :class:`~src.core.TranslatedVarlistEntry` object.
+    """
+    name: str = 'PLACEHOLDER_N_COORD'
+    """Coordinate name; defaults to 'PLACEHOLDER_Z_COORD' since this is a temporary
+    object."""
+    standard_name: str = NotImplemented
+    """Coordinate CF standard name."""
+    units: src.units.Units = NotImplemented
+    """Coordinate units (str or :class:`~src.units.Units`)."""
+    axis: str = 'N'
+    """Coordinate long name"""
+    long_name: str = NotImplemented
 
     @property
     def is_static(self):
@@ -577,6 +626,11 @@ class _DMDimensionsMixin:
     def T(self):
         """Return T axis dimension coordinate if defined, else None."""
         return self.dim_axes.get('T', None)
+
+    @property
+    def N(self):
+        """Return N axis dimension coordinate if defined, else None."""
+        return self.dim_axes.get('N', None)
 
     @property
     def dim_axes_set(self):
@@ -669,7 +723,7 @@ class DMDependentVariable(_DMDimensionsMixin, AbstractDMDependentVariable):
     """
     name: str = util.MANDATORY
     standard_name: str = util.MANDATORY
-    long_name: str =""
+    long_name: str = ""
     realm: str = ""
     units: src.units.Units = ""  # not MANDATORY since may be set later from var translation
     modifier: str = ""

--- a/src/data_model.py
+++ b/src/data_model.py
@@ -588,7 +588,8 @@ class _DMDimensionsMixin:
     def __post_init__(self, coords=None):
         if coords is None:
             # if we're called to rebuild dicts, rather than after __init__
-            assert (self.dims or self.scalar_coords)
+            assert (self.dims or self.scalar_coords), \
+                f'dims and/or scalar_coords not defined for _DMDimensionsMixin instance'
             coords = self.dims + self.scalar_coords
         self.dims = []
         self.scalar_coords = []

--- a/src/data_sources.py
+++ b/src/data_sources.py
@@ -6,6 +6,7 @@ import dataclasses
 from src import util, cmip6, varlist_util
 
 import logging
+
 _log = logging.getLogger(__name__)
 
 # RegexPattern that matches any string (path) that doesn't end with ".nc".
@@ -149,7 +150,7 @@ class CMIPDataSource(DataSourceBase):
     query: dict = dict(frequency="",
                        path="",
                        standard_name=""
-                      )
+                       )
 
 
 @data_source.maker
@@ -164,7 +165,7 @@ class CESMDataSource(DataSourceBase):
     query: dict = dict(frequency="",
                        path="",
                        standard_name=""
-                      )
+                       )
 
 
 @data_source.maker
@@ -179,7 +180,8 @@ class GFDLDataSource(DataSourceBase):
     query: dict = dict(frequency="",
                        path="",
                        standard_name=""
-                      )
+                       )
+
 
 dummy_regex = util.RegexPattern(
     r"""(?P<dummy_group>.*) # match everything; RegexPattern needs >= 1 named groups
@@ -204,7 +206,7 @@ class CMIP6DataSourceAttributes(DataSourceAttributesBase):
     # date_range: util.DateRange
     # CASE_ROOT_DIR: str
     # log: dataclasses.InitVar = _log
-    convention: str = "CMIP" # hard-code naming convention
+    convention: str = "CMIP"  # hard-code naming convention
     activity_id: str = ""
     institution_id: str = ""
     source_id: str = ""
@@ -212,7 +214,7 @@ class CMIP6DataSourceAttributes(DataSourceAttributesBase):
     variant_label: str = ""
     grid_label: str = ""
     version_date: str = ""
-    model: dataclasses.InitVar = ""      # synonym for source_id
+    model: dataclasses.InitVar = ""  # synonym for source_id
     experiment: dataclasses.InitVar = ""  # synonym for experiment_id
     CATALOG_DIR: str = dataclasses.field(init=False)
 
@@ -229,7 +231,7 @@ class CMIP6DataSourceAttributes(DataSourceAttributesBase):
                         raise KeyError()
                     dest_val = cv.lookup_single(source_val, source, dest)
                     log.debug("Set %s='%s' based on %s='%s'.",
-                        dest, dest_val, source, source_val)
+                              dest, dest_val, source, source_val)
                     setattr(self, dest, dest_val)
                 except KeyError:
                     log.debug("Couldn't set %s from %s='%s'.",
@@ -259,8 +261,8 @@ class CMIP6DataSourceAttributes(DataSourceAttributesBase):
             try:
                 if not cv.is_in_cv(field.name, val):
                     log.error(("Supplied value '%s' for '%s' is not recognized by "
-                        "the CMIP6 CV. Continuing, but queries will probably fail."),
-                        val, field.name)
+                               "the CMIP6 CV. Continuing, but queries will probably fail."),
+                              val, field.name)
             except KeyError:
                 # raised if not a valid CMIP6 CV category
                 continue

--- a/src/data_sources.py
+++ b/src/data_sources.py
@@ -121,9 +121,15 @@ class DataSourceBase(util.MDTFObjectBase, util.CaseLoggerMixin):
     def translate_varlist(self,
                           model_paths: util.ModelDataPathManager,
                           case_name: str,
+                          from_convention: str,
                           to_convention: str):
         for v in self.varlist.iter_vars():
-            self.varlist.setup_var(model_paths, case_name, v, to_convention, self.date_range)
+            self.varlist.setup_var(model_paths,
+                                   case_name,
+                                   v,
+                                   from_convention,
+                                   to_convention,
+                                   self.date_range)
 
 
 # instantiate the class maker so that the convention-specific classes can be instantiated using
@@ -145,6 +151,7 @@ class CMIPDataSource(DataSourceBase):
                        standard_name=""
                       )
 
+
 @data_source.maker
 class CESMDataSource(DataSourceBase):
     """DataSource for handling POD sample model data for multirun cases stored on a local filesystem.
@@ -158,6 +165,7 @@ class CESMDataSource(DataSourceBase):
                        path="",
                        standard_name=""
                       )
+
 
 @data_source.maker
 class GFDLDataSource(DataSourceBase):
@@ -188,20 +196,6 @@ class GlobbedDataFile:
     remote_path: str = util.MANDATORY
 
 
-
-    #def to_file_glob_tuple(self):
-    #    return dm.FileGlobTuple(
-    #        name=self.full_name, glob=self.glob,
-    #        attrs={
-    #            'glob_id': self.glob_id,
-    #            'pod_name': self.pod_name, 'name': self.name
-    #        }
-    #    )
-
-
-
-
-
 @util.mdtf_dataclass
 class CMIP6DataSourceAttributes(DataSourceAttributesBase):
     # CASENAME: str          # fields inherited from DataSourceAttributesBase
@@ -219,7 +213,7 @@ class CMIP6DataSourceAttributes(DataSourceAttributesBase):
     grid_label: str = ""
     version_date: str = ""
     model: dataclasses.InitVar = ""      # synonym for source_id
-    experiment: dataclasses.InitVar = "" # synonym for experiment_id
+    experiment: dataclasses.InitVar = ""  # synonym for experiment_id
     CATALOG_DIR: str = dataclasses.field(init=False)
 
     def __post_init__(self, log=_log, model=None, experiment=None):
@@ -248,7 +242,7 @@ class CMIP6DataSourceAttributes(DataSourceAttributesBase):
         # verify case root dir exists
         if not os.path.isdir(self.CASE_ROOT_DIR):
             log.critical("Data directory CASE_ROOT_DIR = '%s' not found.",
-                self.CASE_ROOT_DIR)
+                         self.CASE_ROOT_DIR)
             util.exit_handler(code=1)
 
         # should really fix this at the level of CLI flag synonyms
@@ -290,7 +284,7 @@ class CMIP6DataSourceAttributes(DataSourceAttributesBase):
             new_root = os.path.join(new_root, drs_val)
         if not os.path.isdir(new_root):
             log.error("Data directory '%s' not found; starting crawl at '%s'.",
-                new_root, self.CASE_ROOT_DIR)
+                      new_root, self.CASE_ROOT_DIR)
             self.CATALOG_DIR = self.CASE_ROOT_DIR
         else:
             self.CATALOG_DIR = new_root

--- a/src/data_sources.py
+++ b/src/data_sources.py
@@ -77,6 +77,7 @@ class DataSourceBase(util.MDTFObjectBase, util.CaseLoggerMixin):
     # _AttributesClass = SampleDataAttributes
     # col_spec = sampleLocalFileDataSource_col_spec
     convention: str
+    query: dict
     date_range: util.DateRange = dataclasses.field(init=False)
     varlist: varlist_util.Varlist = None
     log_file: io.IOBase = dataclasses.field(default=None, init=False)
@@ -139,7 +140,10 @@ class CMIPDataSource(DataSourceBase):
     # col_spec = sampleLocalFileDataSource_col_spec
     # varlist = diagnostic.varlist
     convention: str = "CMIP"
-
+    query: dict = dict(frequency="",
+                       path="",
+                       standard_name=""
+                      )
 
 @data_source.maker
 class CESMDataSource(DataSourceBase):
@@ -150,7 +154,10 @@ class CESMDataSource(DataSourceBase):
     # col_spec = sampleLocalFileDataSource_col_spec
     # varlist = diagnostic.varlist
     convention: str = "CESM"
-
+    query: dict = dict(frequency="",
+                       path="",
+                       standard_name=""
+                      )
 
 @data_source.maker
 class GFDLDataSource(DataSourceBase):
@@ -161,7 +168,10 @@ class GFDLDataSource(DataSourceBase):
     # col_spec = sampleLocalFileDataSource_col_spec
     # varlist = diagnostic.varlist
     convention: str = "GFDL"
-
+    query: dict = dict(frequency="",
+                       path="",
+                       standard_name=""
+                      )
 
 dummy_regex = util.RegexPattern(
     r"""(?P<dummy_group>.*) # match everything; RegexPattern needs >= 1 named groups
@@ -284,12 +294,3 @@ class CMIP6DataSourceAttributes(DataSourceAttributesBase):
             self.CATALOG_DIR = self.CASE_ROOT_DIR
         else:
             self.CATALOG_DIR = new_root
-
-
-
-
-
-
-
-
-

--- a/src/pod_setup.py
+++ b/src/pod_setup.py
@@ -295,6 +295,7 @@ class PodObject(util.MDTFObjectBase, util.PODLoggerMixin, PodBaseClass):
             # A 'noTranslationFieldlist' will be defined for the varlistEntry translation attribute
             cases[case_name].translate_varlist(model_paths,
                                                case_name,
+                                               pod_convention,
                                                data_convention)
 
         for case_name in cases.keys():

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -14,6 +14,7 @@ import intake
 import numpy as np
 import xarray as xr
 import collections
+import re
 
 # TODO: Make the following lines a unit test
 # import sys
@@ -308,7 +309,7 @@ class PrecipRateToFluxFunction(PreprocessorFunctionBase):
         new_v = copy_as_alternate(v)
         new_v.translation = new_tv
         return new_v
-        #v = new_v
+        # v = new_v
 
     def execute(self, var, ds, **kwargs):
         """Convert units of dependent variable *ds* between precip rate and
@@ -796,6 +797,8 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             log: log file
         """
         date_col = "date_range"
+        if not hasattr(group_df, 'start_time') or not hasattr(group_df, 'end_time'):
+            raise AttributeError('Data catalog is missing attributes `start_time` and/or `end_time`')
         try:
             # method throws ValueError if ranges aren't contiguous
             dates_df = group_df.loc[:, ['start_time', 'end_time']]
@@ -804,7 +807,6 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 st = dates_df.at[idx, 'start_time']
                 en = dates_df.at[idx, 'end_time']
                 date_range_vals.append(util.DateRange(st, en))
-
             group_df = group_df.assign(date_range=date_range_vals)
             sorted_df = group_df.sort_values(by=date_col)
 
@@ -851,61 +853,40 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
 
         for case_name, case_d in case_dict.items():
             # path_regex = re.compile(r'(?i)(?<!\\S){}(?!\\S+)'.format(case_name))
-            # path_regex = re.compile(r'({})'.format(case_name))
-            path_regex = case_name + '*'
+            path_regex = re.compile(r'({})'.format(case_name))
+            # path_regex = '*' + case_name + '*'
             freq = case_d.varlist.T.frequency
 
             for v in case_d.varlist.iter_vars():
                 realm_regex = v.realm + '*'
                 # define initial query dictionary with variable settings requirements that do not change if
                 # the variable is translated
-                query_dict = dict(frequency=freq,
-                                  realm=realm_regex,
-                                  path=path_regex)
-                # search the catalog for a standard_name or long_name using the translated variable attributes
-                # the translated variable class will contain the same information as the variable class if no
-                # translation was performed
-                cat_subset = cat.search(standard_name=v.translation.standard_name)
+                case_d.query['frequency'] = freq
+                case_d.query['path'] = [path_regex]
+                case_d.query['variable'] = v.name
+                # search translation for further query requirements
+                for q in case_d.query:
+                    if hasattr(v.translation, q):
+                        case_d.query.update({q: getattr(v.translation, q)})
+                if hasattr(v.translation, 'name'):
+                    case_d.query.update({'variable': getattr(v.translation, 'name')})
+                # search catalog for convention specific query object
+                cat_subset = cat.search(**case_d.query)
                 if cat_subset.df.empty:
-                    cat_subset = cat.search(long_name=v.translation.long_name)
-                    if cat_subset.df.empty:
-                        raise util.DataRequestError(f"No standard_name or long_name found for "
-                                                    f"{v.translation.name} in {data_catalog}")
-                    else:
-                        query_dict.update({'long_name': v.translation.long_name})
-                else:
-                    query_dict.update({'standard_name': v.translation.standard_name})
-
-                # find the catalog column with the data convention information
-                cat_subset = cat.search(activity_id=case_d.convention)
-                if cat_subset.df.empty:
-                    cat_subset = cat.search(institution_id=case_d.convention)
-                    if cat_subset.df.empty:
-                        raise util.DataRequestError(f"No activity_id or institution_id found for "
-                                                    f"{case_d.convention} in {data_catalog}")
-                    else:
-                        query_dict.update({'institution_id': case_d.convention})
-                else:
-                    query_dict.update({'activity_id': case_d.convention})
-
-                cat_subset = cat.search(**query_dict
-                                        )
-                if cat_subset.df.empty:
-                    raise util.DataRequestError(f"No assets found for {case_name} in {data_catalog}")
+                    raise util.DataRequestError(
+                        f"No assets matching query requirements found for {case_name} in {data_catalog}")
                 # Get files in specified date range
                 # https://intake-esm.readthedocs.io/en/stable/how-to/modify-catalog.html
-                cat_subset.esmcat._df = self.check_group_daterange(cat_subset.df)
-                v.log.debug("Read %d mb for %s.", cat_subset.esmcat._df.dtypes.nbytes / (1024 * 1024), v.full_name)
+                # cat_subset.esmcat._df = self.check_group_daterange(cat_subset.df)
+                # v.log.debug("Read %d mb for %s.", cat_subset.esmcat._df.dtypes.nbytes / (1024 * 1024), v.full_name)
                 # convert subset catalog to an xarray dataset dict
                 # and concatenate the result with the final dict
                 cat_dict = cat_dict | cat_subset.to_dataset_dict(
                     progressbar=False,
                     xarray_open_kwargs=self.open_dataset_kwargs
                 )
-
         # rename cat_subset case dict keys to case names
         cat_dict_rename = self.rename_dataset_keys(cat_dict, case_dict)
-
         return cat_dict_rename
 
     def edit_request(self, v: varlist_util.VarlistEntry, **kwargs):
@@ -1188,10 +1169,9 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         """
         # get the initial model data subset from the ESM-intake catalog
         cat_subset = self.query_catalog(case_list, config.DATA_CATALOG)
-
         for case_name, case_xr_dataset in cat_subset.items():
             for v in case_list[case_name].varlist.iter_vars():
-                self.edit_request(v, convention=cat_subset[case_name].convention)
+                self.edit_request(v, convention=case_list[case_name].convention)
                 cat_subset[case_name] = self.parse_ds(v, case_xr_dataset)
                 self.execute_pp_functions(v,
                                           cat_subset[case_name],
@@ -1211,7 +1191,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         pp_cat_assets = util.define_pp_catalog_assets(config, cat_file_name)
         file_list = util.get_file_list(config.OUTPUT_DIR)
         # fill in catalog information from pp file name
-        entries = list(map(util.mdtf_pp_parser, file_list))
+        entries = [e.cat_entry for e in list(map(util.catalog.ppParser['ppParser' + 'GFDL'], file_list))]
         # append columns defined in assets
         columns = [att['column_name'] for att in pp_cat_assets['attributes']]
         for col in columns:

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -861,6 +861,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 realm_regex = v.realm + '*'
                 # define initial query dictionary with variable settings requirements that do not change if
                 # the variable is translated
+                # TODO: add method to convert freq from DateFrequency object to string
                 case_d.query['frequency'] = freq
                 case_d.query['path'] = [path_regex]
                 case_d.query['variable'] = v.name

--- a/src/translation.py
+++ b/src/translation.py
@@ -276,7 +276,7 @@ class Fieldlist:
             else:
                 # TODO refine the following query
                 # The logic below optimized for identifying the correct pressure level coordinate to select
-                # from the CMIP CV by comparing the varlistentry scalar coord value (supplied by the POD settings file)
+                # from the CMIP CV by comparing the VarlistEntry scalar coord value (supplied by the POD settings file)
                 # in hPa with the CV values in Pa (hPa * 100 = pa).
                 # If both coordinate values are strings, then there is just a simple check to see if the varlistentry
                 # value is contained by the CV string value. This is not robust, but sufficient for testing purposes
@@ -295,6 +295,9 @@ class Fieldlist:
                                 if coord.value in v.get('value'):
                                     new_coord = v
                                     break
+                            else:
+                                raise KeyError(f'coord value and/or Varlist value could not be parsed'
+                                               f' by translate_coord')
         else:
             new_coord = [lut1.values()][0]
 

--- a/src/translation.py
+++ b/src/translation.py
@@ -444,6 +444,14 @@ class Fieldlist:
             new_name = self.create_scalar_name(
                 var.scalar_coords[0], new_scalars[0],
                 new_name, log=var.log)
+            # append an is_scalar attribute for the coordinate check in
+            # data_model._DMDimensionsMixin.__post_init__() call from
+            # TranslatedVarlistEntry
+            for s in new_scalars:
+                if 'is_scalar' not in s:
+                    s['is_scalar'] = True
+
+            new_scalars = util.NameSpace.fromDict(new_scalars)
 
         return util.coerce_to_dataclass(
             fl_atts, TranslatedVarlistEntry,

--- a/src/translation.py
+++ b/src/translation.py
@@ -7,7 +7,6 @@ import dataclasses as dc
 import glob
 import typing
 import pathlib
-import itertools
 from src import util, data_model, units
 from src.units import Units
 

--- a/src/translation.py
+++ b/src/translation.py
@@ -158,20 +158,25 @@ class Fieldlist:
     a unique identifier, but should include cell_methods, etc. as well as
     dimensionality.
     """
+    axes_standard_names: list
     lut_standard_names: list
     name: str = util.MANDATORY
     axes_lut: util.WormDict = dc.field(default_factory=util.WormDict)
     lut: util.WormDict = dc.field(default_factory=util.WormDict)
     env_vars: dict = dc.field(default_factory=dict)
+
     @classmethod
     def from_struct(cls, d: dict, code_root: str, log=None):
-        def _process_coord(section_name: str, d: dict, temp_d: dict, code_root: str, log=None):
+        def _process_coord(section_name: str,
+                           in_dict: collections.OrderedDict,
+                           root_dir: str,
+                           log=None):
             # build two-stage lookup table by axis type, then name
             # The name is the key since standard_names are not necessarily unique ID's
             # and coordinates may be assigned to variables in multiple realms
-            section_d = d.pop(section_name, dict())
+            section_d = in_dict.pop(section_name, dict())
             if '$ref' in section_d.keys():
-                ref_file_query = pathlib.Path(code_root, 'data', section_d['$ref'])
+                ref_file_query = pathlib.Path(root_dir, 'data', section_d['$ref'])
                 ref_file_path = str(ref_file_query)
                 assert ".json" in ref_file_query.suffix, f"{ref_file_path} is not a json(c) file"
                 coord_file_entries = util.read_json(ref_file_path, log=log)
@@ -182,27 +187,31 @@ class Fieldlist:
 
             return section_d
 
-        def _process_var(section_name, d, temp_d):
+        def _process_var(section_name: str, in_dict, lut_dict):
             # build two-stage lookup table (by standard name, then data
             # dimensionality)
-            section_d = d.pop(section_name, dict())
+            section_d = in_dict.pop(section_name, dict())
             for k, v in section_d.items():
-                temp_d['entries'][k] = v
+                lut_dict['entries'][k] = v
                 # note that realm and modifier class atts are empty strings
                 # by default and, therefore, so are the corresponding dictionary
                 # keys. TODO: be sure to handle empty keys in PP
                 if not hasattr(v, 'modifier'):
-                    temp_d['entries'][k].update({'modifier': ""})
-            return temp_d
+                    lut_dict['entries'][k].update({'modifier': ""})
+                if not hasattr(v, 'long_name'):
+                    lut_dict['entries'][k].update({'long_name': ""})
+            return lut_dict
 
-        temp_d = collections.defaultdict(util.WormDict)
         d['axes_lut'] = util.WormDict()
-        temp_d = _process_coord('coords', d, temp_d, code_root, log)
+        temp_d = _process_coord('coords', d, code_root, log)
         d['axes_lut'].update(temp_d)
+
+        d['axes_standard_names'] = []
+        for sn in d['axes_lut'].values():
+            d['axes_standard_names'].append(sn['standard_name'])
 
         temp_d = collections.defaultdict(util.WormDict)
         d['lut'] = util.WormDict()
-        temp_d = _process_var('aux_coords', d, temp_d)
         temp_d = _process_var('variables', d, temp_d)
         d['lut'].update(temp_d['entries'])
         d['lut_standard_names'] = []
@@ -228,19 +237,19 @@ class Fieldlist:
     def to_CF_standard_name(self, standard_name: str,
                             long_name: str,
                             realm: str,
-                            modifier: str):
+                            modifier: str) -> str:
 
-        # search the lookup table for the variable with the specified standard_name attribute
-        try:
-            for var_name, var_dict in self.lut.items():
-                # print(var_name)
-                if var_dict.standard_name == standard_name and var_dict.realm == realm and var_dict.modifier == modifier:
-                    if not var_dict.long_name or var_dict.long_name.lower() == long_name.lower():
-                        return var_dict.name
-        except ValueError:
-            _log.error(f'Could not find variable in {self.name} fieldlist'
-                       f' with standard_name {standard_name}, long_name {long_name}'
-                       f' and realm {realm}')
+        # search the lookup table for the variable with the specified standard_name
+        # realm, modifier, and long_name attributes
+        for var_name, var_dict in self.lut.items():
+            # print(var_name)
+            if var_dict['standard_name'] == standard_name\
+                    and var_dict['realm'] == realm\
+                    and var_dict['modifier'] == modifier:
+                if not var_dict['long_name'] or var_dict['long_name'].lower() == long_name.lower():
+                    return var_name
+            else:
+                continue
 
     def from_CF(self,
                 standard_name: str,
@@ -249,7 +258,7 @@ class Fieldlist:
                 long_name: str = "",
                 num_dims: int = 0,
                 has_scalar_coords_att: bool = False,
-                name_only: bool = False) -> FieldlistEntry:
+                name_only: bool = False) -> dict:
         """Look up :class:`FieldlistEntry` corresponding to the given standard
         name, optionally providing a modifier to resolve ambiguity.
 
@@ -269,7 +278,6 @@ class Fieldlist:
         """
         assert standard_name in self.lut_standard_names, f'{standard_name} not found in Fieldlist lut_standard_names'
         lut1 = dict()
-        flentry: FieldlistEntry = None
         for k, v in self.lut.items():
             if v['standard_name'] == standard_name and v['realm'] == realm and v['modifier'] == modifier:
                 if not hasattr(v, 'long_name'):
@@ -279,9 +287,8 @@ class Fieldlist:
 
         entries = tuple(lut1)
         if len(entries) > 1:
-            raise ValueError(f'Could not find a unique entry in Fieldlist for {standard_name}')
-        flentry = lut1
-        return copy.deepcopy(flentry)
+            _log.warning(f'Found multiple entries in {self.name} Fieldlist for {standard_name}')
+        return copy.deepcopy(lut1)
 
     def from_CF_name(self,
                      var_or_name: str,
@@ -317,12 +324,12 @@ class Fieldlist:
         """
         ax = coord.standard_name
 
-        if ax not in self.axes_std_names:
+        if ax not in self.axes_standard_names:
             raise KeyError((f"Coordinate {coord.name} with standard name "
                             f"'{coord.standard_name}' not defined in convention '{self.name}'."))
 
         lut1 = {ax: self.axes_lut[ax]}
-        new_coord = [lut1[k] for k in lut1.keys() if lut1[k].standard_name == coord.standard_name][0]
+        new_coord = [lut1[k] for k in lut1.keys() if lut1[k].get('standard_name') == coord.standard_name][0]
 
         if hasattr(coord, 'is_scalar') and coord.is_scalar:
             new_coord = copy.deepcopy(new_coord)

--- a/src/units.py
+++ b/src/units.py
@@ -142,11 +142,11 @@ def conversion_factor(source_unit, dest_unit):
 
 # --------------------------------------------------------------------
 
-def convert_scalar_coord(coord, dest_units, log=_log):
+def convert_scalar_coord(coord, dest_units: str, log=_log):
     """Given scalar coordinate *coord*, return the appropriate scalar value in
     new units *dest_units*.
     """
-    assert hasattr(coord, 'is_scalar') and coord.is_scalar
+    assert hasattr(coord, 'is_scalar') and coord.is_scalar, 'coord is missing is_scalar attribute or is_scalar = False'
     if not units_equal(coord.units, dest_units):
         # convert units of scalar value to convention's coordinate's units
         dest_value = coord.value * conversion_factor(coord.units, dest_units)

--- a/src/varlist_util.py
+++ b/src/varlist_util.py
@@ -71,8 +71,9 @@ class VarlistEntryBase(metaclass=util.MDTFABCMeta):
         path_variable: Name of env var containing path(s) to local data.
         dest_path: Path(s) to local data.
         alternates: List of lists of VarlistEntries.
-        translation: :class:`core.TranslatedVarlistEntry`, populated by DataSource.
+        translation: :class: `translation.TranslatedVarlistEntry`, populated by DataSource.
         data: dict mapping experiment_keys to DataKeys. Populated by DataSource.
+        scalar_coords: dict
     """
 
     def __init_subclass__(cls):
@@ -80,6 +81,7 @@ class VarlistEntryBase(metaclass=util.MDTFABCMeta):
             'use_exact_name',
             'env_var',
             'requirement',
+            'scalar_coords',
             'alternates',
             'translation',
             'data',
@@ -152,7 +154,7 @@ class VarlistEntry(VarlistEntryBase, util.MDTFObjectBase, data_model.DMVariable,
         path_variable: Name of env var containing path to local data.
         dest_path: Path to local data.
         alternates: List of lists of VarlistEntries.
-        translation: :class:`core.TranslatedVarlistEntry`, populated by DataSource.
+        translation: :class:`translation.TranslatedVarlistEntry`, populated by DataSource.
         data: dict mapping experiment_keys to DataKeys. Populated by DataSource.
     """
     # _id = util.MDTF_ID()           # fields inherited from core.MDTFObjectBase
@@ -211,10 +213,14 @@ class VarlistEntry(VarlistEntryBase, util.MDTFObjectBase, data_model.DMVariable,
         if not self.path_variable:
             self.path_variable = self.name.upper() + _file_env_var_suffix
         # self.alternates is either [] or a list of nonempty lists of VEs
-        if self.alternates:
-            if not isinstance(self.alternates[0], list):
-                self.alternates = [self.alternates]
-            self.alternates = [vs for vs in self.alternates if vs]
+        if hasattr(self, 'alternates'):
+            if isinstance(self.alternates, list):
+                if any(self.alternates):
+                    if not isinstance(self.alternates[0], list):
+                        self.alternates = [self.alternates]
+                    self.alternates = [vs for vs in self.alternates if vs]
+        if hasattr(self, 'scalar_coords'):
+            self.scalar_coords = self.scalar_coords
 
     def dims(self):
         pass
@@ -319,8 +325,9 @@ class VarlistEntry(VarlistEntryBase, util.MDTFObjectBase, data_model.DMVariable,
             "realm": self.realm,
             **assoc_dict
         })
+
         for ax, dim in self.dim_axes.items():
-            trans_dim = self.translation.dim_axes[ax]
+            trans_dim = self.translation.axes[ax]
             self.env_vars[dim.name + _coord_env_var_suffix] = trans_dim.name
             if trans_dim.has_bounds:
                 self.env_vars[dim.name + _coord_bounds_env_var_suffix] = trans_dim.bounds
@@ -510,7 +517,8 @@ class Varlist(data_model.DMDataSet):
                   model_paths: util.ModelDataPathManager,
                   case_name: str,
                   v: VarlistEntry,
-                  data_convention: str,
+                  from_convention: str,
+                  to_convention: str,
                   date_range: util.DateRange):
         """Update VarlistEntry fields with information that only becomes
         available after DataManager and Diagnostic have been configured (ie,
@@ -519,7 +527,8 @@ class Varlist(data_model.DMDataSet):
         Could arguably be moved into VarlistEntry's init, at the cost of
         dependency inversion.
         """
-        translate = translation.VariableTranslator().get_convention(data_convention)
+        # Note: VariableTranslator object is instantiated in mdtf_framework with runtime information
+        translate = translation.VariableTranslator().get_convention(to_convention)
         if v.T is not None:
             v.change_coord(
                 'T',
@@ -534,7 +543,8 @@ class Varlist(data_model.DMDataSet):
             )
         v.dest_path = self.variable_dest_path(model_paths, case_name, v)
         try:
-            trans_v = translate.translate(v)
+            trans_v = translate.translate(v, from_convention)
+            assert trans_v is not None, f'translation for varlistentry {v.name} failed'
             v.translation = trans_v
             # copy preferred gfdl post-processing component during translation
             if hasattr(trans_v, "component"):


### PR DESCRIPTION
**Description**
* refactor the translation module to parse additional coordinate information from the CMIP CV tables
* add from_convention parameter to reference pod_convention to translate from
* update translate_coord logic to use coordinate values when defining scalar_coords
* add new variables and refs to gfdl_to_cmor jsons to the GFDL fieldlist
* add an N coordinate to the data_model coordinate classes for entries are not X,Y,Z,T

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [x] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [x] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
