### PR TITLE
fix typo in ref_output.rst

### DIFF
--- a/doc/sphinx/ref_output.rst
+++ b/doc/sphinx/ref_output.rst
@@ -6,7 +6,7 @@ Output Reference
 Processed data, ESM-intake catalogs, POD output, and logs from the MDTF-framework run are stored in a directory called 
 :code-rst:`MDTF_output` that is appended to the :code-rst:`OUTPUT_DIR` (defaults to :code-rst:`WORK_DIR` if 
 :code-rst:`OUTPUT_DIR` is not set) specified in the runtime configuration file. Each new run will generate an output 
-directory with _v# appended to the code-rst:`MDTF_output` base name if the :code-rst:`OUTPUT_DIR` contains directories 
+directory with _v# appended to the :code-rst:`MDTF_output` base name if the :code-rst:`OUTPUT_DIR` contains directories 
 from prior framework runs.
 
 Example Directory


### PR DESCRIPTION
**Description**
Include a summary of the change, and link the associated issue (if applicable).  
List any dependencies that are required for this change, including libraries and variables,  
and their metadata (units, frequencies, etc...). Be sure to separate PRs and issues for new PODs and PODs currently under development.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [ ] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [ ] The repository contains no extra test scripts or data files
