### PR TITLE
move line setting date_range in query_catalog()

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -927,7 +927,6 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
 
             for var in case_d.varlist.iter_vars():
                 realm_regex = var.realm + '*'
-                print(var.translation.T)
                 var_id = var.translation.name
                 standard_name = var.translation.standard_name
                 if var.translation.convention == 'no_translation':

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -927,9 +927,9 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
 
             for var in case_d.varlist.iter_vars():
                 realm_regex = var.realm + '*'
+                print(var.translation.T)
                 var_id = var.translation.name
                 standard_name = var.translation.standard_name
-                date_range = var.translation.T.range
                 if var.translation.convention == 'no_translation':
                     date_range = var.T.range
                     var_id = var.name
@@ -938,6 +938,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                     date_range = None
                     freq = "fx"
                 else:
+                    date_range = var.translation.T.range
                     freq = var.T.frequency
                     if freq == 'hr':
                         freq = '1hr'


### PR DESCRIPTION
**Description**
Line setting date_range was too early in the logic. Static vars would reach this line and cause an error.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [ ] The repository contains no extra test scripts or data files
