### PR TITLE
update 'standard_name' for each var in write_pp_catalog

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -1457,8 +1457,9 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 else:
                     d.update({'project_id': var.translation.convention})
                 d.update({'path': var.dest_path})
-                d.update({'start_time': util.cftime_to_str(input_catalog_ds[case_name].time.values[0])})
-                d.update({'end_time': util.cftime_to_str(input_catalog_ds[case_name].time.values[-1])})
+                d.update({'start_time': util.cftime_to_str(ds_match.time.values[0])})
+                d.update({'end_time': util.cftime_to_str(ds_match.time.values[-1])})
+                d.update({'standard_name': ds_match[var.name].attrs['standard_name']})
                 cat_entries.append(d)
 
         # create a Pandas dataframe from the catalog entries


### PR DESCRIPTION
**Description**
@aradhakrishnanGFDL  noticed an issue where all of the entries in the pp_catalog had the same name. This PR adds an update to the dict passed to make the catalog for the 'standard_name' of each variable. 

Associated issue #672 

**How Has This Been Tested?**
Ran for MJO_suite and Wheeler_Kiladis on the workstation with some GFDL data.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
