### PR TITLE
Fix pod paths and util formatting

### DIFF
--- a/diagnostics/MJO_suite/mjo.ncl
+++ b/diagnostics/MJO_suite/mjo.ncl
@@ -65,7 +65,7 @@ do n = 50,nfil-51
 end do
 
 ; MAKE PLOTS
-psplot = getenv("WK_DIR")+"/model/PS/"+casename+".MJO"
+psplot = getenv("WORK_DIR")+"/model/PS/"+casename+".MJO"
 wks = gsn_open_wks("ps",psplot)
 plot = new(3,graphic)
 res = True

--- a/diagnostics/MJO_suite/mjo_spectra.ncl
+++ b/diagnostics/MJO_suite/mjo_spectra.ncl
@@ -37,7 +37,7 @@ filename_v850 = file_dir+casename+".v850.day.anom.nc"
 ;  fili   = "uwnd.day.850.anomalies.1980-2005.nc"
 ;  f      = addfile(diri+fili, "r")  
 
-  pltDir  = getenv("WORK_DIR")+"/model/PS"
+  pltDir  = getenv("WORK_DIR")+"/model/PS/"
   pltType = "ps"
   
 

--- a/diagnostics/precip_diurnal_cycle/pr_diurnal_phase.ncl
+++ b/diagnostics/precip_diurnal_cycle/pr_diurnal_phase.ncl
@@ -218,8 +218,8 @@ ps_name = ps_name0+"_pr."+region_plot+".dc."
 ;      end if
 ;      print(ps_dir+ps_name+sprinti("%0.4i",min(mrun_years))+"."+season+tphase)
             
-       wks1 = gsn_open_wks("ps",ps_dir+"/"+ps_name1+season)
-       wks2 = gsn_open_wks("ps",ps_dir+"/"+ps_name2+season)
+       wks1 = gsn_open_wks("ps",ps_dir+ps_name1+season)
+       wks2 = gsn_open_wks("ps",ps_dir+ps_name2+season)
 
       nmonths = dimsizes(months)
       nyears = dimsizes(mrun_years)

--- a/diagnostics/precip_diurnal_cycle/precip_diurnal_cycle.py
+++ b/diagnostics/precip_diurnal_cycle/precip_diurnal_cycle.py
@@ -34,11 +34,11 @@ def generate_ncl_plots(nclPlotFile):
     nclPlotFile (string) - full path to ncl plotting file name
     """
     # check if the nclPlotFile exists - 
-    # don't exit if it does not exists just print a warning.
+    # don't exit if it does not exist, just print a warning.
     try:
         pipe = subprocess.Popen(['ncl {0}'.format(nclPlotFile)], shell=True, stdout=subprocess.PIPE)
         output = pipe.communicate()[0].decode()
-        print('NCL routine {0} \n {1}'.format(nclPlotFile,output))            
+        print('NCL routine {0} \n {1}'.format(nclPlotFile, output))
         while pipe.poll() is None:
             time.sleep(0.5)
     except OSError as e:

--- a/src/util/datelabel.py
+++ b/src/util/datelabel.py
@@ -1110,8 +1110,8 @@ with no time dependence.
 class DateFrequency(datetime.timedelta):
     """Class representing a frequency or time period.
 
-    .. warning::
-       Period lengths are *not* defined accurately, eg. a year is taken as
+    . warning::
+       Period lengths are *not* defined accurately; e.g., a year is taken as
        365 days and a month is taken as 30 days. For this reason, we do not
        implement addition and subtraction of DateFrequency objects to Dates,
        as is possible for :py:class:`~datetime.timedelta` and


### PR DESCRIPTION


**Description**
* fix path defs in precip_diurnal_cycle and MJO_suite ncl scripts
* fix formatting in precip_diurnal_cycle driver script fix formatting in datelabel comments
Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
