### PR TITLE
Fix MJO suite env vars

### DIFF
--- a/diagnostics/MJO_suite/MJO_suite.py
+++ b/diagnostics/MJO_suite/MJO_suite.py
@@ -21,7 +21,7 @@ def generate_ncl_plots(nclPlotFile):
     nclPlotFile (string) - full path to ncl plotting file name
     """
     # check if the nclPlotFile exists - 
-    # don't exit if it does not exists just print a warning.
+    # don't exit if it does not exist just print a warning.
     try:
         pipe = subprocess.Popen(['ncl {0}'.format(nclPlotFile)], shell=True, stdout=subprocess.PIPE)
         output = pipe.communicate()[0].decode()

--- a/diagnostics/MJO_suite/mjo.ncl
+++ b/diagnostics/MJO_suite/mjo.ncl
@@ -16,9 +16,9 @@ begin
 routine_name = "mjo.ncl"
 pod_home = getenv("POD_HOME")
 casename = getenv("CASENAME")
-file_dir = getenv("WK_DIR")+"/model/netCDF/"
-yr1 = getenv("FIRSTYR")
-yr2 = getenv("LASTYR")
+file_dir = getenv("WORK_DIR")+"/model/netCDF/"
+yr1 = getenv("startdate")
+yr2 = getenv("enddate")
 time_coord = getenv("time_coord")
 
 firstyr = stringtointeger(yr1)

--- a/diagnostics/MJO_suite/mjo_EOF.ncl
+++ b/diagnostics/MJO_suite/mjo_EOF.ncl
@@ -17,7 +17,6 @@ routine_name = "mjo_EOF.ncl"
 vars = (/"pr","rlut","u200","u850","v200","v850"/)
 
 casename = getenv("CASENAME")
-
 file_dir = getenv("WORK_DIR")+"/model/netCDF/"
 filename_pr = file_dir+casename+".pr.day.anom.nc"
 filename_rlut = file_dir+casename+".rlut.day.anom.nc"
@@ -40,7 +39,7 @@ seasons_name = (/"winter","summer"/)
 ;   yrStrt  = ymdStrt/10000
 ;   yrLast  = ymdLast/10000
 
-   pltDir  = getenv("WK_DIR")+"/model/PS/"             ; plot directory
+   pltDir  = getenv("WORK_DIR")+"/model/PS/"             ; plot directory
    pltType = "ps"
 ;   pltName = "mjoclivar"                      ; yrStrt+"_"+yrLast
   

--- a/diagnostics/MJO_suite/mjo_EOF_cal.ncl
+++ b/diagnostics/MJO_suite/mjo_EOF_cal.ncl
@@ -26,7 +26,7 @@ begin
 ;   yrStrt  = ymdStrt/10000
 ;   yrLast  = ymdLast/10000
 
-   pltDir  = getenv("WK_DIR")+"/model/PS/"                             ; plot directory
+   pltDir  = getenv("WORK_DIR")+"/model/PS/"                             ; plot directory
    pltType = "ps"  
    pltName = "mjoclivar"                      ; yrStrt+"_"+yrLast
   

--- a/diagnostics/MJO_suite/mjo_lag_lat_lon.ncl
+++ b/diagnostics/MJO_suite/mjo_lag_lat_lon.ncl
@@ -55,7 +55,7 @@ nameSeason = (/"winter","summer","annual"/)
 
   pltName    = casename+".MJO.lag.lat.lon"       ; output plot name         
   pltType    = "ps"       ; x11, ps, eps, pdf, png 
-  pltDir     = getenv("WK_DIR")+"/model/PS/"       ; output plot directory
+  pltDir     = getenv("WORK_DIR")+"/model/PS/"       ; output plot directory
 
 ;************************************************
 ; create Lanczos BandPass Filter

--- a/diagnostics/MJO_suite/mjo_life_cycle.ncl
+++ b/diagnostics/MJO_suite/mjo_life_cycle.ncl
@@ -27,7 +27,7 @@ begin
 
    pltSubTitle = "Anomalous: OLR, U850, V850"
 
-   pltDir  = getenv("WK_DIR")+"/model/PS/"                           ; plot directory
+   pltDir  = getenv("WORK_DIR")+"/model/PS/"                           ; plot directory
    pltType = "ps"  
    pltName = casename+".MJO.life.cycle"                      ; yrStrt+"_"+yrLast
   

--- a/diagnostics/MJO_suite/mjo_spectra.ncl
+++ b/diagnostics/MJO_suite/mjo_spectra.ncl
@@ -37,7 +37,7 @@ filename_v850 = file_dir+casename+".v850.day.anom.nc"
 ;  fili   = "uwnd.day.850.anomalies.1980-2005.nc"
 ;  f      = addfile(diri+fili, "r")  
 
-  pltDir  = getenv("WK_DIR")+"/model/PS"
+  pltDir  = getenv("WORK_DIR")+"/model/PS"
   pltType = "ps"
   
 


### PR DESCRIPTION


**Description**
* fix refs to WORK_DIR and startdate, enddate in MJO_suite ncl files
* fix typo in MJO_suite driver script
Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
