### PR TITLE
add logic to format method of DateFrequency object

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -855,7 +855,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             # path_regex = re.compile(r'(?i)(?<!\\S){}(?!\\S+)'.format(case_name))
             path_regex = re.compile(r'({})'.format(case_name))
             # path_regex = '*' + case_name + '*'
-            freq = case_d.varlist.T.frequency
+            freq = case_d.varlist.T.frequency.format()
 
             for v in case_d.varlist.iter_vars():
                 realm_regex = v.realm + '*'
@@ -863,6 +863,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 # the variable is translated
                 # TODO: add method to convert freq from DateFrequency object to string
                 case_d.query['frequency'] = freq
+                print(freq)
                 case_d.query['path'] = [path_regex]
                 case_d.query['variable'] = v.name
                 # search translation for further query requirements

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -863,7 +863,6 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 # the variable is translated
                 # TODO: add method to convert freq from DateFrequency object to string
                 case_d.query['frequency'] = freq
-                print(freq)
                 case_d.query['path'] = [path_regex]
                 case_d.query['variable'] = v.name
                 # search translation for further query requirements

--- a/src/util/datelabel.py
+++ b/src/util/datelabel.py
@@ -1148,7 +1148,10 @@ class DateFrequency(datetime.timedelta):
         if self.unit == 'fx':
             return 'fx'
         else:
-            return "{}{}".format(self.quantity, self.unit)
+            if self.quantity == '1':
+                return self.unit
+            else:
+                return "{}{}".format(self.quantity, self.unit)
 
     __str__ = format
 


### PR DESCRIPTION
**Description**
Add of simple logic to return the DateFrequency object in the type of str for use in the catalog query. Can be spun out into a match-case statement instead for further specificity.

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x ] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ]x The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ x] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [ x] The repository contains no extra test scripts or data files
