### PR TITLE
Fix issues with preprocessor functions

### DIFF
--- a/src/data_model.py
+++ b/src/data_model.py
@@ -808,8 +808,7 @@ class DMDependentVariable(_DMDimensionsMixin, AbstractDMDependentVariable):
         """
         dim = self.get_scalar(ax)
         assert dim is not None, 'remove_scalar.get_scalar did not return dim information'
-        new_dim = copy.deepcopy(dim)
-        new_dim.update({'value': None})
+        new_dim = dc.replace(dim, value=None)
         new_dims = self.dims.copy()
         new_dims.insert(position, new_dim)
         new_scalars = self.scalar_coords.copy()

--- a/src/data_model.py
+++ b/src/data_model.py
@@ -5,7 +5,6 @@ This is based on the `CF standard terminology
 <https://cfconventions.org/Data/cf-conventions/cf-conventions-1.9/cf-conventions.html>`__.
 """
 import abc
-import copy
 import dataclasses as dc
 import itertools
 import typing

--- a/src/data_model.py
+++ b/src/data_model.py
@@ -5,6 +5,7 @@ This is based on the `CF standard terminology
 <https://cfconventions.org/Data/cf-conventions/cf-conventions-1.9/cf-conventions.html>`__.
 """
 import abc
+import copy
 import dataclasses as dc
 import itertools
 import typing
@@ -643,7 +644,7 @@ class _DMDimensionsMixin:
         """Whether the variable has time dependence (bool)."""
         return (self.T is None) or self.T.is_static
 
-    def get_scalar(self, ax_name):
+    def get_scalar(self, ax_name: str):
         """If the axis label *ax_name* is a scalar coordinate, return the
         corresponding :class:`AbstractDMCoordinate` object, otherwise return None.
         """
@@ -799,15 +800,16 @@ class DMDependentVariable(_DMDimensionsMixin, AbstractDMDependentVariable):
                           **kwargs
                           )
 
-    def remove_scalar(self, ax, position=-1, **kwargs):
+    def remove_scalar(self, ax: str, position=-1, **kwargs):
         """Metadata operation that's the inverse of :meth:`add_scalar`. Given an
         axis label *ax* that's currently a scalar coordinate, remove the slice
         value and add it to the list of dimension coordinates at *position*
         (default end of the list.)
         """
         dim = self.get_scalar(ax)
-        assert dim is not None
-        new_dim = dc.replace(dim, value=None)
+        assert dim is not None, 'remove_scalar.get_scalar did not return dim information'
+        new_dim = copy.deepcopy(dim)
+        new_dim.update({'value': None})
         new_dims = self.dims.copy()
         new_dims.insert(position, new_dim)
         new_scalars = self.scalar_coords.copy()

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -553,12 +553,12 @@ class ExtractLevelFunction(PreprocessorFunctionBase):
             )
             # CMIP CV will return multiple values for same standard name (e.g., ua250, ua10, ua)
             # so choose the 4-D value (assumes that 4-D vars from same realm do not share the same standard name)
-            for v in new_tv_dict.values():
-                if v['ndim'] == 4:
-                    new_tv_name = v['name']
-        sc_axis = [c for c in tv.scalar_coords if c.axis == 'Z'][0]
+            for var_dict in new_tv_dict.values():
+                if var_dict['ndim'] == 4:
+                    new_tv_name = var_dict['name']
+        time_coord = [c for c in tv.scalar_coords if c.axis == 'T'][0]
         new_tv = tv.remove_scalar(
-            sc_axis.axis,
+            time_coord.axis,
             name=new_tv_name
         )
         new_v = copy_as_alternate(v)

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -269,6 +269,7 @@ class PrecipRateToFluxFunction(PreprocessorFunctionBase):
         The signature of this method is altered by the :func:`edit_request_wrapper`
         decorator.
         """
+        v_to_translate = None
         std_name = getattr(v, 'standard_name', "")
         if std_name not in self._rate_d and std_name not in self._flux_d:
             # logic not applicable to this VE; do nothing and return varlistEntry for

--- a/src/translation.py
+++ b/src/translation.py
@@ -211,7 +211,7 @@ class Fieldlist:
                      var_or_name: str,
                      realm: str,
                      long_name: str = "",
-                     modifier: str = "") -> collections.OrderedDict:
+                     modifier: str = "") -> dict:
         """Like :meth:`from_CF`, but only return the variable's name in this
         convention.
 
@@ -222,11 +222,12 @@ class Fieldlist:
             modifier:optional string to distinguish a 3-D field from a 4-D field with
             the same var_or_name value
         """
+
         return self.from_CF(var_or_name,
                             modifier=modifier,
                             long_name=long_name,
                             name_only=True,
-                            realm=realm).name
+                            realm=realm)
 
     def get_variable_long_name(self, var, has_scalar_coords: bool) -> str:
         if not var.long_name and has_scalar_coords:
@@ -242,10 +243,11 @@ class Fieldlist:
         """
         c = old_coord
         assert c.is_scalar, f'{c.name} is not a scalar coordinate'
-        if 'name' in new_coord:
-            key = new_coord['name']
-        elif 'out_name' in new_coord:
-            key = new_coord['out_name']
+        key = ""
+        if hasattr(new_coord, 'name'):
+            key = new_coord.name
+        elif hasattr(new_coord, 'out_name'):
+            key = new_coord.out_name
         for v in self.scalar_coord_templates.values():
             if key not in v.keys():
                 raise ValueError((f"Don't know how to name {c.name} ({c.axis}) slice "
@@ -253,23 +255,23 @@ class Fieldlist:
                                   ))
         # construct convention's name for this variable on a level
         name_template = self.scalar_coord_templates[var_id][key]
-        if new_coord['units'].strip('').lower() == 'pa':
-            val = int(new_coord['value']/100)
+        if new_coord.units.strip('').lower() == 'pa':
+            val = int(new_coord.value/100)
         else:
-            val = int(new_coord['value'])
+            val = int(new_coord.value)
 
         new_name = name_template.format(value=val)
-        if units.units_equal(c.units, new_coord['units']):
+        if units.units_equal(c.units, new_coord.units):
             log.debug("Renaming %s %s %s slice of '%s' to '%s'.",
                       c.value, c.units, c.axis, self.name, new_name)
         else:
             log.debug("Renaming %s slice of '%s' to '%s' (@ %s %s = %s %s).",
                       c.axis, self.name, new_name, c.value, c.units,
-                      new_coord['value'], new_coord['units']
+                      new_coord.value, new_coord.units
                       )
         return new_name
 
-    def translate_coord(self, coord, log=_log) -> dict:
+    def translate_coord(self, coord, class_dict=None, log=_log) -> dict:
         """Given a :class:`~data_model.DMCoordinate`, look up the corresponding
         translated :class:`~data_model.DMCoordinate` in this convention.
         """
@@ -316,10 +318,21 @@ class Fieldlist:
             new_coord = [lut1.values()][0]
 
         if hasattr(coord, 'is_scalar') and coord.is_scalar:
-            new_coord = copy.deepcopy(new_coord)
-            new_coord['value'] = units.convert_scalar_coord(coord,
-                                                            new_coord['units'],
-                                                            log=log)
+            coord_name = ""
+            if new_coord.get('name', None):
+                coord_name = new_coord['name']
+            elif new_coord.get('out_name', None):
+                coord_name = new_coord['out_name']
+            coord_copy = copy.deepcopy(new_coord)
+            coord_copy['value'] = units.convert_scalar_coord(coord,
+                                                             coord_copy['units'],
+                                                             log=log)
+            try:
+                new_coord = data_model.coordinate_from_struct(coord_copy,
+                                                              class_dict=class_dict,
+                                                              name=coord_name)
+            except Exception as exc:
+                print(exc)
         else:
             new_coord = dc.replace(coord,
                                    **(util.filter_dataclass(new_coord, coord)))
@@ -362,9 +375,16 @@ class Fieldlist:
                                                 fl_atts['long_name'],
                                                 fl_atts['realm'],
                                                 fl_atts['modifier'])
+        # build reference dictionary of axes classes so that any scalar_coords are cast to
+        # corresponding Varlist[]Coordinate classes
+        class_dict = None
+        if has_scalar_coords:
+            class_dict = dict()
+            for k, v in var.axes.items():
+                class_dict.update({k: v.__class__})
 
         new_dims = [self.translate_coord(dim, log=var.log) for dim in var.dims]
-        new_scalars = [self.translate_coord(dim, log=var.log) for dim in var.scalar_coords]
+        new_scalars = [self.translate_coord(dim, class_dict=class_dict, log=var.log) for dim in var.scalar_coords]
         if len(new_scalars) > 1:
             raise NotImplementedError()
         elif len(new_scalars) == 1:
@@ -378,10 +398,8 @@ class Fieldlist:
             # data_model._DMDimensionsMixin.__post_init__() call from
             # TranslatedVarlistEntry
             for s in new_scalars:
-                if 'is_scalar' not in s:
-                    s['is_scalar'] = True
-
-            new_scalars = util.NameSpace.fromDict(new_scalars)
+                if not s.is_scalar:
+                    s.is_scalar = True
 
         return util.coerce_to_dataclass(
             fl_atts, TranslatedVarlistEntry,
@@ -521,7 +539,7 @@ class VariableTranslator(metaclass=util.Singleton):
             return NoTranslationFieldlist()
         else:
             # normal case: translate according to data source's naming convention
-            conv_name = self.get_convention_name(conv_name)
+            conv_name = self.get_convention_name(conv_name.lower())
             return self.conventions[conv_name]
 
     def _fieldlist_method(self, conv_name: str, method_name: str, *args, **kwargs):

--- a/src/translation.py
+++ b/src/translation.py
@@ -17,7 +17,6 @@ _log = logging.getLogger(__name__)
 _NO_TRANSLATION_CONVENTION = 'no_translation'  # naming convention for disabling translation
 
 
-
 @util.mdtf_dataclass
 class TranslatedVarlistEntry(data_model.DMVariable):
     """Class returned by :meth:`VarlistTranslator.translate`. Marks some

--- a/src/translation.py
+++ b/src/translation.py
@@ -325,45 +325,6 @@ class Fieldlist:
                                    **(util.filter_dataclass(new_coord, coord)))
         return new_coord
 
-    def precip_rate_to_flux(self, v, to_convention: str):
-        """Convert the dependent variable's units, for
-        the specific case of precipitation. Flux and precip rate differ by a factor
-        of the density of water, so can't be handled by the udunits2 implementation
-        provided by :class:`~src.units.Units`. Instead, they're handled here as a
-        special case. The general case of unit conversion is handled by
-        :class:`ConvertUnitsFunction`.
-
-        CF ``standard_names`` recognized for the conversion are ``precipitation_flux``,
-        ``convective_precipitation_flux``, ``large_scale_precipitation_flux``, and
-        likewise for ``*_rate``.
-        """
-        # Incorrect but matches convention for this conversion.
-
-        std_name = getattr(v, 'standard_name', "")
-
-        if std_name not in _rate_d and std_name not in _flux_d:
-            # logic not applicable to this VE; do nothing and return varlistEntry for
-            # next function to run edit_request on
-            return v
-        # var.translation.units set by edit_request will have been overwritten by
-        # DefaultDatasetParser to whatever they are in ds. Change them back.
-        if std_name in _rate_d:
-            # requested rate, received alternate for flux
-            new_units = units.Units(v.units) / _liquid_water_density
-        elif std_name in _flux_d:
-            # requested flux, received alternate for rate
-            new_units = units.Units(v.units) * _liquid_water_density
-
-        v.log.debug(('Assumed implicit factor of water density in units for %s: '
-                     'given %s, will convert as %s.'),
-                    v.full_name, v.units, new_units.units,
-                    tags=util.ObjectLogTag.NC_HISTORY
-                    )
-        v.units = new_units.units
-        #v.standard_name =
-        #v.conversion =
-        return v
-
     def translate(self, var, from_convention: str):
         """Returns :class:`TranslatedVarlistEntry` instance, with populated
         coordinate axes. Units of scalar coord slices are translated to the units

--- a/src/translation.py
+++ b/src/translation.py
@@ -331,8 +331,8 @@ class Fieldlist:
                 new_coord = data_model.coordinate_from_struct(coord_copy,
                                                               class_dict=class_dict,
                                                               name=coord_name)
-            except Exception as exc:
-                print(exc)
+            except ValueError:
+                log.error('unable to obtain new_coord from coordinate_from_struct call in translate.translate_coord')
         else:
             new_coord = dc.replace(coord,
                                    **(util.filter_dataclass(new_coord, coord)))

--- a/src/translation.py
+++ b/src/translation.py
@@ -266,6 +266,7 @@ class Fieldlist:
             raise KeyError((f"Coordinate {coord.name} with standard name "
                             f"'{coord.standard_name}' not defined in convention '{self.name}'."))
 
+        new_coord = dict()
         lut1 = dict()
         for k, v in self.axes_lut.items():
             if v.get('standard_name') == coord.standard_name:

--- a/src/translation.py
+++ b/src/translation.py
@@ -16,20 +16,6 @@ _log = logging.getLogger(__name__)
 
 _NO_TRANSLATION_CONVENTION = 'no_translation'  # naming convention for disabling translation
 
-# only correct for this application
-_liquid_water_density = units.Units('1000.0 kg m-3')
-# list of recognized standard_names for which transformation is applicable
-# NOTE: not exhaustive
-_std_name_tuples = [
-    # flux in CF, rate is not
-    ("precipitation_rate", "precipitation_flux"),
-    # both in CF
-    ("convective_precipitation_rate", "convective_precipitation_flux"),
-    # not in CF; here for compatibility with NCAR-CAM
-    ("large_scale_precipitation_rate", "large_scale_precipitation_flux")
-]
-_rate_d = {tup[0]: tup[1] for tup in _std_name_tuples}
-_flux_d = {tup[1]: tup[0] for tup in _std_name_tuples}
 
 
 @util.mdtf_dataclass

--- a/src/varlist_util.py
+++ b/src/varlist_util.py
@@ -552,7 +552,7 @@ class Varlist(data_model.DMDataSet):
             if hasattr(trans_v, "component"):
                 v.component = trans_v.component
         except KeyError as exc:
-            # can happen in normal operation (eg. precip flux vs. rate)
+            # can happen in normal operation (e.g., precip flux vs. rate)
             chained_exc = util.PodConfigEvent((f"Deactivating {v.full_name} due to "
                                                f"variable name translation: {str(exc)}."))
             # store but don't deactivate, because preprocessor.edit_request()

--- a/src/varlist_util.py
+++ b/src/varlist_util.py
@@ -174,6 +174,7 @@ class VarlistEntry(VarlistEntryBase, util.MDTFObjectBase, data_model.DMVariable,
     realm: str = dc.field(default="", compare=False)
     long_name: str = dc.field(default="", compare=False)
     dest_path: str = ""
+    convention: str = ""
     requirement: VarlistEntryRequirement = dc.field(
         default=VarlistEntryRequirement.REQUIRED, compare=False
     )
@@ -259,7 +260,7 @@ class VarlistEntry(VarlistEntryBase, util.MDTFObjectBase, data_model.DMVariable,
         """
         new_kw = global_settings_d.copy()
         new_kw['coords'] = []
-
+        new_kw['convention'] = parent.pod_settings.get('convention', 'cmip')
         if 'dimensions' not in kwargs:
             raise ValueError(f"No dimensions specified for Varlist entry {name}.")
         # validate: check for duplicate coord names
@@ -287,6 +288,7 @@ class VarlistEntry(VarlistEntryBase, util.MDTFObjectBase, data_model.DMVariable,
                     raise ValueError((f"Unknown dimension name {d_name} in varlist "
                                       f"entry for {name}."))
                 new_kw['coords'].append(dims_d[d_name].make_scalar(scalar_val))
+
         filter_kw = util.filter_dataclass(kwargs, cls, init=True)
         obj = cls(name=name, _parent=parent, **new_kw, **filter_kw)
         # specialize time coord


### PR DESCRIPTION
**Description**
* move preprocessor function edit_request calls before the catalog query
* Update PrecipRatetoFlux and ExtractLevelFunction edit_request methods to work with new translator objects
* Fix translated varlist entry scalar coords so that they are instances of VarlistEntry[X,Y,Z,T,N]Coordinate instead of OrderedDicts for consistency and to ensure that all necessary attributes are accessible to preprocessor functions.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
