### PR TITLE
Fix xr parser issues

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -386,8 +386,16 @@ class ConvertUnitsFunction(PreprocessorFunctionBase):
                     ds, c.name, src_unit=None, dest_unit=dest_c.units,
                     log=var.log
                 )
+                c.value = None
+                if len(ds[c.name]) > 1:
+                    for v in ds[c.name].values:
+                        if int(v) / dest_c.value == 100:  # v = dest_c in Pa
+                            c.value = dest_c.value
+                        elif int(v) == dest_c.value:
+                            c.value = v
+                else:
+                    c.value = ds[c.name].item()
                 c.units = dest_c.units
-                c.value = ds[c.name].item()
 
         var.log.info("Converted units on %s.", var.full_name)
         return ds
@@ -1298,7 +1306,8 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 tv_name = v.translation.name
                 var_xr_dataset = self.parse_ds(v, case_xr_dataset)
                 varlist_ex = [v_l.translation.name for v_l in case_list[case_name].varlist.iter_vars()]
-                varlist_ex.remove(tv_name)
+                if tv_name in varlist_ex:
+                    varlist_ex.remove(tv_name)
                 for v_d in var_xr_dataset.variables:
                     if v_d not in varlist_ex:
                         cat_subset[case_name].update({v_d: var_xr_dataset[v_d]})


### PR DESCRIPTION
**Description**
Add support for multi-value scalar coordinates (e.g., plev19) in xarray dataset to preprocessor and xr_parser functions

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
RHEL8

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
