### PR TITLE
create function rename_dataset_vars and fix in catalog.py

### DIFF
--- a/mdtf_framework.py
+++ b/mdtf_framework.py
@@ -196,6 +196,8 @@ def main(ctx, configfile: str, verbose: bool = False) -> int:
     cat_subset = data_pp.process(cases, ctx.config, model_paths.MODEL_WORK_DIR)
     # write the preprocessed files
     data_pp.write_ds(cases, cat_subset, pod_runtime_reqs)
+    # rename vars in cat_subset to align with POD convention
+    cat_subset = data_pp.rename_dataset_vars(cat_subset, cases)
     # write the ESM intake catalog for the preprocessed  files
     data_pp.write_pp_catalog(cat_subset, model_paths, log.log)
     # configure the runtime environments and run the POD(s)

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -1025,7 +1025,17 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             (path, filename) = os.path.split(case_d.attrs['intake_esm_attrs:path'])
             rename_key(ds, new_dict, old_key, [c for c in case_names if c in filename][0])
         return new_dict
-
+    
+    def rename_dataset_vars(self, ds: dict, case_list: dict) -> collections.OrderedDict:
+        """Rename variables in dataset to conform with variable names requested by the POD"""
+        case_names = [c for c in case_list.keys()]
+        for c in case_names:
+            name_dict = {}
+            for var in case_list[c].varlist.iter_vars():
+                name_dict[var.translation.name] = var.name
+            ds[c] = ds[c].rename_vars(name_dict=name_dict)
+        return ds
+    
     def clean_nc_var_encoding(self, var, name, ds_obj):
         """Clean up the ``attrs`` and ``encoding`` dicts of *ds_obj*
         prior to writing to a netCDF file, as a workaround for the following

--- a/src/util/catalog.py
+++ b/src/util/catalog.py
@@ -87,9 +87,8 @@ ppParser = ClassMaker()
 class ppParserGFDL(ppParserBase):
     def __init__(self, file_path: str):
         super().__init__(file_path)
-
         self.filename_template = (
-            '{realm}.{time_range}.{variable_id}.{frequency}.nc'
+            '{realm}.{variable_id}.{frequency}.nc'
         )
         self.f = _reverse_filename_format(self.file_basename,
                                           filename_template=self.filename_template
@@ -97,7 +96,7 @@ class ppParserGFDL(ppParserBase):
 
         self.cat_entry.update(self.f)
         self.cat_entry['path'] = file_path
-        self.cat_entry['dataset_name'] = self.cat_entry['realm'] + '.' + self.cat_entry['time_range']
+        self.cat_entry['dataset_name'] = self.cat_entry['realm']
 
 
 @ppParser.maker


### PR DESCRIPTION
**Description**

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**


**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
