### PR TITLE
update mdtf output catalog columns

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -1286,9 +1286,9 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                             if key.split('intake_esm_attrs:')[1] == c:
                                 d[c] = val
                 if var.translation.convention == 'no_translation':
-                    d.update({'convention': var.convention})
+                    d.update({'project_id': var.convention})
                 else:
-                    d.update({'convention': var.translation.convention})
+                    d.update({'project_id': var.translation.convention})
                 d.update({'path': var.dest_path})
                 cat_entries.append(d)
 

--- a/src/util/catalog.py
+++ b/src/util/catalog.py
@@ -59,8 +59,8 @@ def define_pp_catalog_assets(config, cat_file_name: str) -> dict:
                 }
 
     for att in cmip6_cv_info['CV']['required_global_attributes']:
-        if att == 'Conventions':
-            att = "convention"
+        if att == 'variant_label':
+            att = "member_id"
         cat_dict["attributes"].append(
             dict(column_name=att,
                  vocabulary=f"https://github.com/WCRP-CMIP/CMIP6_CVs/blob/master/"
@@ -69,7 +69,7 @@ def define_pp_catalog_assets(config, cat_file_name: str) -> dict:
         )
 
     # add columns required for GFDL/CESM institutions
-    append_atts = ['chunk freq', 'path']
+    append_atts = ['chunk_freq', 'path']
     for att in append_atts:
         cat_dict["attributes"].append(
             dict(column_name=att)
@@ -82,9 +82,9 @@ def define_pp_catalog_assets(config, cat_file_name: str) -> dict:
     cat_dict["aggregation_control"] = {
         "variable_column_name": "variable_id",
         "groupby_attrs": [
-            "activity_id",
             "institution_id",
             "source_id",
+            "member_id",
             "experiment_id",
             "frequency",
             "table_id",


### PR DESCRIPTION

**Description**
* replace variant_label with member_id in catalog assets
* add member_id and remove activity_id from aggregation contro
* define project_id instead of convention column in preprocessor write_pp_catalog

Associated issue #588 

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
