### PR TITLE
add documentation to serve as a reference to MDTF output

### DIFF
--- a/doc/sphinx/ref_output.rst
+++ b/doc/sphinx/ref_output.rst
@@ -3,11 +3,11 @@
 
 Output Reference
 ===============================
-After a run of the MDTF framework is completed, the output can be found in the 
-output/work directory that is indicated in the :code-rst:`runtime_config.jsonc` file that is
-passed as a command-line argument. The default setting is normally :code-rst:`"../wkdir".` 
-In this section, we will take a look into such an output directory and explain 
-the structure as well as the files within.
+Processed data, ESM-intake catalogs, POD output, and logs from the MDTF-framework run are stored in a directory called 
+:code-rst:`MDTF_output` that is appended to the :code-rst:`OUTPUT_DIR` (defaults to :code-rst:`WORK_DIR` if 
+:code-rst:`OUTPUT_DIR` is not set) specified in the runtime configuration file. Each new run will generate an output 
+directory with _v# appended to the code-rst:`MDTF_output` base name if the :code-rst:`OUTPUT_DIR` contains directories 
+from prior framework runs.
 
 Example Directory
 -------------------------------
@@ -20,20 +20,25 @@ with the run in our :code-rst:`wkdir`. The resulting tree should look like this:
       ── MDTF_output/
           ├── CMIP_Synthetic_r1i1p1f1_gr1_19800101-19841231.log
           ├── CMIP_Synthetic_r1i1p1f1_gr1_19850101-19891231.log
+          ├── config_save.json
           ├── example_multicase/
+          ├── example_multicase.data.log
+          ├── index.html
           ├── MDTF_CMIP_Synthetic_r1i1p1f1_gr1_19800101-19841231/
           ├── MDTF_CMIP_Synthetic_r1i1p1f1_gr1_19850101-19891231/
-          ├── MDTF_main.2024-07-26:16.28.21.log
+          ├── mdtf_diag_banner.png
+          ├── MDTF_main.2024-07-29:17.13.28.log
           ├── MDTF_postprocessed_data.csv
           └── MDTF_postprocessed_data.json
 
 To explain the contents within:
-   * :code-rst:`MDTF_postprocessed_data.csv` and :code-rst:`MDTF_postprocessed_data.json` are two of the most
-     important files in this folder as far as the POD is concerned as these file correspond to the intake-ESM catalog 
-     generated for the data processed by the framework.
-   * The catalog points towards data that can be found in the folders :code-rst:`MDTF_CMIP_Synthetic_*`.
+   * :code-rst:`index.html` is the html page used to consolidate the MDTF run for the end-user. 
+     This serves as the main way to view all related plots and information for all PODs ran in a nice, condensed manner.
+   * :code-rst:`MDTF_postprocessed_data.csv` and :code-rst:`MDTF_postprocessed_data.json` are the ESM-intake catalog 
+     csv and json header files with information about the processed model data.
+   * The catalog points towards data that can be found in the folders :code-rst:`MDTF_CMIP_Synthetic_*`
    * The rest of the files serve as a method of logging information about what the framework did and various issues that
-     might have arised. Information inside these files could greatly help both POD developers and the framework 
+     might have occured. Information inside these files could greatly help both POD developers and the framework 
      development team!
 
 POD Output Directory
@@ -45,20 +50,17 @@ This directory, :code-rst:`example_multicase`, contains all of the output for th
 
       ── example_multicase/
           ├── case_info.yml
-          ├── config_save.json
           ├── example_multicase.data.log
           ├── example_multicase.html
           ├── example_multicase.log
           ├── index.html
-          ├── mdtf_diag_banner.png
           ├── model/
           └── obs/
 
 These files and folders being:
-   * :code-rst:`case_info.yml` and :code-rst:`config_save.json` provide information about the cases ran for the POD.
+   * :code-rst:`example_multicase.html` serves as the landing page for the POD and can be easily reached from :code-rst:`index.html`.
+   * :code-rst:`case_info.yml` provides information about the cases ran for the POD.
    * :code-rst:`model/` and :code-rst:`obs/` contain both plots and data for both the model data and observation data respectively.
-   * :code-rst:`index.html` is the compiled html page for the POD run. This serves as the main way to view all related plots for this POD in a
-     nice, condensed manner.
    * There also exists various log files which function the same as mentioned previously.
 
-If multiple PODs were to be ran, you would find such a directory for each POD in the :code-rst:`MDTF_output` directory.
+If multiple PODs were run, you would find such a directory for each POD in the :code-rst:`MDTF_output` directory.

--- a/doc/sphinx/ref_output.rst
+++ b/doc/sphinx/ref_output.rst
@@ -4,7 +4,7 @@
 Output Reference
 ===============================
 After a run of the MDTF framework is completed, the output can be found in the 
-output/work directory that is indicated in the runtime_config.jsonc file that is
+output/work directory that is indicated in the :code-rst:`runtime_config.jsonc` file that is
 passed as a command-line argument. The default setting is normally :code-rst:`"../wkdir".` 
 In this section, we will take a look into such an output directory and explain 
 the structure as well as the files within.

--- a/doc/sphinx/ref_output.rst
+++ b/doc/sphinx/ref_output.rst
@@ -1,0 +1,64 @@
+.. role:: code-rst(code)
+   :language: reStructuredText
+
+Output Reference
+===============================
+After a run of the MDTF framework is completed, the output can be found in the 
+output/work directory that is indicated in the runtime_config.jsonc file that is
+passed as a command-line argument. The default setting is normally :code-rst:`"../wkdir".` 
+In this section, we will take a look into such an output directory and explain 
+the structure as well as the files within.
+
+Example Directory
+-------------------------------
+For an example, we will take a look at the output directory of a run of the :code-rst:`'example_multicase'` POD
+on some generated synthetic data. To do this, let's move into the :code-rst:`MDTF_output` directory associated 
+with the run in our :code-rst:`wkdir`. The resulting tree should look like this:
+
+   .. code-block:: none
+
+      ── MDTF_output/
+          ├── CMIP_Synthetic_r1i1p1f1_gr1_19800101-19841231.log
+          ├── CMIP_Synthetic_r1i1p1f1_gr1_19850101-19891231.log
+          ├── example_multicase/
+          ├── MDTF_CMIP_Synthetic_r1i1p1f1_gr1_19800101-19841231/
+          ├── MDTF_CMIP_Synthetic_r1i1p1f1_gr1_19850101-19891231/
+          ├── MDTF_main.2024-07-26:16.28.21.log
+          ├── MDTF_postprocessed_data.csv
+          └── MDTF_postprocessed_data.json
+
+To explain the contents within:
+   * :code-rst:`MDTF_postprocessed_data.csv` and :code-rst:`MDTF_postprocessed_data.json` are two of the most
+     important files in this folder as far as the POD is concerned as these file correspond to the intake-ESM catalog 
+     generated for the data processed by the framework.
+   * The catalog points towards data that can be found in the folders :code-rst:`MDTF_CMIP_Synthetic_*`
+   * The rest of the files serve as a method of logging information about what the framework did and various issues that
+     might have arised. Information inside these files could greatly help both POD developers and the framework 
+     development team!
+
+POD Output Directory
+-------------------------------
+As you probably noticed, there is one directory that was not mentioned in the prior list. 
+This directory, :code-rst:`example_multicase`, contains all of the output for the POD we ran. If we were to take a look inside, we would see:
+   
+   .. code-block:: none
+
+      ── example_multicase/
+          ├── case_info.yml
+          ├── config_save.json
+          ├── example_multicase.data.log
+          ├── example_multicase.html
+          ├── example_multicase.log
+          ├── index.html
+          ├── mdtf_diag_banner.png
+          ├── model/
+          └── obs/
+
+These files and folders being:
+   * :code-rst:`case_info.yml` and :code-rst:`config_save.json` provide information about the cases ran for the POD.
+   * :code-rst:`model/` and :code-rst:`obs/` contain both plots and data for both the model data and observation data respectively.
+   * :code-rst:`index.html` is the compiled html page for the POD run. This serves as the main way to view all related plots for this POD in
+     nice, condensed manner.
+   * There can also be found various log files which function the same as mentioned previously.
+
+If multiple PODs were to be ran, you would find such a directory for each POD in the :code-rst:`MDTF_output` directory.

--- a/doc/sphinx/ref_output.rst
+++ b/doc/sphinx/ref_output.rst
@@ -31,7 +31,7 @@ To explain the contents within:
    * :code-rst:`MDTF_postprocessed_data.csv` and :code-rst:`MDTF_postprocessed_data.json` are two of the most
      important files in this folder as far as the POD is concerned as these file correspond to the intake-ESM catalog 
      generated for the data processed by the framework.
-   * The catalog points towards data that can be found in the folders :code-rst:`MDTF_CMIP_Synthetic_*`
+   * The catalog points towards data that can be found in the folders :code-rst:`MDTF_CMIP_Synthetic_*`.
    * The rest of the files serve as a method of logging information about what the framework did and various issues that
      might have arised. Information inside these files could greatly help both POD developers and the framework 
      development team!
@@ -57,8 +57,8 @@ This directory, :code-rst:`example_multicase`, contains all of the output for th
 These files and folders being:
    * :code-rst:`case_info.yml` and :code-rst:`config_save.json` provide information about the cases ran for the POD.
    * :code-rst:`model/` and :code-rst:`obs/` contain both plots and data for both the model data and observation data respectively.
-   * :code-rst:`index.html` is the compiled html page for the POD run. This serves as the main way to view all related plots for this POD in
+   * :code-rst:`index.html` is the compiled html page for the POD run. This serves as the main way to view all related plots for this POD in a
      nice, condensed manner.
-   * There can also be found various log files which function the same as mentioned previously.
+   * There also exists various log files which function the same as mentioned previously.
 
 If multiple PODs were to be ran, you would find such a directory for each POD in the :code-rst:`MDTF_output` directory.

--- a/doc/sphinx/ref_toc.rst
+++ b/doc/sphinx/ref_toc.rst
@@ -8,4 +8,5 @@ Framework reference
    ref_conventions
    ref_data
    ref_envvars
+   ref_output
    ref_submodules


### PR DESCRIPTION
**Description**
Include a summary of the change, and link the associated issue (if applicable).  
List any dependencies that are required for this change, including libraries and variables,  
and their metadata (units, frequencies, etc...). Be sure to separate PRs and issues for new PODs and PODs currently under development.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
