### PR TITLE
fix alternates

### DIFF
--- a/src/varlist_util.py
+++ b/src/varlist_util.py
@@ -663,15 +663,15 @@ class Varlist(data_model.DMDataSet):
             for k, v in parent.pod_vars.items()}
         )
 
+        alt_vars = [k for k, v in cls.vlist_vars.items() if v.is_alternate]
         for v in cls.vlist_vars.values():
             # validate & replace names of alt vars with references to VE objects
             for altv_name in v.alternates:
                 if altv_name not in cls.vlist_vars:
                     raise ValueError((f"Unknown variable name {altv_name} listed "
                                       f"in alternates for varlist entry {v.name}."))
-            linked_alts = [cls.vlist_vars[v_name] for v_name in v.alternates]
+            linked_alts = [cls.vlist_vars[v_name] for v_name in alt_vars]
             v.alternates = linked_alts
-        alt_vars = [k for k, v in cls.vlist_vars.items() if v.is_alternate]
         for a in alt_vars:
             cls.vlist_vars = util.new_dict_wo_key(cls.vlist_vars, a)
 


### PR DESCRIPTION


**Description**
fix issues with alternate variable configuration in VarlistEntry.from_struct

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
