### PR TITLE
no more time_range in groupby_attrs templates

### DIFF
--- a/diagnostics/example_multicase/esm_catalog_CMIP_synthetic_r1i1p1f1_gr1.json
+++ b/diagnostics/example_multicase/esm_catalog_CMIP_synthetic_r1i1p1f1_gr1.json
@@ -163,23 +163,13 @@
       "table_id",
       "grid_label",
       "realm",
-      "variant_label",
-      "time_range"
+      "variant_label"
     ],
     "aggregations": [
       {
         "type": "union",
         "attribute_name": "variable_id",
         "options": {}
-      },
-      {
-        "type": "join_existing",
-        "attribute_name": "time_range",
-        "options": {
-          "dim": "time",
-          "coords": "minimal",
-          "compat": "override"
-        }
       }
     ]
   },

--- a/src/util/catalog.py
+++ b/src/util/catalog.py
@@ -91,8 +91,7 @@ def define_pp_catalog_assets(config, cat_file_name: str) -> dict:
             "grid_label",
             "realm",
             "chunk_freq",
-            "variant_label",
-            "time_range"
+            "variant_label"
         ],
         "aggregations": [
             {

--- a/tools/catalog_builder/catalog_builder.py
+++ b/tools/catalog_builder/catalog_builder.py
@@ -302,8 +302,7 @@ class CatalogBase(object):
             'table_id',
             'grid_label',
             'realm',
-            'variant_label',
-            'time_range'
+            'variant_label'
         ]  # attributes to group by when reading
         # in variables using intake-esm
         self.xarray_aggregations = [


### PR DESCRIPTION


**Description**
remove time_range from groupby_attrs in catalog_builder, example json, and util/catalog.py

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Macos Sierra, Python 3.12
**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
