### PR TITLE
Test nopp

### DIFF
--- a/mdtf_framework.py
+++ b/mdtf_framework.py
@@ -66,7 +66,7 @@ def print_summary(pods, _log: logging.log):
         _log.info(f"Exiting with errors.")
         for case_name, tup in d.items():
             _log.info(f"Summary for {case_name}:")
-            if tup[0][0] == 'dummy sentinel string':
+            if tup[0] == 'dummy sentinel string':
                 _log.info('\tAn error occurred in setup. No PODs were run.')
             else:
                 if tup[1]:

--- a/mdtf_framework.py
+++ b/mdtf_framework.py
@@ -194,14 +194,13 @@ def main(ctx, configfile: str, verbose: bool = False) -> int:
                 func(args)
     # read the subset of data for the cases and date range(s) and preprocess the data
     cat_subset = data_pp.process(cases, ctx.config, model_paths.MODEL_WORK_DIR)
-    if type(data_pp).__name__ != 'NullPreprocessor':
-        # write the preprocessed files
-        data_pp.write_ds(cases, cat_subset, pod_runtime_reqs)
-        # rename vars in cat_subset to align with POD convention
-        cat_subset = data_pp.rename_dataset_vars(cat_subset, cases)
-        # write the ESM intake catalog for the preprocessed  files
-        data_pp.write_pp_catalog(cases, cat_subset, model_paths, log.log)
-        # configure the runtime environments and run the POD(s)
+    # write the preprocessed files
+    data_pp.write_ds(cases, cat_subset, pod_runtime_reqs)
+    # rename vars in cat_subset to align with POD convention
+    cat_subset = data_pp.rename_dataset_vars(cat_subset, cases)
+    # write the ESM intake catalog for the preprocessed  files
+    data_pp.write_pp_catalog(cases, cat_subset, model_paths, log.log)
+    # configure the runtime environments and run the POD(s)
     if not any(p.failed for p in pods.values()):
         log.log.info("### %s: running pods '%s'.", [p for p in pods.keys()])
         run_mgr = environment_manager.SubprocessRuntimeManager(pods, ctx.config, log)

--- a/mdtf_framework.py
+++ b/mdtf_framework.py
@@ -194,13 +194,14 @@ def main(ctx, configfile: str, verbose: bool = False) -> int:
                 func(args)
     # read the subset of data for the cases and date range(s) and preprocess the data
     cat_subset = data_pp.process(cases, ctx.config, model_paths.MODEL_WORK_DIR)
-    # write the preprocessed files
-    data_pp.write_ds(cases, cat_subset, pod_runtime_reqs)
-    # rename vars in cat_subset to align with POD convention
-    cat_subset = data_pp.rename_dataset_vars(cat_subset, cases)
-    # write the ESM intake catalog for the preprocessed  files
-    data_pp.write_pp_catalog(cases, cat_subset, model_paths, log.log)
-    # configure the runtime environments and run the POD(s)
+    if type(data_pp).__name__ != 'NullPreprocessor':
+        # write the preprocessed files
+        data_pp.write_ds(cases, cat_subset, pod_runtime_reqs)
+        # rename vars in cat_subset to align with POD convention
+        cat_subset = data_pp.rename_dataset_vars(cat_subset, cases)
+        # write the ESM intake catalog for the preprocessed  files
+        data_pp.write_pp_catalog(cases, cat_subset, model_paths, log.log)
+        # configure the runtime environments and run the POD(s)
     if not any(p.failed for p in pods.values()):
         log.log.info("### %s: running pods '%s'.", [p for p in pods.keys()])
         run_mgr = environment_manager.SubprocessRuntimeManager(pods, ctx.config, log)

--- a/src/environment_manager.py
+++ b/src/environment_manager.py
@@ -306,7 +306,7 @@ class SubprocessRuntimePODWrapper:
                 except util.WormKeyError:
                     continue
 
-    def pre_run_setup(self, cases: dict):
+    def pre_run_setup(self, cases: dict, catalog_file: str):
         self.pod.log_file = io.open(
             os.path.join(self.pod.paths.POD_WORK_DIR, self.pod.name+".log"),
             'w', encoding='utf-8'
@@ -327,7 +327,7 @@ class SubprocessRuntimePODWrapper:
 
         self.pod.log.debug("%s", self.pod.format_log(children=False))
     #    self.pod._log_handler.reset_buffer()
-        self.write_case_env_file(cases)
+        self.write_case_env_file(cases, catalog_file)
         self.setup_env_vars()
 
     def setup_env_vars(self):
@@ -355,11 +355,11 @@ class SubprocessRuntimePODWrapper:
         self.pod.log_file.write("\n".join(["### Shell env vars: "] + sorted(env_list)))
         self.pod.log_file.write("\n\n")
 
-    def write_case_env_file(self, case_list):
+    def write_case_env_file(self, case_list: dict, catalog_file: str):
         out_file = os.path.join(self.pod.paths.POD_WORK_DIR, 'case_info.yml')
         self.pod.pod_env_vars["case_env_file"] = out_file
         case_info = dict()
-        case_info['CATALOG_FILE'] = os.path.join(self.pod.paths.WORK_DIR, 'MDTF_postprocessed_data.json')
+        case_info['CATALOG_FILE'] = catalog_file
         case_info['CASE_LIST'] = dict()
         assert os.path.isfile(case_info['CATALOG_FILE']), 'CATALOG_FILE json not found in WORK_DIR'
         for case_name, case in case_list.items():
@@ -496,6 +496,8 @@ class SubprocessRuntimeManager(AbstractRuntimeManager):
     _EnvironmentManagerClass = CondaEnvironmentManager
     pods: list = []
     bash_exec: str = ""
+    no_preprocessing: bool = False
+    catalog_file: str = ""
 
     def __init__(self, pod_dict: dict, config: util.NameSpace, _log: logging.log):
         # transfer all pods, even failed ones, because we need to call their
@@ -506,6 +508,12 @@ class SubprocessRuntimeManager(AbstractRuntimeManager):
         # Need to run bash explicitly because 'conda activate' sources
         # env vars (can't do that in posix sh). tcsh could also work.
         self.bash_exec = find_executable('bash')
+
+        self.no_preprocessing = not(config.get('run_pp', False))
+        if self.no_preprocessing:
+            self.catalog_file = config.get('DATA_CATALOG')
+        else:
+            self.catalog_file = os.path.join(config.get('OUTPUT_DIR', 'MDTF_postprocessed_data.json' ))
 
     def iter_active_pods(self):
         """Generator iterating over all wrapped pods which are currently active,
@@ -558,7 +566,7 @@ class SubprocessRuntimeManager(AbstractRuntimeManager):
         for p in self.iter_active_pods():
             p.pod.log.info('%s: run %s.', self.__class__.__name__, p.pod.full_name)
             try:
-                p.pre_run_setup(cases)
+                p.pre_run_setup(cases, self.catalog_file)
             except Exception as exc:
                 p.setup_exception_handler(exc)
                 continue

--- a/src/environment_manager.py
+++ b/src/environment_manager.py
@@ -513,7 +513,7 @@ class SubprocessRuntimeManager(AbstractRuntimeManager):
         if self.no_preprocessing:
             self.catalog_file = config.get('DATA_CATALOG')
         else:
-            self.catalog_file = os.path.join(config.get('OUTPUT_DIR', 'MDTF_postprocessed_data.json' ))
+            self.catalog_file = os.path.join(config.get('OUTPUT_DIR'), 'MDTF_postprocessed_data.json')
 
     def iter_active_pods(self):
         """Generator iterating over all wrapped pods which are currently active,

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -794,6 +794,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             log: log file
         """
         date_col = "date_range"
+        delimiters = ",.!?/&-:;@_'"
         if not hasattr(group_df, 'start_time') or not hasattr(group_df, 'end_time'):
             raise AttributeError('Data catalog is missing attributes `start_time` and/or `end_time`')
         try:
@@ -804,7 +805,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 if isinstance(start_time_vals[0], str):
                     new_start_time_vals = []
                     new_end_time_vals = []
-                    delimiters = ",.!?/&-:;@_'"
+
                     for s in start_time_vals:
                         new_start_time_vals.append(int(''.join(w for w in re.split("[" + "\\".join(delimiters) + "]", s)
                                                                if w)))
@@ -1013,6 +1014,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 xarray_ds = user_module.main(xarray_ds, v.name)
         
         return xarray_ds
+
     def setup(self, pod):
         """Method to do additional configuration immediately before :meth:`process`
         is called on each variable for *pod*. Implements metadata cleaning via
@@ -1331,6 +1333,8 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 else:
                     d.update({'project_id': var.translation.convention})
                 d.update({'path': var.dest_path})
+                d.update({'start_time': util.cftime_to_str(input_catalog_ds[case_name].time.values[0])})
+                d.update({'end_time': util.cftime_to_str(input_catalog_ds[case_name].time.values[-1])})
                 cat_entries.append(d)
 
         # create a Pandas dataframe romthe catalog entries
@@ -1360,6 +1364,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
 class NullPreprocessor(MDTFPreprocessorBase):
     """A class that skips preprocessing and just symlinks files from the input dir to the work dir
     """
+    _XarrayParserClass = xr_parser.NullDatasetParser
 
     def __init__(self,
                  model_paths: util.ModelDataPathManager,

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -1415,7 +1415,6 @@ class NullPreprocessor(MDTFPreprocessorBase):
         """Dummy method; Same catalog specified at runtime is passed to POD(s)
         """
         log.info(f"Using data catalog specified at runtime")
-        pass
 
     def rename_dataset_vars(self, ds: dict, case_list: dict) -> dict:
         """Dummy method for NullPreprocessor """

--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -25,7 +25,7 @@ from .datelabel import (
     DatePrecision, DateRange, Date, DateFrequency,
     FXDateMin, FXDateMax, FXDateRange, FXDateFrequency,
     AbstractDateRange, AbstractDate, AbstractDateFrequency,
-    cftime_to_str
+    cftime_to_str, str_to_cftime
 )
 
 from .filesystem import (

--- a/src/util/__init__.py
+++ b/src/util/__init__.py
@@ -24,7 +24,8 @@ from .dataclass import (
 from .datelabel import (
     DatePrecision, DateRange, Date, DateFrequency,
     FXDateMin, FXDateMax, FXDateRange, FXDateFrequency,
-    AbstractDateRange, AbstractDate, AbstractDateFrequency
+    AbstractDateRange, AbstractDate, AbstractDateFrequency,
+    cftime_to_str
 )
 
 from .filesystem import (

--- a/src/util/catalog.py
+++ b/src/util/catalog.py
@@ -68,8 +68,8 @@ def define_pp_catalog_assets(config, cat_file_name: str) -> dict:
                  )
         )
 
-    # add columns required for GFDL/CESM institutions
-    append_atts = ['chunk_freq', 'path']
+    # add columns required for GFDL/CESM institutions and MDTF-diagnostics functionality
+    append_atts = ['chunk_freq', 'path', 'standard_name', 'start_time', 'end_time']
     for att in append_atts:
         cat_dict["attributes"].append(
             dict(column_name=att)

--- a/src/util/datelabel.py
+++ b/src/util/datelabel.py
@@ -44,12 +44,21 @@ import re
 import datetime
 import operator as op
 import warnings
+
+import cftime
+
 from src import util
 
 import logging
 
 _log = logging.getLogger(__name__)
 
+
+# convert cftime.Datetime to a string
+def cftime_to_str(cf_time: cftime.datetime, fmt=None):
+    if fmt is None:
+        fmt = '%Y%m%d-%H:%M:%S'
+    return cf_time.strftime(fmt)
 
 # ===============================================================
 # following adapted from Alexandre Decan's python-intervals

--- a/src/util/datelabel.py
+++ b/src/util/datelabel.py
@@ -54,11 +54,28 @@ import logging
 _log = logging.getLogger(__name__)
 
 
+# convert a string to a cftime object
+def str_to_cftime(time_str: str, fmt=None, calendar=None):
+    if fmt is None:
+        fmt = '%Y%m%d-%H:%M:%S'
+    if calendar is None:
+        calendar = 'julian'
+    dt = datetime.datetime.strptime(time_str, fmt)
+    cf_date = cftime.datetime(
+        dt.year,
+        dt.month,
+        dt.day,
+        calendar=calendar,
+    )
+    return cf_date
+
+
 # convert cftime.Datetime to a string
 def cftime_to_str(cf_time: cftime.datetime, fmt=None):
     if fmt is None:
         fmt = '%Y%m%d-%H:%M:%S'
     return cf_time.strftime(fmt)
+
 
 # ===============================================================
 # following adapted from Alexandre Decan's python-intervals

--- a/src/xr_parser.py
+++ b/src/xr_parser.py
@@ -1389,6 +1389,3 @@ class DefaultDatasetParser:
             if (ref not in all_arr_names) and (ref not in all_attr_names):
                 missing_refs[ref] = lookup[ref]
         return missing_refs
-
-
-

--- a/src/xr_parser.py
+++ b/src/xr_parser.py
@@ -1391,38 +1391,4 @@ class DefaultDatasetParser:
         return missing_refs
 
 
-class NullDatasetParser(DefaultDatasetParser):
-    def parse(self, var, ds: xr.Dataset):
-        """Calls the above metadata parsing functions in the intended order;
-        intended to be called immediately after the Dataset *ds* is opened.
-
-        .. note::
-           ``decode_cf=False`` should be passed to the xarray open_dataset
-           method, since that parsing is done here instead.
-
-        - Calls :meth:`normalize_pre_decode` to do basic cleaning of metadata
-          attributes.
-        - Call xarray's `decode_cf
-          <http://xarray.pydata.org/en/stable/generated/xarray.decode_cf.html>`__,
-          using `cftime <https://unidata.github.io/cftime/>`__ to decode
-          CF-compliant date/time axes.
-
-        Args:
-            var (:class:`~src.diagnostic.VarlistEntry`): VerlistEntry describing
-                metadata we expect to find in *ds*.
-            ds (Dataset): xarray Dataset of locally downloaded model data.
-
-        Returns:
-            *ds*, with data unchanged but metadata normalized to expected values.
-            Except in specific cases, attributes of *var* are updated to reflect
-            the 'ground truth' of data in *ds*.
-        """
-
-        self.normalize_pre_decode(ds)
-        ds = xr.decode_cf(ds,
-                          decode_coords=True,  # parse coords attr
-                          decode_times=True,
-                          use_cftime=True  # use cftime instead of np.datetime64
-                          )
-        return ds
 

--- a/src/xr_parser.py
+++ b/src/xr_parser.py
@@ -1389,3 +1389,40 @@ class DefaultDatasetParser:
             if (ref not in all_arr_names) and (ref not in all_attr_names):
                 missing_refs[ref] = lookup[ref]
         return missing_refs
+
+
+class NullDatasetParser(DefaultDatasetParser):
+    def parse(self, var, ds: xr.Dataset):
+        """Calls the above metadata parsing functions in the intended order;
+        intended to be called immediately after the Dataset *ds* is opened.
+
+        .. note::
+           ``decode_cf=False`` should be passed to the xarray open_dataset
+           method, since that parsing is done here instead.
+
+        - Calls :meth:`normalize_pre_decode` to do basic cleaning of metadata
+          attributes.
+        - Call xarray's `decode_cf
+          <http://xarray.pydata.org/en/stable/generated/xarray.decode_cf.html>`__,
+          using `cftime <https://unidata.github.io/cftime/>`__ to decode
+          CF-compliant date/time axes.
+
+        Args:
+            var (:class:`~src.diagnostic.VarlistEntry`): VerlistEntry describing
+                metadata we expect to find in *ds*.
+            ds (Dataset): xarray Dataset of locally downloaded model data.
+
+        Returns:
+            *ds*, with data unchanged but metadata normalized to expected values.
+            Except in specific cases, attributes of *var* are updated to reflect
+            the 'ground truth' of data in *ds*.
+        """
+
+        self.normalize_pre_decode(ds)
+        ds = xr.decode_cf(ds,
+                          decode_coords=True,  # parse coords attr
+                          decode_times=True,
+                          use_cftime=True  # use cftime instead of np.datetime64
+                          )
+        return ds
+


### PR DESCRIPTION
**Description**
* finalize NullPreprocessor class and methods
* set catalog path referenced in env_vars file in SubprocessRuntimeManager
* add methods to convert strings to/from cftime.datetime objects to datelabel module
Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
