### PR TITLE
Fix various pp issues related to running seaice_suite

### DIFF
--- a/data/fieldlist_GFDL.jsonc
+++ b/data/fieldlist_GFDL.jsonc
@@ -163,7 +163,13 @@
       "realm": "atmos",
       "units": "1",
       "ndim": 3
-     },
+    },
+    "siconc": {
+      "standard_name": "sea_ice_area_fraction",
+      "realm": "seaIce",
+      "units": "0-1",
+      "ndim": 3
+    },
     "IWP": {
       "standard_name": "atmosphere_mass_content_of_cloud_ice",
       "long_name": "Ice water path",

--- a/diagnostics/seaice_suite/seaice_suite_sic_mean_sigma.py
+++ b/diagnostics/seaice_suite/seaice_suite_sic_mean_sigma.py
@@ -91,7 +91,7 @@ def readindata(file, varname='siconc', firstyr='1979', lastyr='2014'):
 
 
 # 1) Loading model data files:
-input_file = "{DATADIR}/mon/{CASENAME}.{siconc_var}.mon.nc".format(**os.environ)
+input_file = os.environ['SICONC_FILE']
 obsoutput_dir = "{WORK_DIR}/obs/".format(**os.environ)
 modoutput_dir = "{WORK_DIR}/model/".format(**os.environ)
 figures_dir = "{WORK_DIR}/model/".format(**os.environ)

--- a/src/data_sources.py
+++ b/src/data_sources.py
@@ -126,7 +126,7 @@ class CMIPDataSource(DataSourceBase):
     convention: str = "CMIP"
     
     def set_query(self, var: varlist_util.VarlistEntry, path_regex: str):
-        self.set_query_base(self, var, path_regex)
+        self.set_query_base(var, path_regex)
 
 @data_source.maker
 class CESMDataSource(DataSourceBase):
@@ -139,7 +139,7 @@ class CESMDataSource(DataSourceBase):
     convention: str = "CESM"
     
     def set_query(self, var: varlist_util.VarlistEntry, path_regex: str):
-        self.set_query_base(self, var, path_regex)
+        self.set_query_base(var, path_regex)
 
 @data_source.maker
 class GFDLDataSource(DataSourceBase):

--- a/src/data_sources.py
+++ b/src/data_sources.py
@@ -65,7 +65,7 @@ class DataSourceBase(util.MDTFObjectBase, util.CaseLoggerMixin):
     def set_date_range(self, startdate: str, enddate: str):
         self.date_range = util.DateRange(start=startdate, end=enddate)
     
-    def set_query_base(self, var: varlist_util.VarlistEntry, path_regex: str):
+    def set_query(self, var: varlist_util.VarlistEntry, path_regex: str):
         realm_regex = var.realm + '*'
         date_range = var.T.range
         var_id = var.name
@@ -126,7 +126,8 @@ class CMIPDataSource(DataSourceBase):
     convention: str = "CMIP"
     
     def set_query(self, var: varlist_util.VarlistEntry, path_regex: str):
-        self.set_query_base(var, path_regex)
+        super().set_query(var, path_regex)
+        return
 
 @data_source.maker
 class CESMDataSource(DataSourceBase):
@@ -139,7 +140,8 @@ class CESMDataSource(DataSourceBase):
     convention: str = "CESM"
     
     def set_query(self, var: varlist_util.VarlistEntry, path_regex: str):
-        self.set_query_base(var, path_regex)
+        super().set_query(var, path_regex)
+        return
 
 @data_source.maker
 class GFDLDataSource(DataSourceBase):
@@ -152,7 +154,8 @@ class GFDLDataSource(DataSourceBase):
     convention: str = "GFDL"
 
     def set_query(self, var: varlist_util.VarlistEntry, path_regex: str):
-        self.set_query_base(var, path_regex)
+        super().set_query(var, path_regex)
         # this is hacky, but prevents the framework from grabbing from ice_1x1deg
         if self.query['realm'] == 'seaIce*':
             self.query['realm'] = 'ice'
+        return

--- a/src/data_sources.py
+++ b/src/data_sources.py
@@ -64,6 +64,36 @@ class DataSourceBase(util.MDTFObjectBase, util.CaseLoggerMixin):
 
     def set_date_range(self, startdate: str, enddate: str):
         self.date_range = util.DateRange(start=startdate, end=enddate)
+    
+    def set_query_base(self, var: varlist_util.VarlistEntry, path_regex: str):
+        realm_regex = var.realm + '*'
+        date_range = var.T.range
+        var_id = var.name
+        standard_name = var.standard_name
+        if var.translation.convention is not None:
+            var_id = var.translation.name
+            standard_name = var.translation.standard_name
+            if any(var.translation.alternate_standard_names):
+                standard_name = [var.translation.standard_name] + var.translation.alternate_standard_names
+                date_range = var.translation.T.range
+        if var.is_static:
+            date_range = None
+            freq = "fx"
+        else:
+            freq = var.T.frequency
+        if not isinstance(freq, str):
+            freq = freq.format_local()
+        if freq == 'hr':
+            freq = '1hr'
+
+        # define initial query dictionary with variable settings requirements that do not change if
+        # the variable is translated
+        self.query['frequency'] = freq
+        self.query['path'] = path_regex
+        self.query['realm'] = realm_regex
+        self.query['standard_name'] = standard_name
+        self.query['variable_id'] = var_id
+
 
     def translate_varlist(self,
                           var: varlist_util.VarlistEntry,
@@ -94,7 +124,9 @@ class CMIPDataSource(DataSourceBase):
     # col_spec = sampleLocalFileDataSource_col_spec
     # varlist = diagnostic.varlist
     convention: str = "CMIP"
-
+    
+    def set_query(self, var: varlist_util.VarlistEntry, path_regex: str):
+        self.set_query_base(self, var, path_regex)
 
 @data_source.maker
 class CESMDataSource(DataSourceBase):
@@ -105,7 +137,9 @@ class CESMDataSource(DataSourceBase):
     # col_spec = sampleLocalFileDataSource_col_spec
     # varlist = diagnostic.varlist
     convention: str = "CESM"
-
+    
+    def set_query(self, var: varlist_util.VarlistEntry, path_regex: str):
+        self.set_query_base(self, var, path_regex)
 
 @data_source.maker
 class GFDLDataSource(DataSourceBase):
@@ -116,3 +150,9 @@ class GFDLDataSource(DataSourceBase):
     # col_spec = sampleLocalFileDataSource_col_spec
     # varlist = diagnostic.varlist
     convention: str = "GFDL"
+
+    def set_query(self, var: varlist_util.VarlistEntry, path_regex: str):
+        self.set_query_base(var, path_regex)
+        # this is hacky, but prevents the framework from grabbing from ice_1x1deg
+        if self.query['realm'] == 'seaIce*':
+            self.query['realm'] = 'ice'

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -110,8 +110,6 @@ class PercentConversionFunction(PreprocessorFunctionBase):
         var_unit = getattr(var, "units", "")
         tv = var.translation #abbreviate
         tv_unit = getattr(tv, "units", "")
-        if str(tv_unit) == str(var_unit):
-            return ds
         # 0-1 to %
         if str(tv_unit) == self._std_name_tuple[0] and str(var_unit) == self._std_name_tuple[1]:
             ds[tv.name].attrs['units'] = '%'
@@ -126,6 +124,8 @@ class PercentConversionFunction(PreprocessorFunctionBase):
             else:
                 ds[tv.name].values = ds[tv.name].values/100
                 return ds
+
+        return ds
 
 class PrecipRateToFluxFunction(PreprocessorFunctionBase):
     """A PreprocessorFunction which converts the dependent variable's units, for

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -97,7 +97,7 @@ class PreprocessorFunctionBase(abc.ABC):
         pass
 
 
-class PercentTo01Function(PreprocessorFunctionBase):
+class PercentConversionFunction(PreprocessorFunctionBase):
     """A PreprocessorFunction which convers the dependent variable's units and values,
     for the specific case of percentages. ``0-1`` are not defined in the UDUNITS-2
     library. So, this function handles the case where we have to convert from 
@@ -724,7 +724,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         """
         # normal operation: run all functions
         return [
-            AssociatedVariablesFunction, PercentTo01Function,
+            AssociatedVariablesFunction, PercentConversionFunction,
             PrecipRateToFluxFunction, ConvertUnitsFunction,
             ExtractLevelFunction, RenameVariablesFunction
         ]

--- a/src/units.py
+++ b/src/units.py
@@ -135,6 +135,8 @@ def conversion_factor(source_unit, dest_unit):
     *source_unit*, *dest_unit* are coerced to :class:`Units` objects via
     :func:`to_cfunits`.
     """
+    if str(source_unit) == str(dest_unit):
+        return 1.0 # bypass function if the units have the same string allowing units like '0-1' to be used
     source_unit, dest_unit = to_equivalent_units(source_unit, dest_unit)
     return Units.conform(1.0, source_unit, dest_unit)
 

--- a/src/xr_parser.py
+++ b/src/xr_parser.py
@@ -194,7 +194,7 @@ class MDTFCFAccessorMixin(object):
             if len(v) > 1 and var_name is not None:
                 ax = [c for c in v if c in itertools.chain.from_iterable(axes_obj.cf.coordinates.values())]
                 del_ax = [d for d in v if d not in itertools.chain.from_iterable(axes_obj.cf.coordinates.values())]
-                if del_ax is not None:  # remove the entries that are not in the cf.coordinates.values dict
+                if del_ax is not None and len(del_ax) > 0:  # remove the entries that are not in the cf.coordinates.values dict
                     # append entries that are in the cf.coordinates.values dict if they are missing in coords_list
                     # and dims_list
                     if del_ax[0] in coords_list:
@@ -208,14 +208,15 @@ class MDTFCFAccessorMixin(object):
 
                 if ax is not None:
                     vardict[k] = ax
-                    if ax[0] not in coords_list:
-                        _log.warning(("cf_xarray fix: %s axis %s not in dimensions "
-                                      "for %s; dropping."), k, ax[0], var_name)
-                        delete_keys.append(k)
-                    else:
-                        coords_list.remove(ax[0])
-                        if ax[0] in dims_list:
-                            dims_list.remove(ax[0])
+                    for a in ax:
+                        if a not in coords_list:
+                            _log.warning(("cf_xarray fix: %s axis %s not in dimensions "
+                                          "for %s; dropping."), k, a, var_name)
+                            delete_keys.append(k)
+                        else:
+                            coords_list.remove(a)
+                            if a in dims_list:
+                                dims_list.remove(a)
             elif len(v) == 1:
                 if v[0] not in coords_list:
                     _log.warning(("cf_xarray fix: %s axis %s not in dimensions "


### PR DESCRIPTION
**Description**
A variety issues were found in the preprocesser while trying to run the seaice_suite on CM4.5 data. These issues resolved in the PR are as follows:

1. The realm_regex would grab files from an adjacent ice pp dir. This was fixed by spinning out the setting of case_d.query in the class for each convention (i.e. CMIP, GFDL, and CESM)
2. Add siconc to the GFDL data fieldlist
3. Create PercentTo01Function function to handle conversion for the unit ``0-1`` as cfunits does not handle this
4. Add logic to conversion_factor to return 1 if the units have the same string value
5. fix file path issue in POD
6. fix issues caused by multiple coords per axis

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
