### PR TITLE
Update docs about --env_dir flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,7 @@ for, the Windows Subsystem for Linux.
      when micromamba is installed
   - `$MICROMAMBA_EXE` is full path to the micromamba executable on your system
      (e.g., /home/${USER}/.local/bin/micromamba). This is defined by the `MAMBA_EXE` environment variable on your system
-  - The `--env_dir` flag allows you to put the program files in a designated location `$CONDA_ENV_DIR` 
-  (for space reasons, or if you don’t have write access).
-  You can omit this flag, and the environments will be installed within `$CONDA_ROOT/envs/` by default.
+  - All flags noted for your system above must be supplied for the script to work.
 
   #### NOTE: The micromamba environments may differ from the conda environments because of package compatibility discrepancies between solvers
   `% ./src/conda/micromamba_env_setup.sh --all --micromamba_root $MICROMAMBA_ROOT --micromamba_exe $MICROMAMBA_EXE --env_dir $CONDA_ENV_DIR` builds

--- a/doc/sphinx/start_install.rst
+++ b/doc/sphinx/start_install.rst
@@ -192,9 +192,6 @@ environments in your conda installation. The installation process should finish 
 
 Substitute the paths identified above for <*CONDA_ROOT*> and <*CONDA_ENV_DIR*>.
 
-If the ``--env_dir`` flag is omitted, the environment files will be installed in your system's conda's default
-location (usually <*CONDA_ROOT*>/envs).
-
 Install all the package's conda environments with micromamba by running
 
     .. code-block:: console


### PR DESCRIPTION
**Description**
Removes documentation that states the --env_dir is an optional flag

Associated issue #712  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
