### PR TITLE
Fix pod multicase dict

### DIFF
--- a/src/environment_manager.py
+++ b/src/environment_manager.py
@@ -345,8 +345,8 @@ class SubprocessRuntimePODWrapper:
                          for k, v in self.pod.pod_env_vars.items() if k not in skip_items}
 
         # append varlist env vars for backwards compatibility with single-run PODs
-        if len(self.pod.multi_case_dict['CASE_LIST']) == 1:
-            for case_name, case_info in self.pod.multi_case_dict['CASE_LIST'].items():
+        if len(self.pod.multicase_dict['CASE_LIST']) == 1:
+            for case_name, case_info in self.pod.multicase_dict['CASE_LIST'].items():
                 for k, v in case_info.items():
                     self.env_vars[k] = v
 
@@ -390,7 +390,7 @@ class SubprocessRuntimePODWrapper:
         f = open(out_file, 'w+')
         assert os.path.isfile(out_file), f"Could not find case env file {out_file}"
         yaml.dump(case_info, f, allow_unicode=True, default_flow_style=False)
-        self.pod.multi_case_dict = case_info
+        self.pod.multicase_dict = case_info
         f.close()
 
     def setup_exception_handler(self, exc):

--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -28,16 +28,16 @@ def html_templating_dict(pod) -> dict:
         d[attr] = str(pod.pod_settings.get(attr, ""))
         if not any(d[attr]):
             d[attr] = str(getattr(pod, attr, ""))
-    if len(pod.multicase_dict) > 1:  # multi-case PODs
+    if len(pod.multicase_dict['CASE_LIST']) > 1:  # multi-case PODs
         case_number = 1
-        for case_name, case_dict in pod.multicase_dict.items():
+        for case_name, case_dict in pod.multicase_dict['CASE_LIST'].items():
             case_str = f'CASE_{case_number}'
             d[case_str] = case_name
             case_number += 1
             for att_name, att in case_dict.items():
                 d[att_name] = att
     else:  # single-case PODs
-        for case_name, case_dict in pod.multicase_dict.items():
+        for case_name, case_dict in pod.multicase_dict['CASE_LIST'].items():
             for att_name, att in case_dict.items():
                 d[att_name] = att
     return d
@@ -81,7 +81,7 @@ class HTMLSourceFileMixin:
             str_1 = f"POD {self.obj.name}"
         elif isinstance(self, HTMLOutputManager):
             str_1 = ""
-            for case_name in self.obj.multicase_dict.keys():
+            for case_name in self.obj.multicase_dict['CASE_LIST'].keys():
                 str_1 += f"case {case_name} \n"
         else:
             raise AssertionError("self is not an instance of HTMLPodOutputManager or HTMLOutputManager")
@@ -403,6 +403,7 @@ class HTMLOutputManager(AbstractOutputManager,
                         "<A href={{PODNAME}}_model_plot_{{CASENAME}}.png>{{CASENAME}}\n</A>"
         for case_name, case_settings in case_info.items():
             case_settings['PODNAME'] = template_dict['PODNAME']
+            case_settings['CASENAME'] = template_dict['CASENAME']
             output_template = util._DoubleBraceTemplate(case_template).safe_substitute(case_settings)
             dest_file_handle.write(output_template)
 
@@ -461,8 +462,8 @@ class HTMLOutputManager(AbstractOutputManager,
         util.append_html_template(self.CASE_TEMP_HTML, dest, {})
         with io.open(dest, 'a', encoding='utf-8') as f:
             if self.multi_case_figure:
-                self.generate_html_file_case_loop(self.obj.multicase_dict, template_dict, f)
-            self.append_case_info_html(self.obj.multicase_dict, f)
+                self.generate_html_file_case_loop(self.obj.multicase_dict['CASE_LIST'], template_dict, f)
+            self.append_case_info_html(self.obj.multicase_dict['CASE_LIST'], f)
         f.close()
         util.append_html_template(
             self.html_src_file('mdtf_footer.html'), dest, template_dict

--- a/src/pod_setup.py
+++ b/src/pod_setup.py
@@ -78,7 +78,6 @@ class PodObject(util.MDTFObjectBase, util.PODLoggerMixin, PodBaseClass):
                                          env=self.pod_env_vars,
                                          unittest=False,
                                          new_work_dir=False)
-        self.multicase_dict = runtime_config.case_list
         util.MDTFObjectBase.__init__(self, name=self.name, _parent=None)
 
     # Explicitly invoke MDTFObjectBase post_init and init methods so that _id and other inherited
@@ -106,7 +105,7 @@ class PodObject(util.MDTFObjectBase, util.PODLoggerMixin, PodBaseClass):
     @property
     def _children(self):
         # property required by MDTFObjectBase
-        return self.multi_case_dict.get('CASELIST', None)
+        return self.multicase_dict.get('CASELIST', None)
 
     @property
     def full_name(self):
@@ -121,7 +120,7 @@ class PodObject(util.MDTFObjectBase, util.PODLoggerMixin, PodBaseClass):
     def iter_case_names(self):
         """Iterator returning :c
         """
-        yield self.multi_case_dict.keys()
+        yield self.multicase_dict.keys()
 
     def parse_pod_settings_file(self, code_root: str) -> util.NameSpace:
         """Parse the POD settings file"""

--- a/src/verify_links.py
+++ b/src/verify_links.py
@@ -240,7 +240,7 @@ class LinkVerifier(object):
             # NB: commonprefix not commonpath, since we have URLs
             prefix = os.path.commonprefix([self.rel_path_root, link.target])
             rel_link = link.target[len(prefix):]
-            pod = rel_link.split('/')[0]
+            pod = self.pod_name
             missing_dict[pod].append(rel_link)
         return missing_dict
 


### PR DESCRIPTION
**Description**
* Fix refs to pod multicase_dict attribute and CASE_NAME entry in output_manager and environment_manager
* fix pod name definition in group_relative_links
Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
