### PR TITLE
fix multicase_dict pod attribute

### DIFF
--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -28,16 +28,16 @@ def html_templating_dict(pod) -> dict:
         d[attr] = str(pod.pod_settings.get(attr, ""))
         if not any(d[attr]):
             d[attr] = str(getattr(pod, attr, ""))
-    if len(pod.multi_case_dict['CASE_LIST']) > 1:  # multi-case PODs
+    if len(pod.multicase_dict) > 1:  # multi-case PODs
         case_number = 1
-        for case_name, case_dict in pod.multi_case_dict['CASE_LIST'].items():
+        for case_name, case_dict in pod.multicase_dict.items():
             case_str = f'CASE_{case_number}'
             d[case_str] = case_name
             case_number += 1
             for att_name, att in case_dict.items():
                 d[att_name] = att
     else:  # single-case PODs
-        for case_name, case_dict in pod.multi_case_dict['CASE_LIST'].items():
+        for case_name, case_dict in pod.multicase_dict.items():
             for att_name, att in case_dict.items():
                 d[att_name] = att
     return d
@@ -81,7 +81,7 @@ class HTMLSourceFileMixin:
             str_1 = f"POD {self.obj.name}"
         elif isinstance(self, HTMLOutputManager):
             str_1 = ""
-            for case_name in self.obj.multi_case_dict['CASE_LIST'].keys():
+            for case_name in self.obj.multicase_dict.keys():
                 str_1 += f"case {case_name} \n"
         else:
             raise AssertionError("self is not an instance of HTMLPodOutputManager or HTMLOutputManager")
@@ -311,7 +311,7 @@ class HTMLOutputManager(AbstractOutputManager,
             else:
                 self.overwrite = False
             self.file_overwrite = self.overwrite  # overwrite both config and .tar
-            if hasattr(config, 'make_multicase_figure_html'):
+            if config.get('make_multicase_figure_html', False):
                 self.multi_case_figure = config['make_multicase_figure_html']
             else:
                 self.multi_case_figure = False
@@ -461,8 +461,8 @@ class HTMLOutputManager(AbstractOutputManager,
         util.append_html_template(self.CASE_TEMP_HTML, dest, {})
         with io.open(dest, 'a', encoding='utf-8') as f:
             if self.multi_case_figure:
-                self.generate_html_file_case_loop(self.obj.multi_case_dict['CASE_LIST'], template_dict, f)
-            self.append_case_info_html(self.obj.multi_case_dict['CASE_LIST'], f)
+                self.generate_html_file_case_loop(self.obj.multicase_dict, template_dict, f)
+            self.append_case_info_html(self.obj.multicase_dict, f)
         f.close()
         util.append_html_template(
             self.html_src_file('mdtf_footer.html'), dest, template_dict

--- a/src/pod_setup.py
+++ b/src/pod_setup.py
@@ -39,7 +39,7 @@ class PodObject(util.MDTFObjectBase, util.PODLoggerMixin, PodBaseClass):
     pod_data = dict()
     pod_vars = dict()
     pod_settings = dict()
-    multi_case_dict = dict()  # populated with case_info entries in enviroment_manager
+    multicase_dict = dict()  # populated with case_info entries in enviroment_manager
     overwrite: bool = False
     # explict 'program' attribute in settings
     _interpreters = dict
@@ -76,6 +76,7 @@ class PodObject(util.MDTFObjectBase, util.PODLoggerMixin, PodBaseClass):
                                          env=self.pod_env_vars,
                                          new_work_dir=False)
         self.paths.setup_pod_paths(self.name)
+        self.multicase_dict = runtime_config.case_list
         util.MDTFObjectBase.__init__(self, name=self.name, _parent=None)
 
     # Explicitly invoke MDTFObjectBase post_init and init methods so that _id and other inherited


### PR DESCRIPTION

**Description**
update definitions and refs to multicase_dict attribute in pod_setup and output_manager


Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
