### PR TITLE
grab attrs from ds.time.encoding instead of reattaching

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -129,7 +129,8 @@ class CropDateRangeFunction(PreprocessorFunctionBase):
         objects so that they can be compared with the model data's time axis.
         """
         tv_name = var.name_in_model
-        t_coord = ds.cf.dim_axes(tv_name).get('T', None)
+        # t_coord = ds.cf.dim_axes(tv_name).get('T', None)
+        t_coord = ds.time
         if t_coord is None:
             var.log.debug("Exit %s for %s: time-independent.",
                           self.__class__.__name__, var.full_name)
@@ -137,12 +138,12 @@ class CropDateRangeFunction(PreprocessorFunctionBase):
         # time coordinate will be a list if variable has
         # multiple coordinates/coordinate attributes
         if isinstance(t_coord, list):
-            cal = t_coord[0].attrs['calendar']
+            cal = t_coord[0].encoding['calendar']
             t_start = t_coord[0].values[0]
             t_end = t_coord[0].values[-1]
             t_size = t_coord[0].size
         else:
-            cal = t_coord.attrs['calendar']
+            cal = t_coord.encoding['calendar']
             t_start = t_coord.values[0]
             t_end = t_coord.values[-1]
             t_size = t_coord.size

--- a/src/xr_parser.py
+++ b/src/xr_parser.py
@@ -1278,21 +1278,19 @@ class DefaultDatasetParser:
         """
 
         self.normalize_pre_decode(ds)
-        cal = ds['time'].attrs['calendar']
         ds = xr.decode_cf(ds,
                           decode_coords=True,  # parse coords attr
                           decode_times=True,
                           use_cftime=True  # use cftime instead of np.datetime64
                           )
-        ds['time'].attrs['calendar'] = cal
         # ds = ds.cf.guess_coord_axis()  # may not need this
         # self.restore_attrs_backup(ds)
         # self.normalize_metadata(var, ds)
         self.check_calendar(ds)
         # self._post_normalize_hook(var, ds)
 
-        #if self.disable:
-        #    return ds  # stop here; don't attempt to reconcile
+        if self.disable:
+            return ds  # stop here; don't attempt to reconcile
         #if var is not None:
         #    self.reconcile_variable(var, ds)
         #    self.check_ds_attrs(var, ds)


### PR DESCRIPTION
**Description**
I would like to acknowledge John for bestowing this Xarray knowledge to me.  

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [ x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x ] The repository contains no extra test scripts or data files
