### PR TITLE
Add support for string time_ranges and date ranges with multiple delimiters

### DIFF
--- a/src/util/datelabel.py
+++ b/src/util/datelabel.py
@@ -562,7 +562,15 @@ class DateRange(AtomicInterval, DateMixin):
         """
         if not end:
             if isinstance(start, str):
-                (start, end) = re.split('[-, :]', start)
+                split_str = re.split('[-, :]', start)
+                if len(split_str) == 2:
+                    (start, end) = split_str
+                else:
+                    nelem = len(split_str)
+                    nelem_half = nelem // 2
+                    # start: split_str[start index of 0: nelem_half elements total], end[start index at nelem_half,
+                    (start, end) = ''.join(split_str[:nelem_half]), ''.join(split_str[nelem_half:])
+
             elif len(start) == 2:
                 (start, end) = start
             else:


### PR DESCRIPTION



**Description**
* add support for string time_range values to preprocessor check_date_range function
* add support for date ranges with multiple delimiters to datelabel DateRange init method
Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
