### PR TITLE
rework check_group_daterange to work with data starting at year 0001

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -795,10 +795,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         poss_digits = [6,8,10,12,14]
         for i in range(len(time_vals)):
             if isinstance(time_vals[i], str):
-                if '-' in time_vals[i]:
-                    time_vals[i] = time_vals[i].replace('-', '')
-                if ':' in time_vals[i]:
-                    time_vals[i] = time_vals[i].replace(':', '')
+                time_vals[i] = time_vals[i].replace('-', '').replace(':', '')
                 while len(time_vals[i]) not in poss_digits:
                     time_vals[i] = '0' + time_vals[i]
         return time_vals

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -787,6 +787,24 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 var.log.error(err_str)
                 raise IndexError(err_str)
 
+    def normalize_group_time_vals(self, time_vals: np.ndarray) -> np.ndarray:
+        """Apply logic to fomat time_vals lists found in 
+        check_grouo_daterange and convert them into str type.
+        This function also handles missing leading zeros
+        """
+        poss_digits = [6,8,10,12,14]
+        for i in range(len(time_vals)):
+            if isinstance(time_vals[i], str):
+                if '-' in time_vals[i]:
+                    time_vals[i] = time_vals[i].replace('-', '')
+                if ':' in time_vals[i]:
+                    time_vals[i] = time_vals[i].replace(':', '')
+            elif isinstance(time_vals[i], int):
+                time_vals[i] = str(time_vals[i])
+                while len(time_vals[i]) not in poss_digits:
+                    time_vals[i] = '0' + time_vals[i]
+        return time_vals
+            
     def check_group_daterange(self, group_df: pd.DataFrame, case_dr,
                               log=_log) -> pd.DataFrame:
         """Sort the files found for each experiment by date, verify that
@@ -812,30 +830,14 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             else:
                 raise AttributeError('Data catalog is missing attributes `start_time` and/or `end_time` and can not infer from `time_range`')
         try:
-            start_time_vals = group_df['start_time'].values
-            end_time_vals = group_df['end_time'].values
+            start_time_vals = self.normalize_group_time_vals(group_df['start_time'].values)
+            end_time_vals = self.normalize_group_time_vals(group_df['end_time'].values)
             if not isinstance(start_time_vals[0], datetime.date):
-                # convert string values to ints
-                if isinstance(start_time_vals[0], str):
-                    new_start_time_vals = []
-                    new_end_time_vals = []
-
-                    for s in start_time_vals:
-                        new_start_time_vals.append(int(''.join(w for w in re.split("[" + "\\".join(delimiters) + "]",
-                                                                                   s)
-                                                               if w)))
-                    for e in end_time_vals:
-                        new_end_time_vals.append(int(''.join(w for w in re.split("[" + "\\".join(delimiters) + "]",
-                                                                                 e)
-                                                     if w)))
-
-                    start_time_vals = new_start_time_vals
-                    end_time_vals = new_end_time_vals
                 date_format = dl.date_fmt(start_time_vals[0])
                 # convert start_times to date_format for all files in query
-                group_df['start_time'] = pd.to_datetime(start_time_vals, format=date_format)
+                group_df['start_time'] = group_df['start_time'].apply(lambda x: datetime.datetime.strptime(str(x), date_format))
                 # convert end_times to date_format for all files in query
-                group_df['end_time'] = pd.to_datetime(end_time_vals, format=date_format)
+                group_df['end_time'] = group_df['end_time'].apply(lambda x: datetime.datetime.strptime(str(x), date_format))
             # method throws ValueError if ranges aren't contiguous
             dates_df = group_df.loc[:, ['start_time', 'end_time']]
             date_range_vals = []
@@ -852,21 +854,21 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             # throws AssertionError if we don't span the query range
             # TODO: define self.attrs.DateRange from runtime config info
             # assert files_date_range.contains(self.attrs.date_range)
-
             # throw out df entries not in date_range
+            return_df = []
             for i in sorted_df.index:
                 cat_row = sorted_df.iloc[i]
                 if pd.isnull(cat_row['start_time']):
                     continue 
                 else:
-                    stin = dl.Date(cat_row['start_time']) in case_dr
-                    etin = dl.Date(cat_row['end_time']) in case_dr
-                if (not stin and not etin) or (stin and not etin):
-                    mask = sorted_df == cat_row['start_time']
-                    sorted_df = sorted_df[~mask]
-            mask = np.isnat(sorted_df['start_time']) | np.isnat(sorted_df['end_time'])     
-            sorted_df = sorted_df[~mask]
-            return sorted_df
+                    st = dl.dt_to_str(cat_row['start_time'])
+                    et = dl.dt_to_str(cat_row['end_time'])
+                    stin = dl.Date(st) in case_dr
+                    etin = dl.Date(et) in case_dr
+                if stin and etin:
+                    return_df.append(cat_row.to_dict())
+            
+            return pd.DataFrame.from_dict(return_df)
         except ValueError:
             log.error("Non-contiguous or malformed date range in files:", group_df["path"].values)
         except AssertionError:
@@ -928,7 +930,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 case_d.query['path'] = [path_regex]
                 case_d.query['realm'] = realm_regex
                 case_d.query['standard_name'] = var.translation.standard_name
-
+                
                 # change realm key name if necessary
                 if cat.df.get('modeling_realm', None) is not None:
                     case_d.query['modeling_realm'] = case_d.query.pop('realm')

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -799,8 +799,6 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                     time_vals[i] = time_vals[i].replace('-', '')
                 if ':' in time_vals[i]:
                     time_vals[i] = time_vals[i].replace(':', '')
-            elif isinstance(time_vals[i], int):
-                time_vals[i] = str(time_vals[i])
                 while len(time_vals[i]) not in poss_digits:
                     time_vals[i] = '0' + time_vals[i]
         return time_vals
@@ -830,14 +828,16 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             else:
                 raise AttributeError('Data catalog is missing attributes `start_time` and/or `end_time` and can not infer from `time_range`')
         try:
-            start_time_vals = self.normalize_group_time_vals(group_df['start_time'].values)
-            end_time_vals = self.normalize_group_time_vals(group_df['end_time'].values)
+            start_time_vals = self.normalize_group_time_vals(group_df['start_time'].values.astype(str))
+            end_time_vals = self.normalize_group_time_vals(group_df['end_time'].values.astype(str))
             if not isinstance(start_time_vals[0], datetime.date):
                 date_format = dl.date_fmt(start_time_vals[0])
                 # convert start_times to date_format for all files in query
-                group_df['start_time'] = group_df['start_time'].apply(lambda x: datetime.datetime.strptime(str(x), date_format))
+                group_df['start_time'] = start_time_vals
+                group_df['start_time'] = group_df['start_time'].apply(lambda x: datetime.datetime.strptime(x, date_format))
                 # convert end_times to date_format for all files in query
-                group_df['end_time'] = group_df['end_time'].apply(lambda x: datetime.datetime.strptime(str(x), date_format))
+                group_df['end_time'] = end_time_vals
+                group_df['end_time'] = group_df['end_time'].apply(lambda x: datetime.datetime.strptime(x, date_format))
             # method throws ValueError if ranges aren't contiguous
             dates_df = group_df.loc[:, ['start_time', 'end_time']]
             date_range_vals = []

--- a/src/util/datelabel.py
+++ b/src/util/datelabel.py
@@ -54,13 +54,10 @@ import logging
 
 _log = logging.getLogger(__name__)
 
-
 # match-case statement to give date format
 # input can be int or str
-def date_fmt(date):
-    if isinstance(date, str):
-        date = int(date)
-    date_digits = math.floor(math.log10(date)) + 1
+def date_fmt(date: str):
+    date_digits = len(date)
     match date_digits:
         case 6:
             fmt = '%Y%m'
@@ -74,9 +71,7 @@ def date_fmt(date):
             fmt = '%Y%m%d%H%M%S'
     return fmt
 
-
 # convert a string to a cftime object
-
 def str_to_cftime(time_str: str, fmt=None, calendar=None):
     if fmt is None:
         fmt = date_fmt(time_str)
@@ -91,13 +86,20 @@ def str_to_cftime(time_str: str, fmt=None, calendar=None):
     )
     return cf_date
 
-
 # convert cftime.Datetime to a string
 def cftime_to_str(cf_time: cftime.datetime, fmt=None):
     if fmt is None:
         fmt = '%Y%m%d-%H:%M:%S'
     return cf_time.strftime(fmt)
 
+# convert datetime.datetime to a str for in DateRange operation (year and month only)
+def dt_to_str(dt: datetime.datetime):
+    year = str(dt.year)
+    year = "".join(["0"] * (4 - len(year))) + year
+    month = str(dt.month)
+    month = "".join(["0"] * (2 - len(month))) + month
+    
+    return f'{year}{month}'
 
 # ===============================================================
 # following adapted from Alexandre Decan's python-intervals


### PR DESCRIPTION
**Description**
Include a summary of the change, and link the associated issue (if applicable).  
List any dependencies that are required for this change, including libraries and variables,  
and their metadata (units, frequencies, etc...). Be sure to separate PRs and issues for new PODs and PODs currently under development.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
