### PR TITLE
add exception list of vars to prevent overwriting in preprocessor

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -1297,14 +1297,16 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             for v in case_list[case_name].varlist.iter_vars():
                 tv_name = v.translation.name
                 var_xr_dataset = self.parse_ds(v, case_xr_dataset)
+                varlist_ex = [v_l.translation.name for v_l in case_list[case_name].varlist.iter_vars()]
+                varlist_ex.remove(tv_name)
                 for v_d in var_xr_dataset.variables:
-                    cat_subset[case_name][v_d] = var_xr_dataset[v_d]
+                    if v_d not in varlist_ex:
+                        cat_subset[case_name].update({v_d: var_xr_dataset[v_d]})
                 pp_func_dataset = self.execute_pp_functions(v,
                                                             cat_subset[case_name],
                                                             work_dir=model_work_dir[case_name],
                                                             case_name=case_name)
                 cat_subset[case_name] = pp_func_dataset
-        
         return cat_subset
 
     def write_pp_catalog(self,


### PR DESCRIPTION
**Description**
Include a summary of the change, and link the associated issue (if applicable).  
List any dependencies that are required for this change, including libraries and variables,  
and their metadata (units, frequencies, etc...). Be sure to separate PRs and issues for new PODs and PODs currently under development.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
