### PR TITLE
fix issues in environment_manager env_vars and pod logging

### DIFF
--- a/src/pod_setup.py
+++ b/src/pod_setup.py
@@ -103,7 +103,7 @@ class PodObject(util.MDTFObjectBase, util.PODLoggerMixin, PodBaseClass):
     @property
     def _children(self):
         # property required by MDTFObjectBase
-        return self.multi_case_dict.values()
+        return self.multi_case_dict.get('CASELIST', None)
 
     @property
     def full_name(self):

--- a/src/util/logs.py
+++ b/src/util/logs.py
@@ -483,7 +483,7 @@ class MDTFObjectLoggerMixin(MDTFObjectLoggerMixinBase):
         # then log contents:
         #str_ += self._log_handler.buffer_contents().rstrip()
         # then contents of children:
-        if children:
+        if children and self.iter_children() is not None:
             str_ += '\n'
             for child in self.iter_children():
                 str_ += '\n'
@@ -932,6 +932,3 @@ class MDTFObjectBase(metaclass=basic.MDTFABCMeta):
                 # call handler on parent, which may change parent and/or siblings
                 self._parent.child_deactivation_handler(self, exc)
                 self._parent.child_status_update()
-            # update children (deactivate all)
-            for obj in self.iter_children(status_neq=basic.ObjectStatus.FAILED):
-                obj.deactivate(exceptions.PropagatedEvent(exc=exc, parent=self), level=None)


### PR DESCRIPTION


**Description**
* add alternate var env vars to main env_var list passed to pod via subprocessruntime manager
* redefine pod children attribute
* add check to logs for None value for iter_children change child parm to False for final POD log
Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [ ] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [ ] The repository contains no extra test scripts or data files
