### PR TITLE
add logic for query freq and make parsing in process more explicit

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -905,9 +905,11 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         for case_name, case_d in case_dict.items():
             # path_regex = re.compile(r'(?i)(?<!\\S){}(?!\\S+)'.format(case_name))
             path_regex = re.compile(r'({})'.format(case_name))
-            # path_regex = '*' + case_name + '*'
-            freq = case_d.varlist.T.frequency.format_local()
-
+            # path_regex = '*' + case_name + '*' 
+            freq = case_d.varlist.T.frequency
+            if not isinstance(freq, str):
+                freq = freq.format_local()
+            
             for var in case_d.varlist.iter_vars():
                 realm_regex = var.realm + '*'
                 date_range = var.translation.T.range
@@ -1295,8 +1297,8 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             for v in case_list[case_name].varlist.iter_vars():
                 tv_name = v.translation.name
                 var_xr_dataset = self.parse_ds(v, case_xr_dataset)
-                cat_subset[case_name]['time'] = var_xr_dataset['time']
-                cat_subset[case_name].update({tv_name: var_xr_dataset[tv_name]})
+                for v_d in var_xr_dataset.variables:
+                    cat_subset[case_name][v_d] = var_xr_dataset[v_d]
                 pp_func_dataset = self.execute_pp_functions(v,
                                                             cat_subset[case_name],
                                                             work_dir=model_work_dir[case_name],


### PR DESCRIPTION
**Description**
Sometimes, the varlist.T.frequency is of type string instead of the custom DateFrequency. This adds logic to handle that. The process function in the preprocessor would sometimes drop parsing done on bounds. The added for loop makes the edits done by the parser be explicitly added to the cat_subset.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
