### PR TITLE
add logic to add all groupby_attrs in pp_cat_assets

### DIFF
--- a/src/util/catalog.py
+++ b/src/util/catalog.py
@@ -107,5 +107,13 @@ def define_pp_catalog_assets(config, cat_file_name: str) -> dict:
             }
         ]
     }
+    
+    # check groupby_attrs to prevent Key Error in PODs
+    for att in cat_dict["aggregation_control"]["groupby_attrs"]:
+        if att not in cat_dict["attributes"]:
+            cat_dict["attributes"].append(
+                dict(column_name=att)
+            )
+
 
     return cat_dict


### PR DESCRIPTION
**Description**
Some groupyby_attrs were not being populated in the csv of the postprocessed catalog leading to an error. This adds logic to catch these outstanding attrs.

Associated issue #609

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
