### PR TITLE
infer 'start_time' and 'end_time' from 'time_range' due to type issues

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -820,19 +820,15 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         """
         date_col = "date_range"
         delimiters = ",.!?/&-:;@_'\\s+"
-        if not hasattr(group_df, 'start_time') or not hasattr(group_df, 'end_time'):
-            if hasattr(group_df, 'time_range'):
-                start_times = []
-                end_times = []
-                for tr in group_df['time_range'].values:
-                    tr = tr.split('-')
-                    start_times.append(tr[0])
-                    end_times.append(tr[1])
-                group_df['start_time'] = pd.Series(start_times)
-                group_df['end_time'] = pd.Series(end_times)
-            else:
-                raise AttributeError('Data catalog is missing attributes `start_time` and/or'
-                                     ' `end_time` and can not infer from `time_range`')
+        if hasattr(group_df, 'time_range'):
+            start_times = []
+            end_times = []
+            for tr in group_df['time_range'].values:
+                tr = tr.split('-')
+                start_times.append(tr[0])
+                end_times.append(tr[1])
+            group_df['start_time'] = pd.Series(start_times)
+            group_df['end_time'] = pd.Series(end_times)
         try:
             start_time_vals = self.normalize_group_time_vals(group_df['start_time'].values.astype(str))
             end_time_vals = self.normalize_group_time_vals(group_df['end_time'].values.astype(str))

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -829,6 +829,9 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 end_times.append(tr[1])
             group_df['start_time'] = pd.Series(start_times)
             group_df['end_time'] = pd.Series(end_times)
+        else:
+            raise AttributeError('Data catalog is missing the attribute `time_range`;'
+                                 ' this is a required entry.')
         try:
             start_time_vals = self.normalize_group_time_vals(group_df['start_time'].values.astype(str))
             end_time_vals = self.normalize_group_time_vals(group_df['end_time'].values.astype(str))

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -824,9 +824,9 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             start_times = []
             end_times = []
             for tr in group_df['time_range'].values:
-                tr = tr.split('-')
-                start_times.append(tr[0])
-                end_times.append(tr[1])
+                tr = tr.replace(' ', '').replace('-', '').replace(':', '')
+                start_times.append(tr[0:len(tr)//2])
+                end_times.append(tr[len(tr)//2:])
             group_df['start_time'] = pd.Series(start_times)
             group_df['end_time'] = pd.Series(end_times)
         else:


### PR DESCRIPTION
**Description**
Include a summary of the change, and link the associated issue (if applicable).  
List any dependencies that are required for this change, including libraries and variables,  
and their metadata (units, frequencies, etc...). Be sure to separate PRs and issues for new PODs and PODs currently under development.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [ ] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [ ] The repository contains no extra test scripts or data files
