### PR TITLE
small fix

### DIFF
--- a/tools/catalog_builder/parsers.py
+++ b/tools/catalog_builder/parsers.py
@@ -217,7 +217,7 @@ def parse_gfdl_am5_data(file_name: str):
     if hasattr(gfdl_info['variables'], catalog_info['variable_id']):
         var_metadata = gfdl_info['variables'].get(catalog_info['variable_id'])
     else:
-        raise KeyError(f'{catalog_info['variable_id']} not found in {gfdl_fieldlist}')
+        raise KeyError(f"{catalog_info['variable_id']} not found in {gfdl_fieldlist}")
     if hasattr(var_metadata, 'standard_name'):
         catalog_info.update({'standard_name': var_metadata.standard_name})
     if hasattr(var_metadata, 'long_name'):


### PR DESCRIPTION
The catalog parser wouldn't run for me without this small change.

**How Has This Been Tested?**
Run on CESM data, NCAR's casper machine

**Checklist:**
- [x ] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x ] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ n/a] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ n/a] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ n/a] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [n/a ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ n/a] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ n/a] I have provided the code to generate digested data files from raw data files
- [n/a ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ n/a] I have included copies of the figures generated by the POD in the pull request
- [ n/a] The repository contains no extra test scripts or data files
