### PR TITLE
fix forcing_feedback paths

### DIFF
--- a/diagnostics/forcing_feedback/forcing_feedback.html
+++ b/diagnostics/forcing_feedback/forcing_feedback.html
@@ -34,7 +34,7 @@ These results can be used to understand what is driving the a model's particular
 <TR>
 <TR>
 <TH ALIGN=LEFT>Global-Mean Shortwave Feedbacks
-<TH ALIGN=CENTER><A HREF=model/PS/forcing_feedback_globemean_SWFB.png>plot</A>
+<TH ALIGN=CENTER><A HREF=model/forcing_feedback_globemean_SWFB.png>plot</A>
 <TR>
 <TR>
 <TH ALIGN=LEFT>Comparison with CMIP6 Models

--- a/diagnostics/forcing_feedback/forcing_feedback.html
+++ b/diagnostics/forcing_feedback/forcing_feedback.html
@@ -34,7 +34,7 @@ These results can be used to understand what is driving the a model's particular
 <TR>
 <TR>
 <TH ALIGN=LEFT>Global-Mean Shortwave Feedbacks
-<TH ALIGN=CENTER><A HREF=model/forcing_feedback_globemean_SWFB.png>plot</A>
+<TH ALIGN=CENTER><A HREF=model/PS/forcing_feedback_globemean_SWFB.png>plot</A>
 <TR>
 <TR>
 <TH ALIGN=LEFT>Comparison with CMIP6 Models

--- a/diagnostics/forcing_feedback/forcing_feedback_kernelcalcs.py
+++ b/diagnostics/forcing_feedback/forcing_feedback_kernelcalcs.py
@@ -278,6 +278,7 @@ fluxanom_Rcre_SW_TOA = fluxanom_Rtot_SW_TOA - fluxanom_Rclr_SW_TOA
 # the sum of all individual radiative flux anomalies. Total-sky IRF computed as
 # Clear-Sky IRF divided by cloud masking constant. NOTE, these cloud masking constants may not apply
 # to user's specific model experiment.
+
 IRF_lw_clr_TOA = fluxanom_Rclr_LW_TOA - fluxanom_pl_clr_TOA_tropo - fluxanom_lr_clr_TOA_tropo - \
                  fluxanom_lw_q_clr_TOA_tropo - fluxanom_pl_sfc_clr_TOA - fluxanom_pl_clr_TOA_tropo - \
                  fluxanom_lr_clr_TOA_strato - fluxanom_lw_q_clr_TOA_strato

--- a/diagnostics/forcing_feedback/forcing_feedback_plot.py
+++ b/diagnostics/forcing_feedback/forcing_feedback_plot.py
@@ -34,7 +34,7 @@ lon_obs = nc_obs.lon.values
 llons_obs, llats_obs = np.meshgrid(lon_obs, lat_obs)
 
 # Read in model results
-path_prefix = "/model/"
+path_prefix = "/model/netCDF/"
 nc_pl = xr.open_dataset(os.environ["WORK_DIR"] + path_prefix + "fluxanom2D_Planck.nc")
 nc_lr = xr.open_dataset(os.environ["WORK_DIR"] + path_prefix + "fluxanom2D_LapseRate.nc")
 nc_lw_q = xr.open_dataset(os.environ["WORK_DIR"] + path_prefix + "fluxanom2D_LW_WaterVapor.nc")

--- a/diagnostics/forcing_feedback/forcing_feedback_util.py
+++ b/diagnostics/forcing_feedback/forcing_feedback_util.py
@@ -381,7 +381,7 @@ def fluxanom_nc_create(variable, lat, lon, fbname):
 
     """
     var = xr.DataArray(variable, coords=[lat, lon], dims=['lat', 'lon'], name=fbname)
-    var.to_netcdf(os.environ['WORK_DIR'] + '/model/fluxanom2D_' + fbname + '.nc')
+    var.to_netcdf(os.environ['WORK_DIR'] + '/model/netCDF/fluxanom2D_' + fbname + '.nc')
 
     return None
 


### PR DESCRIPTION
**Description**
fix forcing feedback figure paths

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
