### PR TITLE
Add dask_delayed nc write calls

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -1412,7 +1412,6 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         )
         delayed_write.compute()
         delayed_write.close()
-        #ds.close()
 
     def write_ds(self, case_list: dict,
                  catalog_subset: collections.OrderedDict,

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -16,6 +16,7 @@ import numpy as np
 import xarray as xr
 import collections
 import re
+import dask
 
 # TODO: Make the following lines a unit test
 # import sys
@@ -1105,9 +1106,9 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                     cat_subset.esmcat._df = self.check_group_daterange(cat_subset.df, date_range, var.log)
                 if cat_subset.df.empty:
                     raise util.DataRequestError(
-                        f"check_group_daterange returned empty data frame for {var_id}"
+                        f"check_group_daterange returned empty data frame for {var.name}"
                         f" case {case_name} in {data_catalog}, indicating issues with data continuity")
-                # v.log.debug("Read %d mb for %s.", cat_subset.esmcat._df.dtypes.nbytes / (1024 * 1024), v.full_name)
+                var.log.info(f"Converting {var.name} catalog subset to dataset dictionary")
                 # convert subset catalog to an xarray dataset dict
                 # and concatenate the result with the final dict
                 cat_subset_dict = cat_subset.to_dataset_dict(
@@ -1170,9 +1171,10 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 # check that the trimmed variable data in the merged dataset matches the desired date range
                 if not var.is_static:
                     try:
+                        var.log.info(f'Calling check_time_bounds for {var.name}')
                         self.check_time_bounds(cat_dict[case_name], var.translation, var.T.frequency)
                     except LookupError:
-                        var.log.error(f'Time bounds in trimmed dataset for {var_id} in case {case_name} do not match'
+                        var.log.error(f'Time bounds in trimmed dataset for {var.name} in case {case_name} do not match'
                                       f'requested date_range.')
                         raise SystemExit("Terminating program")
         return cat_dict
@@ -1401,13 +1403,16 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             unlimited_dims = []
         else:
             unlimited_dims = [var.T.name]
-        var_ds.to_netcdf(
+        delayed_write = var_ds.to_netcdf(
             path=var.dest_path,
             mode='w',
             **self.save_dataset_kwargs,
-            unlimited_dims=unlimited_dims
+            unlimited_dims=unlimited_dims,
+            compute=False
         )
-        ds.close()
+        delayed_write.compute()
+        delayed_write.close()
+        #ds.close()
 
     def write_ds(self, case_list: dict,
                  catalog_subset: collections.OrderedDict,
@@ -1480,6 +1485,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             for v in case_list[case_name].varlist.iter_vars():
                 tv_name = v.translation.name
                 # todo: maybe skip this if no standard_name attribute for v in case_xr_dataset
+                v.log.info(f'Calling parse_ds for {v.name}')
                 var_xr_dataset = self.parse_ds(v, case_xr_dataset)
                 varlist_ex = [v_l.translation.name for v_l in case_list[case_name].varlist.iter_vars()]
                 if tv_name in varlist_ex:
@@ -1487,6 +1493,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 for v_d in var_xr_dataset.variables:
                     if v_d not in varlist_ex:
                         cat_subset[case_name].update({v_d: var_xr_dataset[v_d]})
+                v.log.info(f'Calling preprocessing functions for {v.name}')
                 pp_func_dataset = self.execute_pp_functions(v,
                                                             cat_subset[case_name],
                                                             work_dir=model_work_dir[case_name],


### PR DESCRIPTION
**Description**
Write processed netcdf files as dask_delayed objects to improve performance, and add debugging time lines to write_dataset.
Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Tested on macOS with W-K POD using sample QBOI data

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
