### PR TITLE
fix to write single variable with POD's convention in write_dataset

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -406,13 +406,13 @@ class RenameVariablesFunction(PreprocessorFunctionBase):
         tv = var.translation  # abbreviate
         rename_d = dict()
         # rename var
-        if tv.name != var.name:
-            var.log.debug("Rename '%s' variable in %s to '%s'.",
-                          tv.name, var.full_name, var.name,
-                          tags=util.ObjectLogTag.NC_HISTORY
-                          )
-            rename_d[tv.name] = var.name
-            tv.name = var.name
+        #if tv.name != var.name:
+        #    var.log.debug("Rename '%s' variable in %s to '%s'.",
+        #                  tv.name, var.full_name, var.name,
+        #                  tags=util.ObjectLogTag.NC_HISTORY
+        #                  )
+        #    rename_d[tv.name] = var.name
+        #    tv.name = var.name
 
         # rename coords
         for c in tv.dim_axes.values():
@@ -1153,15 +1153,15 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         <https://xarray.pydata.org/en/stable/generated/xarray.Dataset.to_netcdf.html>`__.
         May be overwritten by child classes.
         """
-        # TODO: remove any netCDF Variables that were present in the input file
-        # (and ds) but not needed for PODs' data request
         os.makedirs(os.path.dirname(var.dest_path), exist_ok=True)
+        var_ds = ds[var.translation.name].to_dataset()
+        var_ds = var_ds.rename_vars(name_dict={var.translation.name:var.name})
         # var.log.info("Writing '%s'.", var.dest_path, tags=util.ObjectLogTag.OUT_FILE)
         if var.is_static:
             unlimited_dims = []
         else:
             unlimited_dims = [var.T.name]
-        ds.to_netcdf(
+        var_ds.to_netcdf(
             path=var.dest_path,
             mode='w',
             **self.save_dataset_kwargs,


### PR DESCRIPTION


**Description**


Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [ x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x ] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [ x] The repository contains no extra test scripts or data files
