### PR TITLE
Fix EOF_500hPa by getting monthly plev data past catalog search

### DIFF
--- a/diagnostics/EOF_500hPa/settings.jsonc
+++ b/diagnostics/EOF_500hPa/settings.jsonc
@@ -31,7 +31,7 @@
     "lon": {
              "standard_name": "longitude",
              "units": "degrees_east",
-             "axis": "x"
+             "axis": "X"
            },
     "plev": {
       "standard_name": "air_pressure",

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -918,12 +918,15 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                             case_name)
                 cat_subset = cat.search(**case_d.query)
 
+                rename_var = False
                 if cat_subset.df.empty:
                     # check if variable_id is grabbed by catalog search without plev value appended
                     for c in var.scalar_coords:
                         if c.name == 'plev':
                             case_d.query['variable_id'] = case_d.query['variable_id'].removesuffix(str(c.value))
                             cat_subset = cat.search(**case_d.query)
+                            if not cat_subset.df.empty:
+                                rename_var = True
                             break
 
                 if cat_subset.df.empty:
@@ -981,6 +984,8 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                             var_xr = cat_subset_df[k]
                         else:
                             var_xr = xr.concat([var_xr, cat_subset_df[k]], "time")
+                if rename_var:
+                    var_xr = var_xr.rename_vars(name_dict={case_d.query['variable_id']:var.translation.name})
                 if case_name not in cat_dict:
                     cat_dict[case_name] = var_xr
                 else:

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -910,13 +910,22 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 # change realm key name if necessary
                 if cat.df.get('modeling_realm', None) is not None:
                     case_d.query['modeling_realm'] = case_d.query.pop('realm')
-               
+ 
                 # search catalog for convention specific query object
                 var.log.info("Querying %s for variable %s for case %s.",
                             data_catalog,
                             var.translation.name,
                             case_name)
                 cat_subset = cat.search(**case_d.query)
+
+                if cat_subset.df.empty:
+                    # check if variable_id is grabbed by catalog search without plev value appended
+                    for c in var.scalar_coords:
+                        if c.name == 'plev':
+                            case_d.query['variable_id'] = case_d.query['variable_id'].removesuffix(str(c.value))
+                            cat_subset = cat.search(**case_d.query)
+                            break
+
                 if cat_subset.df.empty:
                     # check whether there is an alternate variable to substitute
                     if any(var.alternates):


### PR DESCRIPTION
**Description**
Include a summary of the change, and link the associated issue (if applicable).  
List any dependencies that are required for this change, including libraries and variables,  
and their metadata (units, frequencies, etc...). Be sure to separate PRs and issues for new PODs and PODs currently under development.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
