### PR TITLE
Fix translator

### DIFF
--- a/src/data_sources.py
+++ b/src/data_sources.py
@@ -62,7 +62,6 @@ class DataSourceBase(util.MDTFObjectBase, util.CaseLoggerMixin):
     def read_varlist(self, parent, append_vars: bool=False):
         self.varlist = varlist_util.Varlist.from_struct(parent, append_vars)
 
-
     def set_date_range(self, startdate: str, enddate: str):
         self.date_range = util.DateRange(start=startdate, end=enddate)
 

--- a/src/pod_setup.py
+++ b/src/pod_setup.py
@@ -292,7 +292,7 @@ class PodObject(util.MDTFObjectBase, util.PODLoggerMixin, PodBaseClass):
 
         for case_name, case_dict in runtime_config.case_list.items():
             cases[case_name].read_varlist(self, append_vars=append_vars)
-            # Translate the data if desired and the pod convention does not match the case convention
+            # Translate the varlistEntries from the POD convention to the data convention if desired and the pod convention does not match the case convention
             data_convention = case_dict.convention.lower()
             if runtime_config.translate_data and pod_convention != data_convention:
                 self.log.info(f'Translating POD variables from {pod_convention} to {data_convention}')

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -162,11 +162,10 @@ class PrecipRateToFluxFunction(PreprocessorFunctionBase):
             )
 
         translate = translation.VariableTranslator()
+        to_convention = None
         for key, val in kwargs.items():
-            if 'convention' in key:
+            if 'to_convention' in key:
                 to_convention = val.lower()
-            else:
-                to_convention = None
         # check if pod variable standard name is the same as translation standard name
         if std_name != v.translation.standard_name:
             try:
@@ -178,9 +177,9 @@ class PrecipRateToFluxFunction(PreprocessorFunctionBase):
                              'translate \'%s\'; varlist unaltered.'), self.__class__.__name__,
                             v.full_name, exc, v_to_translate.standard_name)
                 return None
-            new_v = copy_as_alternate(v)
-            new_v.translation = new_tv
-            v.alternates.append(new_v)
+            v.alternates.append(v.translation)
+            #new_v = copy_as_alternate(v)
+            #new_v.translation = new_tv
             v.translation.name = new_tv.name
             v.translation.standard_name = new_tv.standard_name
             v.translation.units = new_tv.units
@@ -218,6 +217,7 @@ class PrecipRateToFluxFunction(PreprocessorFunctionBase):
                       )
         ds[tv.name].attrs['units'] = str(new_units)
         tv.units = new_units
+        tv.standard_name = var.standard_name
         # actual conversion done by ConvertUnitsFunction; this assures
         # units.convert_dataarray is called with correct parameters.
         return ds
@@ -1281,7 +1281,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         """
         for case_name, case_dict in case_list.items():
             for v in case_dict.varlist.iter_vars():
-                self.edit_request(v, convention=case_dict.convention)
+                self.edit_request(v, to_convention=case_dict.convention)
         # get the initial model data subset from the ESM-intake catalog
         cat_subset = self.query_catalog(case_list, config.DATA_CATALOG)
         for case_name, case_xr_dataset in cat_subset.items():

--- a/src/translation.py
+++ b/src/translation.py
@@ -148,23 +148,20 @@ class Fieldlist:
                             realm: str,
                             modifier: str) -> str:
 
-        precip_vars: ['precipitation_rate', 'precipitation_flux']
+        precip_vars = ['precipitation_rate', 'precipitation_flux']
         # search the lookup table for the variable with the specified standard_name
         # realm, modifier, and long_name attributes
         for var_name, var_dict in self.lut.items():
-            # print(var_name)
             if var_dict['standard_name'] == standard_name\
                     and var_dict['realm'] == realm\
                     and var_dict['modifier'] == modifier:
                 if not var_dict['long_name'] or var_dict['long_name'].lower() == long_name.lower():
                     return var_name
             else:
-                precip_rate_flux = list(set(var_dict['standard_name'], standard_name) & set(precip_vars))
-                if len(precip_rate_flux) > 0:
-                    return precip_rate_flux[0]
+                if var_dict['standard_name'] in precip_vars and standard_name in precip_vars:
+                    return var_name
                 else:
                     continue
-
 
     def from_CF(self,
                 standard_name: str,
@@ -340,7 +337,7 @@ class Fieldlist:
 
         return new_coord
 
-    def translate(self, var, from_convention: str, to_convention: str):
+    def translate(self, var, from_convention: str):
         """Returns :class:`TranslatedVarlistEntry` instance, with populated
         coordinate axes. Units of scalar coord slices are translated to the units
         of the conventions' coordinates. Includes logic to translate and rename
@@ -403,8 +400,10 @@ class Fieldlist:
                 if not s.is_scalar:
                     s.is_scalar = True
 
+        new_atts = self.lut[new_name]
+
         return util.coerce_to_dataclass(
-            fl_atts, TranslatedVarlistEntry,
+            new_atts, TranslatedVarlistEntry,
             name=new_name,
             coords=(new_dims + new_scalars),
             convention=self.name, log=var.log

--- a/src/varlist_util.py
+++ b/src/varlist_util.py
@@ -558,7 +558,7 @@ class Varlist(data_model.DMDataSet):
             )
         v.dest_path = self.variable_dest_path(model_paths, case_name, v)
         try:
-            trans_v = translate.translate(v, from_convention, to_convention)
+            trans_v = translate.translate(v, from_convention)
             assert trans_v is not None, f'translation for varlistentry {v.name} failed'
             v.translation = trans_v
             # copy preferred gfdl post-processing component during translation

--- a/src/varlist_util.py
+++ b/src/varlist_util.py
@@ -538,10 +538,11 @@ class Varlist(data_model.DMDataSet):
         available after DataManager and Diagnostic have been configured (ie,
         only known at runtime, not from settings.jsonc.)
 
-        Could arguably be moved into VarlistEntry's init, at the cost of
-        dependency inversion.
         """
-        # Note: VariableTranslator object is instantiated in mdtf_framework with runtime information
+        # Note: VariableTranslator object is instantiated in mdtf_framework with runtime information from the POD
+        # settings file
+
+        # instantiate a translation object for the Data convention
         translate = translation.VariableTranslator().get_convention(to_convention)
         if v.T is not None:
             v.change_coord(
@@ -557,7 +558,7 @@ class Varlist(data_model.DMDataSet):
             )
         v.dest_path = self.variable_dest_path(model_paths, case_name, v)
         try:
-            trans_v = translate.translate(v, from_convention)
+            trans_v = translate.translate(v, from_convention, to_convention)
             assert trans_v is not None, f'translation for varlistentry {v.name} failed'
             v.translation = trans_v
             # copy preferred gfdl post-processing component during translation


### PR DESCRIPTION
**Description**
* fix attribute refs in varlistentry translator setup
* update parameter names in precipratetoflux edit_request
* update xarray dataset standard_name attribute after precip units conversion is applied
* add precip variables list to cross reference when querying the lookup table of convention to use for the translation

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.11 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
