### PR TITLE
spin out to function and extend match case for date format

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -827,21 +827,9 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                         new_end_time_vals.append(int(''.join(w for w in re.split("[" + "\\".join(delimiters) + "]", e)
                                                              if w)))
 
-                    date_digits = math.floor(math.log10(new_start_time_vals[0])) + 1
                     start_time_vals = new_start_time_vals
                     end_time_vals = new_end_time_vals
-                else:
-                    date_digits = math.floor(math.log10(start_time_vals[0])) + 1
-
-                # convert int to date type
-                date_format = ''
-                match date_digits:
-                    case 6:
-                        date_format = '%Y%m'
-                    case 8:
-                        date_format = '%Y%m%d'
-                    case 14:
-                        date_format = '%Y%m%d%H%M%S'
+                date_format = dl.date_fmt(start_time_vals[0])
                 # convert start_times to date_format for all files in query
                 group_df['start_time'] = pd.to_datetime(start_time_vals, format=date_format)
                 # convert end_times to date_format for all files in query

--- a/src/util/datelabel.py
+++ b/src/util/datelabel.py
@@ -54,18 +54,29 @@ import logging
 
 _log = logging.getLogger(__name__)
 
+# match-case statment to give date format
+# input can be int or str
+def date_fmt(date):
+    if isinstance(date, str):
+        date = int(date)
+    date_digits = math.floor(math.log10(date)) + 1
+    match date_digits:
+        case 6:
+            fmt = '%Y%m'
+        case 8:
+            fmt = '%Y%m%d'
+        case 10:
+            fmt = '%Y%m%d%H'
+        case 12:
+            fmt = '%Y%m%d%H%M'
+        case 14:
+            fmt = '%Y%m%d-%H%M%S'
+    return fmt
 
 # convert a string to a cftime object
 def str_to_cftime(time_str: str, fmt=None, calendar=None):
     if fmt is None:
-        date_digits = math.floor(math.log10(int(time_str))) + 1
-        match date_digits:
-            case 6:
-                fmt = '%Y%m'
-            case 8:
-                fmt = '%Y%m%d'
-            case 14:
-                fmt = '%Y%m%d-%H%M%S'
+        fmt = date_fmt(time_str)
     if calendar is None:
         calendar = 'julian'
     dt = datetime.datetime.strptime(time_str, fmt)


### PR DESCRIPTION
**Description**
Include a summary of the change, and link the associated issue (if applicable).  
List any dependencies that are required for this change, including libraries and variables,  
and their metadata (units, frequencies, etc...). Be sure to separate PRs and issues for new PODs and PODs currently under development.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
