### PR TITLE
Update preprocessor.py

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -930,24 +930,24 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                         raise util.DataRequestError(
                             f"Unable to find match or alternate for {v.translation.name}"
                             f" for case {case_name} in {data_catalog}")
+
+                # Get files in specified date range
+                # https://intake-esm.readthedocs.io/en/stable/how-to/modify-catalog.html
+                # cat_subset.esmcat._df = self.check_group_daterange(cat_subset.df)
+                # v.log.debug("Read %d mb for %s.", cat_subset.esmcat._df.dtypes.nbytes / (1024 * 1024), v.full_name)
+                # convert subset catalog to an xarray dataset dict
+                # and concatenate the result with the final dict
+                cat_subset_df = cat_dict | cat_subset.to_dataset_dict(
+                    progressbar=False,
+                    xarray_open_kwargs=self.open_dataset_kwargs
+                )
+                dict_key = list(cat_subset_df)[0]
+                if dict_key not in cat_dict:
+                    cat_dict[dict_key] = cat_subset_df[dict_key]
                 else:
-                    # Get files in specified date range
-                    # https://intake-esm.readthedocs.io/en/stable/how-to/modify-catalog.html
-                    # cat_subset.esmcat._df = self.check_group_daterange(cat_subset.df)
-                    # v.log.debug("Read %d mb for %s.", cat_subset.esmcat._df.dtypes.nbytes / (1024 * 1024), v.full_name)
-                    # convert subset catalog to an xarray dataset dict
-                    # and concatenate the result with the final dict
-                    cat_subset_df = cat_dict | cat_subset.to_dataset_dict(
-                        progressbar=False,
-                        xarray_open_kwargs=self.open_dataset_kwargs
-                    )
-                    dict_key = list(cat_subset_df)[0]
-                    if dict_key not in cat_dict:
-                        cat_dict[dict_key] = cat_subset_df[dict_key]
-                    else:
-                        cat_dict[dict_key] = xr.merge([cat_dict[dict_key], cat_subset_df[dict_key]])
-                  #  print(cat_dict)
-                    # rename cat_subset case dict keys to case names
+                    cat_dict[dict_key] = xr.merge([cat_dict[dict_key], cat_subset_df[dict_key]])
+                # print(cat_dict)
+                # rename cat_subset case dict keys to case names
         cat_dict_rename = self.rename_dataset_keys(cat_dict, case_dict)
         return cat_dict_rename
 


### PR DESCRIPTION
remove last "else" conditional from preprocessor catalog query

**Description**
Include a summary of the change, and link the associated issue (if applicable).  
List any dependencies that are required for this change, including libraries and variables,  
and their metadata (units, frequencies, etc...). Be sure to separate PRs and issues for new PODs and PODs currently under development.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [ ] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [ ] The repository contains no extra test scripts or data files
