### PR TITLE
add plots link to pod_error_snippet.html

### DIFF
--- a/src/html/pod_error_snippet.html
+++ b/src/html/pod_error_snippet.html
@@ -1,7 +1,9 @@
 <H3 style="color:navy; font-weight:bold">
     {{description}} failed to execute:
-    <A href="{{name}}/{{name}}.log" type="text/plain" charset="UTF-8">error log</A>; 
+    <A href="{{name}}/{{name}}.html">plots</A>,
+    <A href="{{name}}/{{name}}.log" type="text/plain" charset="UTF-8">error log</A>,
     <A href="{{name}}/{{name}}.data.log" type="text/plain" charset="UTF-8">data used</A>.
+
 </H3>
 
 <TABLE>

--- a/src/html/pod_error_snippet.html
+++ b/src/html/pod_error_snippet.html
@@ -3,7 +3,6 @@
     <A href="{{name}}/{{name}}.html">plots</A>,
     <A href="{{name}}/{{name}}.log" type="text/plain" charset="UTF-8">error log</A>,
     <A href="{{name}}/{{name}}.data.log" type="text/plain" charset="UTF-8">data used</A>.
-
 </H3>
 
 <TABLE>


### PR DESCRIPTION
**Description**
This PR adds a hyperlink to the main index.html for PODs that suffer an error. The error warning still shows, but now users are able to see the rest of the plots that completed normally. This helps with DORA integration.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
