### PR TITLE
Iss 677

### DIFF
--- a/data/fieldlist_GFDL.jsonc
+++ b/data/fieldlist_GFDL.jsonc
@@ -20,15 +20,15 @@
       "standard_name": "latitude",
       "units": "degrees_north"
     },
-    "yh": {
+    "xq": {
       "axis": "Y",
-      "standard_name": "h_point_nominal_longitude",
+      "standard_name": "q_point_nominal_latitude",
       "long_name": "h point nominal latitude",
       "units": "degrees_north"
     },
-    "xq": {
+    "xh": {
       "axis": "X",
-      "standard_name": "x_point_nominal_latitude",
+      "standard_name": "h_point_nominal_latitude",
       "long_name": "x point nominal latitude",
       "units": "degrees_north"
     },
@@ -96,8 +96,8 @@
     }
   },
   "variables" : {
-    "$ref": "./gfdl-cmor-tables/gfdl_to_cmip6_vars.json",
-    "$ref": "./gfdl-cmor-tables/gfdl_to_cmip5_vars.json",
+    //"$ref": "./gfdl-cmor-tables/gfdl_to_cmip6_vars.json",
+    //"$ref": "./gfdl-cmor-tables/gfdl_to_cmip5_vars.json",
 
     "areacello": {
       "standard_name": "cell_area",

--- a/src/xr_parser.py
+++ b/src/xr_parser.py
@@ -899,12 +899,12 @@ class DefaultDatasetParser:
             # try searching for 4-D field instead of variable name for a specific level
             # (e.g., U instead of U500)
             else:
+                ds_names = []
                 tv_name = ds_var_name
                 if len(our_var.scalar_coords) > 0:
-                    ds_var_name = ''.join(filter(lambda x: not x.isdigit(), tv_name))
+                   ds_names.append(''.join(filter(lambda x: not x.isdigit(), tv_name)))
                 else:
                     # attempt to match on standard_name attribute if present in data
-                    ds_names = []
                     for v in ds.variables:
                         if hasattr(v, 'name') and ds.variables[v].attrs.get('standard_name', "") == our_var.standard_name:
                             ds_names.append(ds.variables[v].name)


### PR DESCRIPTION
**Description**
* add variable_id back to catalog query
* refine fieldlist lookup table search for 4D field base names only to ensure unique entries for standard_name are returned. The variable_id for a single level is then inferred from the scalar_coords attribute in the pod settings file as before.
* fix definition of ds_names list in xr_parser reconcile_names
* fix bad entries in GFDL field table
* comment out $refs in gfdl field table variables block as current configuration does not handle multiple json $refs in a single block
* Note that the Wheeler-Kiladis POD will not run with the test catalog linked in the associated issue because several standard_name entries are missing for variables--in particular ua200.
Associated issue #677 

**How Has This Been Tested?**
RHEL 8 with EOF500 hPa POD 1980-1990

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
