### PR TITLE
Fix multi-pod implementation

### DIFF
--- a/mdtf_framework.py
+++ b/mdtf_framework.py
@@ -177,9 +177,12 @@ def main(ctx, configfile: str, verbose: bool = False) -> int:
     pods = dict.fromkeys(ctx.config.pod_list, [])
     pod_runtime_reqs = dict()
     # configure pod object(s)
-    for pod_name in ctx.config.pod_list:
+    append_vars = False
+    for count, pod_name in enumerate(ctx.config.pod_list):
+        if count > 0:
+            append_vars = True
         pods[pod_name] = pod_setup.PodObject(pod_name, ctx.config)
-        pods[pod_name].setup_pod(ctx.config, model_paths, cases)
+        pods[pod_name].setup_pod(ctx.config, model_paths, cases, append_vars)
         pods[pod_name].log.info(f"Preprocessing data for {pod_name}")
         for k, v in pods[pod_name].runtime_requirements.items():
             if not hasattr(pod_runtime_reqs, k):

--- a/src/data_sources.py
+++ b/src/data_sources.py
@@ -24,7 +24,7 @@ class DataSourceBase(util.MDTFObjectBase, util.CaseLoggerMixin):
     date_range: util.DateRange = dataclasses.field(init=False)
     varlist: varlist_util.Varlist = None
     log_file: io.IOBase = dataclasses.field(default=None, init=False)
-    env_vars: util.WormDict()
+    env_vars: util.WormDict
     query: dict = dict(frequency="",
                        path="",
                        standard_name="",
@@ -60,8 +60,8 @@ class DataSourceBase(util.MDTFObjectBase, util.CaseLoggerMixin):
     def iter_vars_only(self, active=None):
         yield from self.varlist.iter_vars_only(active=active)
 
-    def read_varlist(self, parent):
-        self.varlist = varlist_util.Varlist.from_struct(parent)
+    def read_varlist(self, parent, append_vars: bool=False):
+        self.varlist = varlist_util.Varlist.from_struct(parent, append_vars)
 
     def set_date_range(self, startdate: str, enddate: str):
         self.date_range = util.DateRange(start=startdate, end=enddate)

--- a/src/data_sources.py
+++ b/src/data_sources.py
@@ -1,9 +1,8 @@
 """Implementation classes for model data query
 """
-import os
 import io
 import dataclasses
-from src import util, cmip6, varlist_util
+from src import util, varlist_util
 
 import logging
 
@@ -63,21 +62,23 @@ class DataSourceBase(util.MDTFObjectBase, util.CaseLoggerMixin):
     def read_varlist(self, parent, append_vars: bool=False):
         self.varlist = varlist_util.Varlist.from_struct(parent, append_vars)
 
+
     def set_date_range(self, startdate: str, enddate: str):
         self.date_range = util.DateRange(start=startdate, end=enddate)
 
     def translate_varlist(self,
+                          var: varlist_util.VarlistEntry,
                           model_paths: util.ModelDataPathManager,
                           case_name: str,
                           from_convention: str,
                           to_convention: str):
-        for v in self.varlist.iter_vars():
-            self.varlist.setup_var(model_paths,
-                                   case_name,
-                                   v,
-                                   from_convention,
-                                   to_convention,
-                                   self.date_range)
+
+        self.varlist.setup_var(model_paths,
+                               case_name,
+                               var,
+                               from_convention,
+                               to_convention,
+                               self.date_range)
 
 
 # instantiate the class maker so that the convention-specific classes can be instantiated using

--- a/src/pod_setup.py
+++ b/src/pod_setup.py
@@ -302,10 +302,14 @@ class PodObject(util.MDTFObjectBase, util.PODLoggerMixin, PodBaseClass):
                 self.log.info(f'POD convention and data convention are both {data_convention}. '
                               f'No data translation will be performed for case {case_name}.')
             # A 'noTranslationFieldlist' will be defined for the varlistEntry translation attribute
-            cases[case_name].translate_varlist(model_paths,
-                                               case_name,
-                                               pod_convention,
-                                               data_convention)
+            for v in pod_input.varlist.keys():
+                for v_entry in cases[case_name].varlist.iter_vars():
+                    if v_entry.name == v:
+                        cases[case_name].translate_varlist(v_entry,
+                                                           model_paths,
+                                                           case_name,
+                                                           pod_convention,
+                                                           data_convention)
 
         for case_name in cases.keys():
             for v in cases[case_name].iter_children():

--- a/src/pod_setup.py
+++ b/src/pod_setup.py
@@ -51,6 +51,7 @@ class PodObject(util.MDTFObjectBase, util.PODLoggerMixin, PodBaseClass):
     nc_largefile: bool = False
     bash_exec: str
     global_env_vars: dict
+    paths: util.PodPathManager
 
     def __init__(self, name: str, runtime_config: util.NameSpace):
         self.name = name
@@ -72,10 +73,11 @@ class PodObject(util.MDTFObjectBase, util.PODLoggerMixin, PodBaseClass):
         self.bash_exec = find_executable('bash')
         # Initialize the POD path object and define the POD output paths
         # Don't need a new working directory since one is created when the model data directories are initialized
-        self.paths = util.PodPathManager(runtime_config,
+        self.paths = util.PodPathManager(self.name,
+                                         runtime_config,
                                          env=self.pod_env_vars,
+                                         unittest=False,
                                          new_work_dir=False)
-        self.paths.setup_pod_paths(self.name)
         self.multicase_dict = runtime_config.case_list
         util.MDTFObjectBase.__init__(self, name=self.name, _parent=None)
 
@@ -262,7 +264,8 @@ class PodObject(util.MDTFObjectBase, util.PODLoggerMixin, PodBaseClass):
 
     def setup_pod(self, runtime_config: util.NameSpace,
                   model_paths: util.ModelDataPathManager,
-                  cases: dict):
+                  cases: dict,
+                  append_vars: bool=False):
         """Update POD information from settings and runtime configuration files
         """
         # Parse the POD settings file
@@ -289,7 +292,7 @@ class PodObject(util.MDTFObjectBase, util.PODLoggerMixin, PodBaseClass):
         pod_convention = self.pod_settings['convention'].lower()
 
         for case_name, case_dict in runtime_config.case_list.items():
-            cases[case_name].read_varlist(self)
+            cases[case_name].read_varlist(self, append_vars=append_vars)
             # Translate the data if desired and the pod convention does not match the case convention
             data_convention = case_dict.convention.lower()
             if runtime_config.translate_data and pod_convention != data_convention:

--- a/src/util/path_utils.py
+++ b/src/util/path_utils.py
@@ -13,7 +13,7 @@ import logging
 _log = logging.getLogger(__name__)
 
 
-class PathManagerBase(metaclass=Singleton):
+class PathManagerBase:
     """:class:`~util.Singleton` holding the root directories for all paths used
     by the code.
     """
@@ -93,9 +93,13 @@ class PodPathManager(PathManagerBase):
     POD_OBS_DATA: str
     POD_CODE_DIR: str
 
-    def setup_pod_paths(self, pod_name: str):
-        """Check and create directories specific to this POD.
-        """
+    def __init__(self, pod_name: str,
+                 config: NameSpace = None,
+                 env: dict = None,
+                 unittest: bool = False,
+                 new_work_dir: bool = True):
+
+        super().__init__(config, env, unittest, new_work_dir)
 
         self.POD_CODE_DIR = os.path.join(self.CODE_ROOT, 'diagnostics', pod_name)
         self.POD_WORK_DIR = os.path.join(self.WORK_DIR, pod_name)


### PR DESCRIPTION
**Description**
* fix issues with pod paths overwriting settings when new pod object is instantiated
* refactor varlist configuration so that varlistentries can be appended for each pod
* update preprocessor freq entry in query to use the variable spec instead of the case spec
* add line to delete problem height attribute from queried xarray dataset

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
MacOS Sonoma with example and ocn_surf_flux_diag PODs on synthetic data

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
