### PR TITLE
add function to verify that conda dirs exists after parsing config file

### DIFF
--- a/mdtf_framework.py
+++ b/mdtf_framework.py
@@ -124,7 +124,7 @@ def main(ctx, configfile: str, verbose: bool = False) -> int:
     ctx.config = util.NameSpace()
     # parse the runtime config file
     ctx.config = cli.parse_config_file(configfile)
-    ctx.config = cli.verify_conda_envs(ctx.config)
+    ctx.config = cli.verify_conda_envs(ctx.config, configfile)
     # Test ctx.config
     # print(ctx.config.WORK_DIR)
     ctx.config.CODE_ROOT = os.path.dirname(os.path.realpath(__file__))

--- a/mdtf_framework.py
+++ b/mdtf_framework.py
@@ -124,6 +124,7 @@ def main(ctx, configfile: str, verbose: bool = False) -> int:
     ctx.config = util.NameSpace()
     # parse the runtime config file
     ctx.config = cli.parse_config_file(configfile)
+    ctx.config = cli.verify_conda_envs(ctx.config)
     # Test ctx.config
     # print(ctx.config.WORK_DIR)
     ctx.config.CODE_ROOT = os.path.dirname(os.path.realpath(__file__))

--- a/src/cli.py
+++ b/src/cli.py
@@ -171,17 +171,12 @@ def verify_conda_envs(config: util.NameSpace, filename: str):
             f"Could not find conda or micromamba executable; please check the runtime config file: "
             f'{filename}'
         ) 
-    if c_exists and config['conda_env_root'] == '':
+    if c_exists and not cenv_exists:
         new_env_root = os.path.join(config['conda_root'], "envs")
         if os.path.exists(new_env_root):
             config.update({'conda_env_root':new_env_root})
         else:
             raise util.exceptions.MDTFBaseException(
-                f"Count not find conda enviroment directory; please check the runtime config file: "
-                f'{filename}'
-            )
-    elif not cenv_exists and config['conda_env_root'] != '':
-        raise util.exceptions.MDTFBaseException(
                 f"Count not find conda enviroment directory; please check the runtime config file: "
                 f'{filename}'
             )

--- a/src/cli.py
+++ b/src/cli.py
@@ -162,12 +162,14 @@ def verify_runtime_config_options(config: util.NameSpace):
         update_config(config, 'OUTPUT_DIR', new_output_dir)
     verify_case_atts(config.case_list)
 
-def verify_conda_envs(config: util.NameSpace):
+def verify_conda_envs(config: util.NameSpace, filename: str):
     m_exists = os.path.exists(config['micromamba_exe'])
     c_exists = os.path.exists(config['conda_root'])
+    cenv_exists = os.path.exists(config['conda_env_root'])
     if not m_exists and not c_exists:
         raise util.exceptions.MDTFBaseException(
-            f"Could not find conda or micromamba executable; please check the runtime config file"
+            f"Could not find conda or micromamba executable; please check the runtime config file: "
+            f'{filename}'
         ) 
     if c_exists and config['conda_env_root'] == '':
         new_env_root = os.path.join(config['conda_root'], "envs")
@@ -175,7 +177,14 @@ def verify_conda_envs(config: util.NameSpace):
             config.update({'conda_env_root':new_env_root})
         else:
             raise util.exceptions.MDTFBaseException(
-                f"Count not find conda enviroment directory; please check the runtime config file"
+                f"Count not find conda enviroment directory; please check the runtime config file: "
+                f'{filename}'
             )
+    elif not cenv_exists and config['conda_env_root'] != '':
+        raise util.exceptions.MDTFBaseException(
+                f"Count not find conda enviroment directory; please check the runtime config file: "
+                f'{filename}'
+            )
+
     return config
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -161,3 +161,21 @@ def verify_runtime_config_options(config: util.NameSpace):
         new_output_dir = verify_dirpath(config.OUTPUT_DIR, config.CODE_ROOT)
         update_config(config, 'OUTPUT_DIR', new_output_dir)
     verify_case_atts(config.case_list)
+
+def verify_conda_envs(config: util.NameSpace):
+    m_exists = os.path.exists(config['micromamba_exe'])
+    c_exists = os.path.exists(config['conda_root'])
+    if not m_exists and not c_exists:
+        raise util.exceptions.MDTFBaseException(
+            f"Could not find conda or micromamba executable; please check the runtime config file"
+        ) 
+    if c_exists and config['conda_env_root'] == '':
+        new_env_root = os.path.join(config['conda_root'], "envs")
+        if os.path.exists(new_env_root):
+            config.update({'conda_env_root':new_env_root})
+        else:
+            raise util.exceptions.MDTFBaseException(
+                f"Count not find conda enviroment directory; please check the runtime config file"
+            )
+    return config
+


### PR DESCRIPTION
**Description**
Include a summary of the change, and link the associated issue (if applicable).  
List any dependencies that are required for this change, including libraries and variables,  
and their metadata (units, frequencies, etc...). Be sure to separate PRs and issues for new PODs and PODs currently under development.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
