### PR TITLE
add check for correct config file path to framework driver

### DIFF
--- a/mdtf_framework.py
+++ b/mdtf_framework.py
@@ -118,7 +118,7 @@ def main(ctx, configfile: str, verbose: bool = False) -> int:
 
     # Cache log info in memory until log file is set up
     util.logs.initial_log_config()
-
+    assert os.path.isfile(configfile), f'Configuration file {configfile} not found. Check that file path for typos.'
     # print(f"=== Starting {os.path.realpath(__file__)}\n")
     # NameSpace allows dictionary keys to be referenced with dot notation
     ctx.config = util.NameSpace()
@@ -142,7 +142,6 @@ def main(ctx, configfile: str, verbose: bool = False) -> int:
     ctx.config.update({'OUTPUT_DIR': model_paths.OUTPUT_DIR})
     cat_path = ctx.config.DATA_CATALOG
     ctx.config.update({'DATA_CATALOG': util.filesystem.resolve_path(cat_path)})
-    # TODO: update paths in ctx.config so that POD paths are placed in the correct sub-directories
     backup_config = backup_config(ctx.config)
     ctx.config._configs = dict()
     ctx.config._configs[backup_config.name] = backup_config

--- a/mdtf_framework.py
+++ b/mdtf_framework.py
@@ -118,7 +118,7 @@ def main(ctx, configfile: str, verbose: bool = False) -> int:
 
     # Cache log info in memory until log file is set up
     util.logs.initial_log_config()
-    assert os.path.isfile(configfile), f'Configuration file {configfile} not found. Check that file path for typos.'
+    assert os.path.isfile(configfile), f'Configuration file {configfile} not found. Check the file path for typos.'
     # print(f"=== Starting {os.path.realpath(__file__)}\n")
     # NameSpace allows dictionary keys to be referenced with dot notation
     ctx.config = util.NameSpace()


### PR DESCRIPTION
**Description**
Include a summary of the change, and link the associated issue (if applicable).  
List any dependencies that are required for this change, including libraries and variables,  
and their metadata (units, frequencies, etc...). Be sure to separate PRs and issues for new PODs and PODs currently under development.

Associated issue #676 

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
