### PR TITLE
add support for yyyy, yyyymm to start and end dates

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -116,7 +116,8 @@ def check_date_format(date_string: str):
         except ValueError:
             pass
     raise util.exceptions.MDTFBaseException(
-                f"Input date string {date_string} does not match accepted formats: YYYY, YYYY-mm-dd, YYYYmmdd,"
+                f"Input date string {date_string} does not match accepted formats: YYYY, YYYYmm,"
+                f" YYYY-mm, YYYY-mm-dd, YYYYmmdd,"
                 f"YYYYmmdd:HHMMSS, YYYY-mm-dd:HH:MM:SS, YYYY-mm-dd:HH-MM-SS"
             )
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -108,13 +108,15 @@ def check_date_format(date_string: str):
         Credit: https://stackoverflow.com/questions/23581128/how-to-format-date-string-via-multiple-formats-in-python
     """
 
-    for fmt in ('%Y-%m-%d', '%Y-%m-%d:%H:%M:%S', '%Y%m%d:%H%M%S', '%Y-%m-%d:%H-%M-%S', '%Y%m%d', '%Y%m%d%H%M%S'):
+    for fmt in ('%Y', '%Y%m', '%Y-%m', '%Y%m%d',
+                '%Y-%m-%d', '%Y-%m-%d:%H:%M:%S', '%Y%m%d:%H%M%S',
+                '%Y-%m-%d:%H-%M-%S', '%Y%m%d%H%M%S'):
         try:
             return datetime.strptime(date_string, fmt)
         except ValueError:
             pass
     raise util.exceptions.MDTFBaseException(
-                f"Input date string {date_string} does not match accepted formats: YYYY-mm-dd, YYYYmmdd,"
+                f"Input date string {date_string} does not match accepted formats: YYYY, YYYY-mm-dd, YYYYmmdd,"
                 f"YYYYmmdd:HHMMSS, YYYY-mm-dd:HH:MM:SS, YYYY-mm-dd:HH-MM-SS"
             )
 

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -786,7 +786,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         """
         # normal operation: run all functions
         return [
-            CropDateRangeFunction, AssociatedVariablesFunction,
+            AssociatedVariablesFunction,
             PrecipRateToFluxFunction, ConvertUnitsFunction,
             ExtractLevelFunction, RenameVariablesFunction,
         ]

--- a/src/util/datelabel.py
+++ b/src/util/datelabel.py
@@ -631,10 +631,13 @@ class DateRange(AtomicInterval, DateMixin):
             )
         else:
             tmp = Date._coerce_to_self(dt)
+            date_precision = tmp.precision
+            if date_precision <= DatePrecision.MONTH:
+                date_precision = DatePrecision.DAY
             if is_lower:
-                return tmp.lower, tmp.precision
+                return tmp.lower, date_precision
             else:
-                return tmp.upper, tmp.precision
+                return tmp.upper, date_precision
 
     @classmethod
     def _coerce_to_self(cls, item, precision=None):


### PR DESCRIPTION

**Description**
* add support for yyyy and yymm startdate and enddate precision to the framework cli
* put in dummy day date precision for startdate and enddate defined as yymm or yyyy to datelabel
*  remove cropdaterangefunction call from preprocessor execute wrapper as this functionality has been added to checkgroupdaterange during the catalog query. Retain function in code for reference in case extra start/end time refinement is required


Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
RHEL8
**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [ ] The repository contains no extra test scripts or data files
