### PR TITLE
add logic to convert pod_env_vars to strings

### DIFF
--- a/src/pod_setup.py
+++ b/src/pod_setup.py
@@ -277,7 +277,12 @@ class PodObject(util.MDTFObjectBase, util.PODLoggerMixin, PodBaseClass):
         if 'pod_env_vars' in self.pod_settings:
             if len(self.pod_settings['pod_env_vars']) > 0:
                 for k, v in self.pod_settings['pod_env_vars'].items():
-                    self.pod_env_vars[k] = v
+                    try:
+                        if not isinstance(v, str):
+                            v = str(v)
+                        self.pod_env_vars[k] = v
+                    except:
+                        raise util.exceptions.MDTFBaseException(f"failed to convert pod_env_vars '{k}' with value '{v}' to type string")
         self.set_interpreter(pod_input.settings)
         self.runtime_requirements = pod_input.settings['runtime_requirements']
         pod_convention = self.pod_settings['convention'].lower()


### PR DESCRIPTION
**Description**
Include a summary of the change, and link the associated issue (if applicable).  
List any dependencies that are required for this change, including libraries and variables,  
and their metadata (units, frequencies, etc...). Be sure to separate PRs and issues for new PODs and PODs currently under development.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
