### PR TITLE
add logic to handle unexpected type in check_group_daterange

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -939,7 +939,6 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                              var.translation.name,
                              case_name)
                 cat_subset = cat.search(**case_d.query)
-                print(case_d.query)
                 if cat_subset.df.empty:
                     # check whether there is an alternate variable to substitute
                     if any(var.alternates):

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -856,14 +856,16 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             # throw out df entries not in date_range
             for i in sorted_df.index:
                 cat_row = sorted_df.iloc[i]
-                stin = dl.Date(cat_row['start_time']) in case_dr
-                etin = dl.Date(cat_row['end_time']) in case_dr
+                if pd.isnull(cat_row['start_time']):
+                    continue 
+                else:
+                    stin = dl.Date(cat_row['start_time']) in case_dr
+                    etin = dl.Date(cat_row['end_time']) in case_dr
                 if (not stin and not etin) or (stin and not etin):
                     mask = sorted_df == cat_row['start_time']
                     sorted_df = sorted_df[~mask]
             mask = np.isnat(sorted_df['start_time']) | np.isnat(sorted_df['end_time'])     
             sorted_df = sorted_df[~mask]
-
             return sorted_df
         except ValueError:
             log.error("Non-contiguous or malformed date range in files:", group_df["path"].values)
@@ -937,6 +939,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                              var.translation.name,
                              case_name)
                 cat_subset = cat.search(**case_d.query)
+                print(case_d.query)
                 if cat_subset.df.empty:
                     # check whether there is an alternate variable to substitute
                     if any(var.alternates):


### PR DESCRIPTION
**Description**
Include a summary of the change, and link the associated issue (if applicable).  
List any dependencies that are required for this change, including libraries and variables,  
and their metadata (units, frequencies, etc...). Be sure to separate PRs and issues for new PODs and PODs currently under development.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
