### PR TITLE
add external script into example_notebook

### DIFF
--- a/diagnostics/example_notebook/example_notebook.ipynb
+++ b/diagnostics/example_notebook/example_notebook.ipynb
@@ -314,13 +314,28 @@
    "outputs": [],
    "execution_count": null,
    "source": [
-    "# Part 4: Close the catalog files and\n",
+    "# Part 4: running an external script\n",
+    "# the use of external python scripts can help prevent bloat in the notebook\n",
+    "# here, we show how this can be done\n",
+    "sys.path.append(os.environ[\"POD_HOME\"])\n",
+    "import script\n",
+    "script.HelloWorld()"
+   ],
+   "id": "dfff0ee7ac28d733"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "# Part 5: Close the catalog files and\n",
     "# release variable dict reference for garbage collection\n",
     "# ------------------------------------------------------\n",
     "cat.close()\n",
     "tas_dict = None\n",
     "\n",
-    "# Part 5: Confirm POD executed successfully\n",
+    "# Part 6: Confirm POD executed successfully\n",
     "# ----------------------------------------\n",
     "print(\"Last log message by example_multicase POD: finished successfully!\")"
    ],

--- a/diagnostics/example_notebook/script.py
+++ b/diagnostics/example_notebook/script.py
@@ -1,0 +1,4 @@
+# script to showcase launching external scripts in the notebook
+
+def HelloWorld():
+    print("Hello, world!")


### PR DESCRIPTION
**Description**
As notebooks become a feature that may be available to POD devs in the near future, I though it would be a good idea to update the example to showcase how external scripts would have to be called from the notebook in the MDTF-framework.

**How Has This Been Tested?**
Ran on GFDL workstation using synthetic data

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [x] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [x] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
