### PR TITLE
fix cat_dict concatenation in query_catalog

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -951,13 +951,18 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 )
                 date_range_dict = {f: cat_subset_df[f].attrs['intake_esm_attrs:time_range'] for f in list(cat_subset_df)}
                 date_range_dict = dict(sorted(date_range_dict.items(), key=lambda item: item[1]))
+                var_xr = []
                 for k in list(date_range_dict):
                     date_range_k = dl.DateRange(cat_subset_df[k].attrs['intake_esm_attrs:time_range'])
                     if date_range_k in date_range:
-                        if case_name not in cat_dict:
-                            cat_dict[case_name] = cat_subset_df[k]
+                        if not var_xr:
+                            var_xr = cat_subset_df[k]
                         else:
-                            cat_dict[case_name] = xr.concat([cat_dict[case_name],cat_subset_df[k]], "time")
+                            var_xr = xr.concat([var_xr, cat_subset_df[k]], "time")
+                if case_name not in cat_dict:
+                    cat_dict[case_name] = var_xr
+                else:
+                    cat_dict[case_name] = xr.merge([cat_dict[case_name], var_xr])
                 # rename cat_subset case dict keys to case names
         cat_dict_rename = self.rename_dataset_keys(cat_dict, case_dict)
         return cat_dict_rename

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -9,6 +9,7 @@ import datetime
 import importlib
 import pandas as pd
 from src import util, varlist_util, translation, xr_parser, units
+from src.util import datelabel as dl
 import cftime
 import intake
 import math
@@ -890,6 +891,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
 
             for v in case_d.varlist.iter_vars():
                 realm_regex = v.realm + '*'
+                date_range = v.translation.T.range
                 # define initial query dictionary with variable settings requirements that do not change if
                 # the variable is translated
                 # TODO: add method to convert freq from DateFrequency object to string
@@ -947,11 +949,15 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                     progressbar=False,
                     xarray_open_kwargs=self.open_dataset_kwargs
                 )
-                dict_key = list(cat_subset_df)[0]
-                if dict_key not in cat_dict:
-                    cat_dict[dict_key] = cat_subset_df[dict_key]
-                else:
-                    cat_dict[dict_key] = xr.merge([cat_dict[dict_key], cat_subset_df[dict_key]])
+                date_range_dict = {f: cat_subset_df[f].attrs['intake_esm_attrs:time_range'] for f in list(cat_subset_df)}
+                date_range_dict = dict(sorted(date_range_dict.items(), key=lambda item: item[1]))
+                for k in list(date_range_dict):
+                    date_range_k = dl.DateRange(cat_subset_df[k].attrs['intake_esm_attrs:time_range'])
+                    if date_range_k in date_range:
+                        if case_name not in cat_dict:
+                            cat_dict[case_name] = cat_subset_df[k]
+                        else:
+                            cat_dict[case_name] = xr.concat([cat_dict[case_name],cat_subset_df[k]], "time")
                 # rename cat_subset case dict keys to case names
         cat_dict_rename = self.rename_dataset_keys(cat_dict, case_dict)
         return cat_dict_rename


### PR DESCRIPTION
**Description**
Fix the concatenation scheme for the xarray dataset returned by function. This also adds a check to make sure we only pass files that are within the user-specified date range.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**


**Checklist:**
- [ x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [ x] The repository contains no extra test scripts or data files
