### PR TITLE
add ice/ocean precip entries to GFDL fieldlist

### DIFF
--- a/data/fieldlist_GFDL.jsonc
+++ b/data/fieldlist_GFDL.jsonc
@@ -186,6 +186,23 @@
       "scalar_coord_templates": {"plev": "omega{value}"},
       "ndim": 4
     },
+    // NOTE: pr is the same for sea Ice and ocean realms, and there are duplicate entries;
+    // TODO: refine realm entry parsing in framework to allow lists and strings
+    "pr": {
+      "standard_name": "rainfall_flux",
+      "long_name": "Surface Rainfall Rate into the Sea Ice Portion of the Grid Cell",
+      "realm": "seaIce",
+      "units": "kg m-2 s-1",
+      "ndim": 3
+    },
+    "pr": {
+      "standard_name": "rainfall_flux",
+      "long_name": "Surface Rainfall Rate into the Sea Ice Portion of the Grid Cell",
+      "realm": "ocean",
+      "units": "kg m-2 s-1",
+      "ndim": 3
+    },
+   
     "precip": {
       "standard_name": "precipitation_flux",
       "long_name":"",


### PR DESCRIPTION
**Description**
Add sea ice and ocean precip entries to GFDL field table. Included note to modify framework to allow lists of strings for realm entries

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
