### PR TITLE
Add alternate support

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -1282,7 +1282,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         cat_subset = self.query_catalog(case_list, config.DATA_CATALOG)
         for case_name, case_xr_dataset in cat_subset.items():
             for v in case_list[case_name].varlist.iter_vars():
-                tv_name = v.translation.name #abbreviate
+                tv_name = v.translation.name
                 var_xr_dataset = self.parse_ds(v, case_xr_dataset)
                 cat_subset[case_name]['time'] = var_xr_dataset['time']
                 cat_subset[case_name].update({tv_name: var_xr_dataset[tv_name]})

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -557,6 +557,7 @@ class ExtractLevelFunction(PreprocessorFunctionBase):
 
         # add original 4D var defined in new_tv as an alternate TranslatedVarlistEntry
         # to query if no entries on specified levels are found in the data catalog
+
         v.alternates.append(new_tv)
 
         return v
@@ -922,7 +923,13 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                     if any(var.alternates):
                         try_new_query = True
                         for a in var.alternates:
-                            case_d.query.update({'variable_id': a.name})
+                            if hasattr(a, 'translation'):
+                                if a.translation is not None:
+                                    case_d.query.update({'variable_id': a.translation.name})
+                                    case_d.query.update({'standard_name': a.translation.standard_name})
+                            else:
+                                case_d.query.update({'variable_id': a.name})
+                                case_d.query.update({'standard_name': a.standard_name})
                             if any(var.translation.scalar_coords):
                                 found_z_entry = False
                                 # check for vertical coordinate to determine if level extraction is needed

--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -6,7 +6,7 @@ from .basic import (
     ConsistentDict, WormDefaultDict, NameSpace, MDTFEnum,
     sentinel_object_factory, MDTF_ID, deactivate, ObjectStatus,
     is_iterable, to_iter, from_iter, remove_prefix, RegexDict,
-    remove_suffix, filter_kwargs, splice_into_list
+    remove_suffix, filter_kwargs, splice_into_list, new_dict_wo_key
 )
 
 from .logs import (

--- a/src/util/basic.py
+++ b/src/util/basic.py
@@ -3,6 +3,7 @@
 import abc
 import collections
 import collections.abc
+import copy
 import enum
 import itertools
 import string
@@ -709,3 +710,9 @@ class RegexDict(dict):
         return (match for query in queries for match in self.get_matching_value(query))
 
 
+# source: https://stackoverflow.com/questions/5844672/delete-an-element-from-a-dictionary
+def new_dict_wo_key(dictionary: dict, key: str) -> dict:
+    """Returns a **shallow** copy of the input dictionary without a key."""
+    _dict = copy.copy(dictionary)
+    _dict.pop(key, None)
+    return _dict

--- a/src/varlist_util.py
+++ b/src/varlist_util.py
@@ -334,10 +334,15 @@ class VarlistEntry(VarlistEntryBase, util.MDTFObjectBase, data_model.DMVariable,
         })
 
         for ax, dim in self.dim_axes.items():
-            trans_dim = self.translation.axes[ax]
-            self.env_vars[dim.name + _coord_env_var_suffix] = trans_dim.name
-            if trans_dim.has_bounds:
-                self.env_vars[dim.name + _coord_bounds_env_var_suffix] = trans_dim.bounds
+            if self.translation is not None:
+                trans_dim = self.translation.axes[ax]
+                self.env_vars[dim.name + _coord_env_var_suffix] = trans_dim.name
+                if trans_dim.has_bounds:
+                    self.env_vars[dim.name + _coord_bounds_env_var_suffix] = trans_dim.bounds
+            else:
+                self.env_vars[dim.name + _coord_env_var_suffix] = dim.name
+                if dim.has_bounds:
+                    self.env_vars[dim.name + _coord_bounds_env_var_suffix] = dim.bounds
 
     def iter_alternates(self):
         """Breadth-first traversal of "sets" of alternate VarlistEntries,
@@ -569,8 +574,30 @@ class Varlist(data_model.DMDataSet):
             # store but don't deactivate, because preprocessor.edit_request()
             # may supply alternate variables
             v.log.store_exception(chained_exc)
-        # set the VarlistEntry env_vars (required for backwards compatibility with first-gen PODs)
+
+        # set the VarlistEntry env_vars (required for backwards compatibility with first-gen PODs
         v.set_env_vars()
+        # Translate alternate vars if necessary
+        for alt_v in v.alternates:
+            if alt_v.T is not None:
+                alt_v.change_coord(
+                    'T',
+                    new_class={
+                        'self': VarlistTimeCoordinate,
+                        'range': util.DateRange,
+                        'frequency': util.DateFrequency
+                    },
+                    range=date_range,
+                    calendar=util.NOTSET,
+                    units=util.NOTSET
+                )
+            alt_v.dest_path = self.variable_dest_path(model_paths, case_name, alt_v)
+            trans_alt = translate.translate(alt_v, from_convention)
+            alt_v.translation = trans_alt
+            if trans_alt is None:
+                alt_v.info(f'Note: alternate variable {alt_v.full_name} not translated from {from_convention} to'
+                           f' {to_convention}')
+            alt_v.set_env_vars()
 
     def variable_dest_path(self,
                            model_paths: util.ModelDataPathManager,

--- a/src/varlist_util.py
+++ b/src/varlist_util.py
@@ -188,6 +188,7 @@ class VarlistEntry(VarlistEntryBase, util.MDTFObjectBase, data_model.DMVariable,
     status: util.ObjectStatus = dc.field(default=util.ObjectStatus.NOTSET, compare=False)
     name: str = util.MANDATORY
     _parent: typing.Any = dc.field(default=util.MANDATORY, compare=False)
+    is_alternate: bool = False
 
     def __post_init__(self, coords=None):
         # set up log (VarlistEntryLoggerMixin)
@@ -215,11 +216,12 @@ class VarlistEntry(VarlistEntryBase, util.MDTFObjectBase, data_model.DMVariable,
             self.path_variable = self.name.upper() + _file_env_var_suffix
         # self.alternates is either [] or a list of nonempty lists of VEs
         if hasattr(self, 'alternates'):
-            if isinstance(self.alternates, list):
-                if any(self.alternates):
-                    if not isinstance(self.alternates[0], list):
-                        self.alternates = [self.alternates]
-                    self.alternates = [vs for vs in self.alternates if vs]
+            if not isinstance(self.alternates, list):
+                self.alternates = [self.alternates]
+        else:
+            self.alternates = []
+        if self.requirement == VarlistEntryRequirement.ALTERNATE:
+            self.is_alternate = True
         if hasattr(self, 'scalar_coords'):
             self.scalar_coords = self.scalar_coords
 
@@ -615,13 +617,6 @@ class Varlist(data_model.DMDataSet):
             except Exception:
                 raise ValueError(f"Couldn't parse dimension entry for {name}: {dd}")
 
-        def _iter_shallow_alternates(var):
-            """Iterator over all VarlistEntries referenced as alternates. Doesn't
-            traverse alternates of alternates, etc.
-            """
-            for alt_vs in var.alternates:
-                yield from alt_vs
-
         vlist_settings = util.coerce_to_dataclass(
             parent.pod_data, VarlistSettings)
         globals_d = vlist_settings.global_settings
@@ -634,12 +629,17 @@ class Varlist(data_model.DMDataSet):
         }
         for v in vlist_vars.values():
             # validate & replace names of alt vars with references to VE objects
-            for altv_name in _iter_shallow_alternates(v):
+            for altv_name in v.alternates:
                 if altv_name not in vlist_vars:
                     raise ValueError((f"Unknown variable name {altv_name} listed "
                                       f"in alternates for varlist entry {v.name}."))
-            linked_alts = []
-            for alts in v.alternates:
-                linked_alts.append([vlist_vars[v_name] for v_name in alts])
+            linked_alts = [vlist_vars[v_name] for v_name in v.alternates]
             v.alternates = linked_alts
+        alt_vars = [k for k, v in vlist_vars.items() if v.is_alternate]
+        for a in alt_vars:
+            vlist_vars = util.new_dict_wo_key(vlist_vars, a)
+
+        # remove alternates from VarlistEntries since they are now attributes of variable
+        # VarlistEntry objects that they can be substituted for
+
         return cls(contents=list(vlist_vars.values()))


### PR DESCRIPTION
**Description**
* refactor alternates as an attribute list of VarlistEntry objects associated with the primary variable VarlistEntry object
* add calls to translate alternate variables if able
* update logic in preprocessor query_catalog to search alternate translation objects if present and update query name, standard name accordingly

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
