### PR TITLE
fix output_manager cleanup

### DIFF
--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -102,7 +102,7 @@ class HTMLPodOutputManager(HTMLSourceFileMixin):
     """Performs cleanup tasks specific to a single POD when that POD has
     finished running.
     """
-    save_ps: bool = False
+    save_ps: bool = True
     save_nc: bool = True
     save_non_nc: bool = False
     CODE_ROOT: str = ""
@@ -120,9 +120,9 @@ class HTMLPodOutputManager(HTMLSourceFileMixin):
                 output files from all PODs.
         """
         try:
-            self.save_ps = config['save_ps']
-            self.save_nc = config['save_pp_data']
-            self.save_non_nc = config['save_pp_data']
+            self.save_ps = config.get('save_ps', True)
+            self.save_nc = config.get('save_pp_data', True)
+            self.save_non_nc = config.get('save_pp_data', False)
         except KeyError as exc:
             pod.deactivate(exc)
             raise
@@ -186,6 +186,7 @@ class HTMLPodOutputManager(HTMLSourceFileMixin):
 
         abs_src_subdir = os.path.join(self.WORK_DIR, src_subdir)
         abs_dest_subdir = os.path.join(self.WORK_DIR, dest_subdir)
+
         files = util.find_files(
             abs_src_subdir,
             ['*.ps', '*.PS', '*.eps', '*.EPS', '*.pdf', '*.PDF']
@@ -250,15 +251,15 @@ class HTMLPodOutputManager(HTMLSourceFileMixin):
 
         # remove .eps files if requested (actually, contents of any 'PS' subdirs)
         if not self.save_ps:
-            for d in util.find_files(self.WORK_DIR, 'PS'+os.sep):
+            for d in util.find_files(self.WORK_DIR, 'obs/PS'):
                 shutil.rmtree(d)
 
         # delete all generated data
         # actually deletes contents of any 'netCDF' subdirs
         elif not self.save_nc:
-            for d in util.find_files(self.WORK_DIR, 'netCDF'+os.sep):
+            for d in util.find_files(self.WORK_DIR, 'model/netCDF'+os.sep):
                 shutil.rmtree(d)
-            for f in util.find_files(self.WORK_DIR, '*.nc'):
+            for f in util.find_files(self.WORK_DIR, 'model/netCDF/*.nc'):
                 os.remove(f)
 
     def make_output(self, config: util.NameSpace):


### PR DESCRIPTION

**Description**
* change logic switches to in HTMLOutputManager init
* fix paths in output_manager.cleanup_pod_files

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
