### PR TITLE
Add separate environment files for micromamba installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ for, the Windows Subsystem for Linux.
   (for space reasons, or if you don’t have write access).
   You can omit this flag, and the environments will be installed within `$CONDA_ROOT/envs/` by default.
 
+  #### NOTE: The micromamba environments may differ from the conda environments because of package compatibility discrepancies between solvers
+  The micromamba installation script only builds the **base** environment, and a limited version of the **python3_base** 
+  enviroment that excludes the following packages and dependencies that may be required by the POD(s) you want to run:
+  - falwa
+  - gridfill
 ## 2. Download the sample data
 
 Supporting observational data and sample model data are available via anonymous FTP at [ftp://ftp.cgd.ucar.edu/archive/mdtf](ftp://ftp.cgd.ucar.edu/archive/mdtf).

--- a/doc/sphinx/start_install.rst
+++ b/doc/sphinx/start_install.rst
@@ -227,6 +227,12 @@ Install all the package's conda environments with micromamba by running
     These environments can be uninstalled by deleting their corresponding directories under <*CONDA_ENV_DIR*>
     (or <*CONDA_ROOT*>/envs/).
 
+.. note::
+    The micromamba environments may differ from the conda environments because of package compatibility discrepancies
+    between solvers. The micromamba installation script only builds the **base** environment, and a limited version of
+    the **python3_base** enviroment that excludes some packages and dependencies that may be required by the
+    POD(s) you want to run.
+
 Location of the installed executable
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/conda/env_NCL_base_micromamba.yml
+++ b/src/conda/env_NCL_base_micromamba.yml
@@ -1,0 +1,9 @@
+name: _MDTF_NCL_base
+channels:
+- conda-forge
+dependencies:
+- python=3.11
+# - openblas=0.3.4 # otherwise ncl 6.5 installs but doesn't function on macs
+- ncl=6.6.2
+- nco=5.1.7
+- pyyaml=6.0.1

--- a/src/conda/env_base_micromamba.yml
+++ b/src/conda/env_base_micromamba.yml
@@ -1,0 +1,33 @@
+name: _MDTF_base
+# environment used by the framework itself
+# use this file if building environment with micromamba
+channels:
+- conda-forge
+dependencies:
+# specify up to minor version number to provide a consistent environment for POD developers
+# versions are current as of Jul 2020
+# see https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/pkg-specs.html
+- python=3.11
+- ghostscript
+- numpy=1.25.2
+- netCDF4=1.6.4
+- cftime=1.6.2
+- xarray=2023.8.0
+# Note: newer versions of cf_xarray are causing issues with missing
+# xarray dataset attributes. There seem to be modifications where
+# ds.cf attributes are defined later in the process, and this clashes
+# with the preprocessing procedures
+- cf_xarray=0.8.4
+- matplotlib=3.8.2
+- pandas=2.1.0
+- pint=0.22
+- dask=2024.1.1
+- ecgtools=2023.7.13
+- cfunits=3.3.6
+- intake=0.7.0
+- intake-esm=2024.2.6
+- subprocess32=3.5.4
+- pyyaml=6.0.1
+- click=8.1.7
+- ghostscript=10.02.1
+- pybind11=2.12.0

--- a/src/conda/env_python3_base_micromamba.yml
+++ b/src/conda/env_python3_base_micromamba.yml
@@ -1,9 +1,9 @@
 name: _MDTF_python3_base
+# use this file if building environment with Anaconda/Miniconda
 channels:
 - conda-forge # NOTE: critical to give highest priority to conda-forge
 dependencies:
 # specify up to minor version number to provide a consistent environment for POD developers
-# versions are current as of Jul 2020
 # see https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/pkg-specs.
 
 - python=3.11
@@ -35,14 +35,11 @@ dependencies:
 - pyyaml=6.0.1
 - networkx=3.1
 - jupyterlab=4.1.0
-- gridfill=1.1.1
 - bottleneck=1.3.8
 - pip=23.3.1
 - pip:
-    - falwa==1.2.1
     - cmocean
     - regionmask
-    - git+https://github.com/csyhuang/hn2016_falwa
     - git+https://github.com/ajdawson/gridfill
     - git+https://github.com/raphaeldussin/static_downsampler
     - git+https://github.com/jkrasting/xcompare

--- a/src/conda/micromamba_env_setup.sh
+++ b/src/conda/micromamba_env_setup.sh
@@ -56,12 +56,12 @@ while (( "$#" )); do
           ;;
         -a|--all)
             # install all envs except dev environment
-            env_glob="env_!(dev).yml"
+            env_glob="env_!(dev)_micromamba.yml"
             shift 1
             ;;
         -e|--env)
             # specify one env by name
-            env_glob="env_${2}.yml"
+            env_glob="env_${2}_micromamba.yml"
             if [ ! -f "${script_dir}/${env_glob}" ]; then
                 echo "ERROR: ${script_dir}/${env_glob} not found."
                 exit 1
@@ -75,7 +75,7 @@ while (( "$#" )); do
             ;;
         --all-dev)
             # all envs, including dev
-            env_glob="env_*.yml"
+            env_glob="env_@(*micromamba|dev).yml"
             shift 1
             ;;
         -d|--env_dir)


### PR DESCRIPTION


**Description**
* add separate environent files for micromamba installation without packages that solver cannot find
* update the micromamba build script to reference the new files
* add notes to README and docs about differences between the conda and micromamba enviroments

Associated issue #605 

**How Has This Been Tested?**
macOS Sonoma w/micromamba, python3

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
