### PR TITLE
Fix issues with coordiante is_scalar attribute

### DIFF
--- a/src/data_model.py
+++ b/src/data_model.py
@@ -188,6 +188,9 @@ class _DMCoordinateShared:
     value: typing.Union[int, float, str] = None
     need_bounds: bool = False
 
+    def __init__(self):
+        self._is_scalar = None
+
     @property
     def bounds(self):
         """The *bounds_var* attribute is stored as a pointer to the actual object
@@ -212,7 +215,18 @@ class _DMCoordinateShared:
         <http://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#scalar-coordinate-variables>`__
         (bool).
         """
-        return self.value is not None
+        if not isinstance(self.value, str):
+            return self.value is not None
+        else:
+            return ''.join(self.value.split()) != ""
+
+    @is_scalar.setter
+    def is_scalar(self, value: bool):
+        """Whether the coordinate is a `scalar coordinate
+        <http://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#scalar-coordinate-variables>`__
+        (bool).
+        """
+        self._is_scalar = value
 
     def make_scalar(self, new_value):
         """Returns a copy of the coordinate, converted to a scalar coordinate

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -562,9 +562,8 @@ class ExtractLevelFunction(PreprocessorFunctionBase):
             for var_dict in new_tv_dict.values():
                 if var_dict['ndim'] == 4:
                     new_tv_name = var_dict['name']
-        time_coord = [c for c in tv.scalar_coords if c.axis == 'T'][0]
         new_tv = tv.remove_scalar(
-            time_coord.axis,
+            'Z',
             name=new_tv_name
         )
 

--- a/src/translation.py
+++ b/src/translation.py
@@ -311,7 +311,6 @@ class Fieldlist:
                                                f' by translate_coord')
         else:
             new_coord = [lut1.values()][0]
-
         if hasattr(coord, 'is_scalar') and coord.is_scalar:
             coord_name = ""
             if new_coord.get('name', None):
@@ -331,6 +330,7 @@ class Fieldlist:
         else:
             new_coord = dc.replace(coord,
                                    **(util.filter_dataclass(new_coord, coord)))
+
         return new_coord
 
     def translate(self, var, from_convention: str):


### PR DESCRIPTION
**Description**
Include a summary of the change, and link the associated issue (if applicable).  
List any dependencies that are required for this change, including libraries and variables,  
and their metadata (units, frequencies, etc...). Be sure to separate PRs and issues for new PODs and PODs currently under development.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
