### PR TITLE
Fix cat templates

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -977,10 +977,8 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                     progressbar=False,
                     xarray_open_kwargs=self.open_dataset_kwargs
                 )
-                # check for time_range or date_range
+
                 range_attr_string = 'intake_esm_attrs:time_range'
-                if not hasattr(cat_subset_df[list(cat_subset_df)[0]].attrs, range_attr_string):
-                    range_attr_string = 'intake_esm_attrs:date_range'
                 date_range_dict = {f: cat_subset_df[f].attrs[range_attr_string]
                                    for f in list(cat_subset_df)}
                 date_range_dict = dict(sorted(date_range_dict.items(), key=lambda item: item[1]))

--- a/src/util/catalog.py
+++ b/src/util/catalog.py
@@ -99,11 +99,6 @@ def define_pp_catalog_assets(config, cat_file_name: str) -> dict:
                 "type": "union",
                 "attribute_name": "variable_id",
                 "options": {}
-            },
-            {
-                "type": "join_existing",
-                "attribute_name": "time_range",
-                "options": {"dim": "time", "coords": "minimal", "compat": "override"}
             }
         ]
     }

--- a/tools/catalog_builder/catalog_builder.py
+++ b/tools/catalog_builder/catalog_builder.py
@@ -307,11 +307,7 @@ class CatalogBase(object):
         ]  # attributes to group by when reading
         # in variables using intake-esm
         self.xarray_aggregations = [
-            {'type': 'union', 'attribute_name': 'variable_id'},
-            {'type': 'join_existing',
-             'attribute_name': 'time_range',
-             'options': {'dim': 'time', 'coords': 'minimal', 'compat': 'override'}
-            }
+            {'type': 'union', 'attribute_name': 'variable_id'}
         ]
         self.data_format = "netcdf" # netcdf or zarr
         self.variable_col_name = "variable_id"


### PR DESCRIPTION
**Description**
remove time_range from catalog aggregation_control template column
remove time_range debugging check from preprocessor 
Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Rhel 8, MacOS Sierra, Python 3.12

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
