### PR TITLE
fix formatting issues in output reference documentation

### DIFF
--- a/doc/sphinx/ref_output.rst
+++ b/doc/sphinx/ref_output.rst
@@ -64,11 +64,10 @@ These files and folders are:
      :code-rst:`index.html`.
    * :code-rst:`case_info.yml` provides environment variables for each case. Multirun PODs can read and set the
      environment variables from this file following the
-     `example_multicase.py <https://github.com/NOAA-GFDL/MDTF-diagnostics/blob/main/diagnostics/example_multicase/example_multicase.py>`__
-      template
+     `example_multicase.py template <https://github.com/NOAA-GFDL/MDTF-diagnostics/blob/main/diagnostics/example_multicase/example_multicase.py>`__
    * :code-rst:`model/` and :code-rst:`obs/` contain both plots and data for both the model data and observation data
      respectively. The framework appends a temporary :code-rst:`PS` subdirectory to the :code-rst:`model` and
-     :code-rst:`obs`directories where PODs can write postscript files instead of png files. The framework will convert
+     :code-rst:`obs` directories where PODs can write postscript files instead of png files. The framework will convert
      any .(e)ps files in the :code-rst:`PS`
      subdirectories to .png files and move them to the :code-rst:`model` and/or :code-rst:`obs` subdirectories, then
      delete the :code-rst:`PS` subdirectories during the output generation stage. Users can retain the :code-rst:`PS`


### PR DESCRIPTION
**Description**
Fixes some slight documentation issues I noticed while looking into the output reference.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [ ] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [ ] The repository contains no extra test scripts or data files
