### PR TITLE
move global realm setting to pod data section

### DIFF
--- a/diagnostics/SM_ET_coupling/settings.jsonc
+++ b/diagnostics/SM_ET_coupling/settings.jsonc
@@ -8,7 +8,6 @@
   "settings" : {
     "driver" : "SM_ET_coupling.py",
     "long_name" : "Coupling between Soil Moisture and EvapoTranspiration",
-    "realm" : ["atmos", "land"],
     "convention" : "cmip",
     "description" : "Coupling of Soil Moisture with Evapotranspiration",
     "runtime_requirements": {

--- a/diagnostics/forcing_feedback/settings.jsonc
+++ b/diagnostics/forcing_feedback/settings.jsonc
@@ -3,7 +3,6 @@
     "driver" : "forcing_feedback.py",
     "long_name" : "Radiative Forcing and Feedback Diagnostics",
     "convention" : "cmip",
-    "realm" : "atmos",
     "runtime_requirements": {
       "python3": ["os", "numpy", "xarray", "pandas", "netCDF4", "scipy", "matplotlib", "cartopy"]
     },
@@ -21,7 +20,8 @@
     "min_frequency": "mon",
     "max_frequency": "mon",
     "min_duration": "5yr",
-    "max_duration": "any"
+    "max_duration": "any",
+    "realm" : "atmos",
   },
    "dimensions": {
     "lat": {

--- a/diagnostics/stc_eddy_heat_fluxes/settings.jsonc
+++ b/diagnostics/stc_eddy_heat_fluxes/settings.jsonc
@@ -28,7 +28,7 @@
     }
   },
   "data": {
-    "realm" : "atmos",
+    "realm" : "atmos"
   },
 
   "dimensions": {

--- a/diagnostics/stc_eddy_heat_fluxes/settings.jsonc
+++ b/diagnostics/stc_eddy_heat_fluxes/settings.jsonc
@@ -8,7 +8,6 @@
   "settings" : {
     "driver" : "stc_eddy_heat_fluxes.py",
     "long_name" : "Upward Coupling of Vertically Propagating Planetary Waves",
-    "realm" : "atmos",
     "convention" : "cmip",
     "description" : "Assess the influence of wave driving on the polar stratosphere",
     "pod_env_vars" : {
@@ -28,6 +27,10 @@
       "python3": ["matplotlib", "numpy", "pandas", "xarray", "xesmf"]
     }
   },
+  "data": {
+    "realm" : "atmos",
+  },
+
   "dimensions": {
     "lat": {
              "standard_name": "latitude",

--- a/diagnostics/stc_qbo_enso/settings.jsonc
+++ b/diagnostics/stc_qbo_enso/settings.jsonc
@@ -8,7 +8,6 @@
   "settings" : {
     "driver" : "stc_qbo_enso.py",
     "long_name" : "Metrics of QBO and extratropical circulation impact of QBO and ENSO",
-    "realm" : ["atmos", "ocean"],
     "description" : "Assess the representation of the QBO",
     "pod_env_vars" : {
       // Isobar (hPa) used to define the QBO in the tropical stratosphere
@@ -37,6 +36,7 @@
     "tos": {
       "standard_name" : "sea_surface_temperature",
       "units" : "degC",
+      "realm": "ocean",
       "frequency": "mon",
       "dimensions": ["time", "lat", "lon"],
       "requirement": "required"
@@ -45,6 +45,7 @@
       "standard_name" : "eastward_wind",
       "units" : "m s-1",
       "frequency": "mon",
+      "realm": "atmos",
       "dimensions": ["time", "lev", "lat", "lon"],
       "requirement": "required"
     },
@@ -52,12 +53,14 @@
       "standard_name" : "northward_wind",
       "units" : "m s-1",
       "frequency": "mon",
+      "realm": "atmos",
       "dimensions": ["time", "lev", "lat", "lon"],
       "requirement": "required"
     },
     "ta": {
       "standard_name" : "air_temperature",
       "units" : "K",
+      "realm": "atmos",
       "frequency": "mon",
       "dimensions": ["time", "lev", "lat", "lon"],
       "requirement": "required"
@@ -66,6 +69,7 @@
       "standard_name" : "air_pressure_at_mean_sea_level",
       "units" : "Pa",
       "frequency": "mon",
+       "realm": "atmos",
       "dimensions": ["time", "lat", "lon"],
       "requirement": "required"
     }

--- a/diagnostics/stc_spv_extremes/settings.jsonc
+++ b/diagnostics/stc_spv_extremes/settings.jsonc
@@ -6,7 +6,6 @@
   "settings" : {
     "driver" : "stc_spv_extremes.py",
     "long_name" : "Stratospheric Polar Vortex Extremes",
-    "realm" : "atmos",
     "description" : "Detecting extreme polar vortex events and their surface impacts",
     "pod_env_vars" : {
       // Lower latitude limit for polar cap avg calculations (defaults to 65)
@@ -18,6 +17,9 @@
     "runtime_requirements": {
       "python3": ["matplotlib", "numpy", "pandas", "xarray", "scipy"]
     }
+  },
+  "data": {
+    "realm" : "atmos",
   },
   "dimensions": {
     "lat": {"standard_name": "latitude"},

--- a/diagnostics/stc_spv_extremes/settings.jsonc
+++ b/diagnostics/stc_spv_extremes/settings.jsonc
@@ -19,7 +19,7 @@
     }
   },
   "data": {
-    "realm" : "atmos",
+    "realm" : "atmos"
   },
   "dimensions": {
     "lat": {"standard_name": "latitude"},

--- a/diagnostics/top_heaviness_metric/settings.jsonc
+++ b/diagnostics/top_heaviness_metric/settings.jsonc
@@ -29,7 +29,7 @@
 	"varlist": {
 		"omega": {
 			"standard_name": "lagrangian_tendency_of_air_pressure",
-                        "frequency": "mon",
+            "frequency": "mon",
 			"realm": "atmos",
 			"units": "Pa s-1",
 			"dimensions": ["lev", "lat", "lon"]

--- a/doc/sphinx/pod_settings.rst
+++ b/doc/sphinx/pod_settings.rst
@@ -33,13 +33,13 @@ Example
     "settings" : {
       "long_name": "My example diagnostic",
       "driver": "example_diagnostic.py",
-      "realm": "atmos",
       "runtime_requirements": {
         "python": ["numpy", "matplotlib", "netCDF4"]
       }
     },
     "data" : {
-      "frequency": "day"
+      "frequency": "day",
+      "realm": "atmos"
     },
     "dimensions": {
       "lat": {
@@ -84,12 +84,6 @@ This is where you describe your diagnostic and list the programs it needs to run
 ``driver``: 
   Filename of the driver script the framework should call to run your diagnostic.
 
-``realm``: 
-  One or more of the eight CMIP6 modeling realms (aerosol, atmos, atmosChem, land, landIce, ocean, ocnBgchem, seaIce)
-  describing what data your diagnostic uses. This is give the user an easy way to, eg, run only ocean diagnostics on
-  data from an ocean model. Realm can be specified in the `settings`` section, or specified separately for each variable
-  in the `varlist` section.
-
 ``runtime_requirements``: 
   This is a list of key-value pairs describing the programs your diagnostic needs to run, and any third-party libraries
   used by those programs.
@@ -120,6 +114,12 @@ This section contains settings that apply to all the data your diagnostic uses. 
   ``hr``, ``day``, ``mon``, ``yr`` or ``fx``. ``fx`` is used where appropriate to denote time-independent data.
   Common synonyms for these units are also recognized (e.g. ``monthly``, ``month``, ``months``, ``mo`` for ``mon``,
   ``static`` for ``fx``, etc.)
+
+``realm``:
+  One or more of the eight CMIP6 modeling realms (aerosol, atmos, atmosChem, land, landIce, ocean, ocnBgchem, seaIce)
+  describing what data your diagnostic uses. This is give the user an easy way to, eg, run only ocean diagnostics on
+  data from an ocean model. Realm can be specified in the `data` section, or specified separately for each variable
+  in the `varlist` section.
 
 .. _sec_dimensions:
 
@@ -163,7 +163,7 @@ Time
   **Required**. Must be ``"time"``.
 
 ``units``:
-  String. Optional, defaults to "day". Units the diagnostic expects the dimension to be in. Currently the diagnostic
+  String, Optional, defaults to "day". Units the diagnostic expects the dimension to be in. Currently the diagnostic
   only supports time axes of the form "<units> since <reference data>", and the value given here is interpreted in this
   sense (e.g. settings this to "day" would accommodate a dimension of the form "[decimal] days since 1850-01-01".)
 
@@ -220,7 +220,8 @@ Other dimensions (wavelength, ...)
   employed in the CMIP6 MIP tables.
 
 ``units``:
-  Optional, a :ref:`CFunit<cfunit>`. Units the diagnostic expects the dimension to be in. **If not provided, the framework will assume CF convention** `canonical units <http://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html>`__.
+  **Required** :ref:`CFunit<cfunit>`, string. Units the diagnostic expects the dimension to be in. Use `1` if the
+  dimension has no units
 
 ``need_bounds``:
   Boolean, optional. Assumed ``false`` if not specified. If ``true``, the framework will ensure that bounds are supplied
@@ -266,14 +267,14 @@ variable. Most settings here are optional, but the main ones are:
   List of names of dimensions specified in the "dimensions" section, to specify the coordinate dependence of each
   variable.
 
-``realm`` (if not specified in the `settings` section):
+``realm`` (if not specified in the `data` section):
   string or list of CMIP modeling realm(s) that the variable belongs to
 
 ``modifier``:
- String, optional; Descriptor to distinguish variables with identical standard names and different dimensionalities or
- realms. See `modifiers.jsonc <https://github.com/NOAA-GFDL/MDTF-diagnostics/blob/main/data/modifiers.jsonc>`__ for
- supported modfiers. Open an issue to request the addition of a new modifier to the modifiers.jsonc file, or submit a
- pull request that includes the new modifier in the modifiers.jsonc file and the necessary POD settings.jsonc file(s).
+  String, optional; Descriptor to distinguish variables with identical standard names and different dimensionalities or
+  realms. See `modifiers.jsonc <https://github.com/NOAA-GFDL/MDTF-diagnostics/blob/main/data/modifiers.jsonc>`__ for
+  supported modifiers. Open an issue to request the addition of a new modifier to the modifiers.jsonc file, or submit a
+  pull request that includes the new modifier in the modifiers.jsonc file and the necessary POD settings.jsonc file(s).
 
 ``requirement``:
   String. Optional; assumed ``"required"`` if not specified. One of three values:
@@ -309,6 +310,7 @@ variable. Most settings here are optional, but the main ones are:
 
   - *keys* are the key (name) of an entry in the :ref:`dimensions<sec_dimensions>` section.
   - *values* are a single number (integer or floating-point) corresponding to the value of the slice to extract.
+
   **Units** of this number are taken to be the ``units`` property of the dimension named as the key.
 
   In order to request multiple slices (e.g. wind velocity on multiple pressure levels, with each level saved to a

--- a/src/varlist_util.py
+++ b/src/varlist_util.py
@@ -263,8 +263,9 @@ class VarlistEntry(VarlistEntryBase, util.MDTFObjectBase, data_model.DMVariable,
         new_kw = global_settings_d.copy()
         new_kw['coords'] = []
         new_kw['convention'] = parent.pod_settings.get('convention', 'cmip')
-        if parent.pod_settings.get('realm', None) is not None:
-            new_kw['realm'] = parent.pod_settings.get('realm')  # populated if realm defined in pod_env_vars instead
+        # check if realm is set for all variables
+        if parent.pod_data.get('realm', None) is not None:
+            new_kw['realm'] = parent.pod_data.get('realm')  # populated if realm defined in pod settings data instead
         #  of an attribute for each POD variable
         if 'dimensions' not in kwargs:
             raise ValueError(f"No dimensions specified for Varlist entry {name}.")


### PR DESCRIPTION

**Description**
update settings files in existing PODs with global realm settings update settings file docs

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [x] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [ ] The repository contains no extra test scripts or data files
