### PR TITLE
reimplement reconcile_variable and fix pathing issues in forcing_feeback

### DIFF
--- a/diagnostics/forcing_feedback/forcing_feedback_plot.py
+++ b/diagnostics/forcing_feedback/forcing_feedback_plot.py
@@ -34,19 +34,19 @@ lon_obs = nc_obs.lon.values
 llons_obs, llats_obs = np.meshgrid(lon_obs, lat_obs)
 
 # Read in model results
-
-nc_pl = xr.open_dataset(os.environ["WORK_DIR"] + "/model/netCDF/fluxanom2D_Planck.nc")
-nc_lr = xr.open_dataset(os.environ["WORK_DIR"] + "/model/netCDF/fluxanom2D_LapseRate.nc")
-nc_lw_q = xr.open_dataset(os.environ["WORK_DIR"] + "/model/netCDF/fluxanom2D_LW_WaterVapor.nc")
-nc_sw_q = xr.open_dataset(os.environ["WORK_DIR"] + "/model/netCDF/fluxanom2D_SW_WaterVapor.nc")
-nc_alb = xr.open_dataset(os.environ["WORK_DIR"] + "/model/netCDF/fluxanom2D_SfcAlbedo.nc")
-nc_lw_c = xr.open_dataset(os.environ["WORK_DIR"] + "/model/netCDF/fluxanom2D_LW_Cloud.nc")
-nc_sw_c = xr.open_dataset(os.environ["WORK_DIR"] + "/model/netCDF/fluxanom2D_SW_Cloud.nc")
-nc_lw_irf = xr.open_dataset(os.environ["WORK_DIR"] + "/model/netCDF/fluxanom2D_LW_IRF.nc")
-nc_sw_irf = xr.open_dataset(os.environ["WORK_DIR"] + "/model/netCDF/fluxanom2D_SW_IRF.nc")
-nc_lw_netrad = xr.open_dataset(os.environ["WORK_DIR"] + "/model/netCDF/fluxanom2D_LW_Rad.nc")
-nc_sw_netrad = xr.open_dataset(os.environ["WORK_DIR"] + "/model/netCDF/fluxanom2D_SW_Rad.nc")
-nc_strat = xr.open_dataset(os.environ["WORK_DIR"] + "/model/netCDF/fluxanom2D_StratFB.nc")
+path_prefix = "/model/"
+nc_pl = xr.open_dataset(os.environ["WORK_DIR"] + path_prefix + "fluxanom2D_Planck.nc")
+nc_lr = xr.open_dataset(os.environ["WORK_DIR"] + path_prefix + "fluxanom2D_LapseRate.nc")
+nc_lw_q = xr.open_dataset(os.environ["WORK_DIR"] + path_prefix + "fluxanom2D_LW_WaterVapor.nc")
+nc_sw_q = xr.open_dataset(os.environ["WORK_DIR"] + path_prefix + "fluxanom2D_SW_WaterVapor.nc")
+nc_alb = xr.open_dataset(os.environ["WORK_DIR"] + path_prefix + "fluxanom2D_SfcAlbedo.nc")
+nc_lw_c = xr.open_dataset(os.environ["WORK_DIR"] + path_prefix + "fluxanom2D_LW_Cloud.nc")
+nc_sw_c = xr.open_dataset(os.environ["WORK_DIR"] + path_prefix + "fluxanom2D_SW_Cloud.nc")
+nc_lw_irf = xr.open_dataset(os.environ["WORK_DIR"] + path_prefix + "fluxanom2D_LW_IRF.nc")
+nc_sw_irf = xr.open_dataset(os.environ["WORK_DIR"] + path_prefix + "fluxanom2D_SW_IRF.nc")
+nc_lw_netrad = xr.open_dataset(os.environ["WORK_DIR"] + path_prefix + "fluxanom2D_LW_Rad.nc")
+nc_sw_netrad = xr.open_dataset(os.environ["WORK_DIR"] + path_prefix + "fluxanom2D_SW_Rad.nc")
+nc_strat = xr.open_dataset(os.environ["WORK_DIR"] + path_prefix + "fluxanom2D_StratFB.nc")
 
 lat_model = nc_sw_irf.lat.values
 weights_model = np.cos(np.deg2rad(lat_model))

--- a/diagnostics/forcing_feedback/forcing_feedback_util.py
+++ b/diagnostics/forcing_feedback/forcing_feedback_util.py
@@ -381,7 +381,7 @@ def fluxanom_nc_create(variable, lat, lon, fbname):
 
     """
     var = xr.DataArray(variable, coords=[lat, lon], dims=['lat', 'lon'], name=fbname)
-    var.to_netcdf(os.environ['WORK_DIR'] + '/model/netCDF/fluxanom2D_' + fbname + '.nc')
+    var.to_netcdf(os.environ['WORK_DIR'] + '/model/fluxanom2D_' + fbname + '.nc')
 
     return None
 

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -437,6 +437,17 @@ class RenameVariablesFunction(PreprocessorFunctionBase):
                 rename_d[c.name] = dest_c.name
                 c.name = dest_c.name
 
+        # check to see if coord has already been translated
+        translated = []
+        for dname, tname in rename_d.items():
+            # will raise an exception if translated coord exists
+            try:
+                if ds[tname] is not None:
+                    translated.append(dname)
+            except:
+                pass
+        [rename_d.pop(t) for t in translated]
+    
         return ds.rename(rename_d)
 
 
@@ -1282,6 +1293,8 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         cat_subset = self.query_catalog(case_list, config.DATA_CATALOG)
         for case_name, case_xr_dataset in cat_subset.items():
             for v in case_list[case_name].varlist.iter_vars():
+                print("start")
+                print(cat_subset[case_name])
                 tv_name = v.translation.name
                 var_xr_dataset = self.parse_ds(v, case_xr_dataset)
                 cat_subset[case_name]['time'] = var_xr_dataset['time']
@@ -1290,7 +1303,9 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                                                             cat_subset[case_name],
                                                             work_dir=model_work_dir[case_name],
                                                             case_name=case_name)
-                cat_subset[case_name].update({tv_name: pp_func_dataset[tv_name]})
+                print("pp_func")
+                print(pp_func_dataset)
+                cat_subset[case_name] = pp_func_dataset
         
         return cat_subset
 

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -1293,8 +1293,6 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         cat_subset = self.query_catalog(case_list, config.DATA_CATALOG)
         for case_name, case_xr_dataset in cat_subset.items():
             for v in case_list[case_name].varlist.iter_vars():
-                print("start")
-                print(cat_subset[case_name])
                 tv_name = v.translation.name
                 var_xr_dataset = self.parse_ds(v, case_xr_dataset)
                 cat_subset[case_name]['time'] = var_xr_dataset['time']
@@ -1303,8 +1301,6 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                                                             cat_subset[case_name],
                                                             work_dir=model_work_dir[case_name],
                                                             case_name=case_name)
-                print("pp_func")
-                print(pp_func_dataset)
                 cat_subset[case_name] = pp_func_dataset
         
         return cat_subset

--- a/src/xr_parser.py
+++ b/src/xr_parser.py
@@ -781,6 +781,11 @@ class DefaultDatasetParser:
                               ds_attr_name, ds_var.name, str(our_attr))
                 ds_var.attrs[ds_attr_name] = str(our_attr)
                 return
+            elif ds_var.encoding[ds_attr_name] is not None:
+                self.log.info("No %s for '%s' found in dataset attrs; setting to '%s' from encoding.",
+                              ds_attr_name, ds_var.name, ds_var.encoding[ds_attr_name])
+                ds_var.attrs[ds_attr_name] = ds_var.encoding[ds_attr_name]
+                return
             else:
                 # don't change ds, raise exception
                 raise util.MetadataError((f"No {ds_attr_name} set for '{ds_var.name}'; "
@@ -1311,7 +1316,7 @@ class DefaultDatasetParser:
         if self.disable:
             return ds  # stop here; don't attempt to reconcile
         if var is not None:
-            # self.reconcile_variable(var, ds)
+            self.reconcile_variable(var, ds)
             self.check_ds_attrs(var, ds)
         else:
             self.check_ds_attrs(None, ds)


### PR DESCRIPTION
**Description**
Uncomment reconcile_variable with a slight fix to allow it to run with the current catalog implementation. This PR also fixes some filepath issues found in forcing_feeback.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
