### PR TITLE
fix issues with check_group_daterange

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -7,8 +7,6 @@ import abc
 import dataclasses
 import datetime
 import importlib
-
-import numpy
 import pandas as pd
 from src import util, varlist_util, translation, xr_parser, units
 import cftime
@@ -940,7 +938,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 cat_subset.esmcat._df = self.check_group_daterange(cat_subset.df)
                 if cat_subset.df.empty:
                     raise util.DataRequestError(
-                        f"check_group_daterange returned empty data frame for {a.name}"
+                        f"check_group_daterange returned empty data frame for {v.translation.name}"
                         f" case {case_name} in {data_catalog}, indicating issues with data continuity")
                 # v.log.debug("Read %d mb for %s.", cat_subset.esmcat._df.dtypes.nbytes / (1024 * 1024), v.full_name)
                 # convert subset catalog to an xarray dataset dict

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -7,6 +7,8 @@ import abc
 import dataclasses
 import datetime
 import importlib
+
+import numpy
 import pandas as pd
 from src import util, varlist_util, translation, xr_parser, units
 import cftime
@@ -826,8 +828,10 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                         date_format = '%Y%m%d'
                     case 14:
                         date_format = '%Y%m%d%H%M%S'
-                group_df['start_time'] = pd.to_datetime(group_df['start_time'].values[0], format=date_format)
-                group_df['end_time'] = pd.to_datetime(group_df['end_time'].values[0], format=date_format)
+                # convert start_times to date_format for all files in query
+                group_df['start_time'] = pd.to_datetime(group_df['start_time'].values, format=date_format)
+                # convert end_times to date_format for all files in query
+                group_df['end_time'] = pd.to_datetime(group_df['end_time'].values, format=date_format)
             # method throws ValueError if ranges aren't contiguous
             dates_df = group_df.loc[:, ['start_time', 'end_time']]
             date_range_vals = []
@@ -924,7 +928,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                         cat_subset = cat.search(**case_d.query)
                         if cat_subset.df.empty:
                             raise util.DataRequestError(
-                                f"No assets matching query requirements found for {a.name} for"
+                                f"No assets matching query requirements found for {v.translation.name} for"
                                 f" case {case_name} in {data_catalog}")
                     else:
                         raise util.DataRequestError(
@@ -933,7 +937,11 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
 
                 # Get files in specified date range
                 # https://intake-esm.readthedocs.io/en/stable/how-to/modify-catalog.html
-                # cat_subset.esmcat._df = self.check_group_daterange(cat_subset.df)
+                cat_subset.esmcat._df = self.check_group_daterange(cat_subset.df)
+                if cat_subset.df.empty:
+                    raise util.DataRequestError(
+                        f"check_group_daterange returned empty data frame for {a.name}"
+                        f" case {case_name} in {data_catalog}, indicating issues with data continuity")
                 # v.log.debug("Read %d mb for %s.", cat_subset.esmcat._df.dtypes.nbytes / (1024 * 1024), v.full_name)
                 # convert subset catalog to an xarray dataset dict
                 # and concatenate the result with the final dict

--- a/src/util/datelabel.py
+++ b/src/util/datelabel.py
@@ -403,9 +403,14 @@ class AtomicInterval(object):
         """
         ints = sorted(args, key=op.attrgetter('lower'))
         for i in list(range(0, len(ints) - 1)):
+            # the following check is questionable since it assumes that
+            # the upper bound of date range A should match the lower bound of date range B
+            # in a sorted list for A and B to be considered contiguous
+            # For example, if range A ends on 19791231595959 and Range B begins on 19800101000000,
+            # they are considered to be not contiguous
             if not ints[i].adjoins_left(ints[i + 1]):
-                raise ValueError(("Intervals {} and {} not contiguous and "
-                                  "nonoverlapping.").format(ints[i], ints[i + 1]))
+                _log.warning(("Intervals {} and {} may not be contiguous and "
+                              "nonoverlapping.").format(ints[i], ints[i + 1]))
         return AtomicInterval(ints[0].left, ints[0].lower,
                               ints[-1].upper, ints[-1].right)
 


### PR DESCRIPTION

**Description**
change error to warning in check_contiguous_span method and add check for empty dataframe reutrned by check_group_daterange

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
