### PR TITLE
add monthly date_format in check_group_daterange

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -828,6 +828,8 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 # convert int to date type
                 date_format = ''
                 match date_digits:
+                    case 6:
+                        date_format = '%Y%m'
                     case 8:
                         date_format = '%Y%m%d'
                     case 14:
@@ -854,7 +856,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             # assert files_date_range.contains(self.attrs.date_range)
             return sorted_df
         except ValueError:
-            log.error("Non-contiguous or malformed date range in files:", sorted_df["path"].values)
+            print("Non-contiguous or malformed date range in files:", group_df["path"].values)
         except AssertionError:
             log.debug(("Eliminating expt_key since date range of files (%s) doesn't "
                        "span query range (%s)."), files_date_range, self.attrs.date_range)
@@ -892,7 +894,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             # path_regex = re.compile(r'(?i)(?<!\\S){}(?!\\S+)'.format(case_name))
             path_regex = re.compile(r'({})'.format(case_name))
             # path_regex = '*' + case_name + '*'
-            freq = case_d.varlist.T.frequency.format()
+            freq = case_d.varlist.T.frequency.format_local()
 
             for var in case_d.varlist.iter_vars():
                 realm_regex = var.realm + '*'
@@ -908,7 +910,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 # change realm key name if necessary
                 if cat.df.get('modeling_realm', None) is not None:
                     case_d.query['modeling_realm'] = case_d.query.pop('realm')
-
+               
                 # search catalog for convention specific query object
                 var.log.info("Querying %s for variable %s for case %s.",
                             data_catalog,

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -856,7 +856,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             # assert files_date_range.contains(self.attrs.date_range)
             return sorted_df
         except ValueError:
-            print("Non-contiguous or malformed date range in files:", group_df["path"].values)
+            log.error("Non-contiguous or malformed date range in files:", group_df["path"].values)
         except AssertionError:
             log.debug(("Eliminating expt_key since date range of files (%s) doesn't "
                        "span query range (%s)."), files_date_range, self.attrs.date_range)


### PR DESCRIPTION
**Description**
Added a new case to allow for monthly data to not throw a ValueError in check_group_daterange

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
