### PR TITLE
add function check_multichunk to fix issue with chunk_freqs

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -827,9 +827,9 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 for c in chunks:
                     if case_dt % c == 0:
                         grabbed_chunk = str(c) + 'yr'
+                        log.warning("Multiple values for 'chunk_freq' found in dataset "
+                                    "only grabbing data with 'chunk_freq': %s", grabbed_chunk)
                         break
-                log.warning("Multiple values for 'chunk_freq' found in dataset "
-                         "only grabbing data with 'chunk_freq': %s", grabbed_chunk)
                 group_df = group_df[group_df['chunk_freq'] == grabbed_chunk]
         return pd.DataFrame.from_dict(group_df).reset_index()
 

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -808,8 +808,8 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         return time_vals
 
     def check_multichunk(self, group_df: pd.DataFrame, case_dr, log) -> pd.DataFrame:
-        """Sort the files found by date, grabs the files thats chunk-freq is the
-        largest number where endyr-startyr modulo chunk-freq is zero and throw out
+        """Sort the files found by date, grabs the files whose 'chunk_freq' is the
+        largest number where endyr-startyr modulo 'chunk_freq' is zero and throws out
         the rest.
 
         Args:

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -807,6 +807,32 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                     time_vals[i] = '0' + time_vals[i]
         return time_vals
 
+    def check_multichunk(self, group_df: pd.DataFrame, case_dr, log) -> pd.DataFrame:
+        """Sort the files found by date, grabs the files thats chunk-freq is the
+        largest number where endyr-startyr modulo chunk-freq is zero and throw out
+        the rest.
+
+        Args:
+            group_df (Pandas Dataframe):
+            case_dr: requested daterange of POD
+            log: log file
+        """
+        if 'chunk_freq' in group_df:
+            chunks = group_df['chunk_freq'].unique()
+            if len(chunks) > 1:
+                for i, c in enumerate(chunks):
+                    chunks[i] = int(c.replace('yr', ''))
+                chunks = -np.sort(-chunks)
+                case_dt = int(str(case_dr.end)[:4]) - int(str(case_dr.start)[:4]) + 1
+                for c in chunks:
+                    if case_dt % c == 0:
+                        grabbed_chunk = str(c) + 'yr'
+                        break
+                log.warning("Multiple values for 'chunk_freq' found in dataset "
+                         "only grabbing data with 'chunk_freq': %s", grabbed_chunk)
+                group_df = group_df[group_df['chunk_freq'] == grabbed_chunk]
+        return pd.DataFrame.from_dict(group_df).reset_index()
+
     def check_group_daterange(self, group_df: pd.DataFrame, case_dr,
                               log=_log) -> pd.DataFrame:
         """Sort the files found for each experiment by date, verify that
@@ -815,6 +841,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
 
         Args:
             group_df (Pandas Dataframe):
+            case_dr: requested daterange of POD
             log: log file
         """
         date_col = "date_range"
@@ -951,7 +978,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 case_d.query['realm'] = realm_regex
                 case_d.query['standard_name'] = standard_name
                 case_d.query['variable_id'] = var_id
-
+                
                 # change realm key name if necessary
                 if cat.df.get('modeling_realm', None) is not None:
                     case_d.query['modeling_realm'] = case_d.query.pop('realm')
@@ -1004,6 +1031,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 # Get files in specified date range
                 # https://intake-esm.readthedocs.io/en/stable/how-to/modify-catalog.html
                 if not var.is_static:
+                    cat_subset.esmcat._df = self.check_multichunk(cat_subset.df, date_range, var.log)
                     cat_subset.esmcat._df = self.check_group_daterange(cat_subset.df, date_range)
                 if cat_subset.df.empty:
                     raise util.DataRequestError(


### PR DESCRIPTION
**Description**
The MDTF would run into an issue if multiple chunk_freqs would exist in a dataset. This new function checks to see if that is an issue. If it is, it grabs the grabs the files whose 'chunk_freq' is the largest number where endyr-startyr modulo chunk-freq is zero and throws out the rest.

Associated issue #700  

**How Has This Been Tested?**
This has been tested with a CM4.5 dataset with the issue on the GFDL network. Various other non-problematic dataset were ran to insure the function doesn't overstep its bounds.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
