### PR TITLE
add function to normalize all time coord units

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -918,6 +918,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             ds_end = self.cast_to_cftime(ds_end_time, cal)
         date_range_cf_start = self.cast_to_cftime(case_date_range.start.lower, cal)
         date_range_cf_end = self.cast_to_cftime(case_date_range.end.lower, cal)
+
         if ds_start < date_range_cf_start and ds_end < date_range_cf_start or \
            ds_end > date_range_cf_end and ds_start > date_range_cf_end:
             new_xr_ds = None
@@ -933,7 +934,8 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             new_xr_ds = xr_ds.sel({time_coord.name: slice(ds_start, date_range_cf_end)})
         # dataset contains all of requested date range
         elif date_range_cf_start>=ds_start and date_range_cf_end<=ds_end:
-            new_xr_ds = xr_ds.sel({time_coord.name: slice(date_range_cf_start, date_range_cf_end)})
+            new_xr_ds = xr_ds.sel({time_coord.name: slice(date_range_cf_start, date_range_cf_end)}
+)
         return new_xr_ds
 
     def check_group_daterange(self, df: pd.DataFrame, date_range: util.DateRange,

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -1014,30 +1014,80 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         # hit an exception; return empty DataFrame to signify failure
         return pd.DataFrame(columns=group_df.columns)
 
-    def normalize_time_units(self, subset_dict: dict, log=_log) -> dict:
+    def normalize_time_units(self, subset_dict: dict, time_coord, log=_log) -> dict:
         """ 
-        Some datasets will have the time units defined based on each individual file.
-        This function updates each time unit to rely on the earliest year grabbed
-        in the query stage.
+        Some datasets will have the time units that are different in each individual file.
+        This function updates each time unit to rely on the earliest year grabbed in the
+        query stage.
+
+        This function assumes the time coord units attr will be of the form "{unit} since ????".
         """
-        time_units = [subset_dict[f].time.units for f in list(subset_dict)]
-        
-        if len(set(time_units)) > 1:
-            if all(["days since " in u for u in time_units]):
-                #assumes "days since ????" unit format
-                start = np.sort([int(u.replace("days since ", "")[:4]) for u in time_units])[0]
-                new_unit = f"days since {start}-01-01 00:00:00"
+
+        time_units = np.sort([subset_dict[f].time.units for f in list(subset_dict)])
+        tn = time_coord.name #abbreviate        
+
+        # assumes each dataset has the same calendar
+        cal = 'noleap'
+        if 'calendar' in subset_dict[list(subset_dict)[0]][tn].attrs:
+            cal = subset_dict[list(subset_dict)[0]][tn].attrs['calendar']
+        elif 'calendar' in subset_dict[list(subset_dict)[0]][tn].encoding:
+            cal = subset_dict[list(subset_dict)[0]][tn].encoding['calendar'] 
+ 
+        if len(set(time_units)) > 1: # check if each dataset has the different time coord units
+            # check if time coord units are in the form "{unit} since {date}"
+            # they can be different units as this function converts to the earliest case
+            if all(["since" in u for u in time_units]):
+                start_unit = time_units[0].split(" ")[0] 
+                start_str = " ".join(time_units[0].split(" ")[2:])
+                start_cft = dl.str_to_cftime(
+                                start_str.replace(" ","").replace(":", "").replace("-", ""),
+                                calendar=cal
+                            )
+                new_unit_str = f"{start_unit} since {start_str}"
+
+                # dictionary of how many seconds are in each time unit
+                seconds_in = {
+                    "seconds": 1.0,
+                    "minutes": 60.0,
+                    "hours": 3600.0,
+                    "days": 86400.0,
+                    "weeks": 604800.0, # these are rarer and vague cases (they could be problematic)
+                    "months": 2628000.0, # seconds in common year (365 days) / 12
+                    "years": 31536000.0 # common year (365 days)
+                }
+
+
                 for f in list(subset_dict):
-                    current = int(subset_dict[f].time.units.replace("days since ", "")[:4])
-                    if current > start:
-                        subset_dict[f].coords['time'] = subset_dict[f].time.assign_attrs(
-                        units=new_unit
+                    current_unit = subset_dict[f][time_coord.name].units.split(" ")[0].lower()
+                    current_str = " ".join(subset_dict[f][tn].units.split(" ")[2:])
+                    current_cft = dl.str_to_cftime(
+                                  current_str.replace(" ","").replace(":", "").replace("-", ""),
+                                  calendar=cal
+                                  )
+
+                    #TODO: add logic to add year values for different calendars
+        
+                    if current_cft > start_cft:
+                        # get difference between current files unit reference point and earliest found
+                        diff = ((current_cft-start_cft).total_seconds())/seconds_in[start_unit] 
+
+                        subset_dict[f].coords['time'] = subset_dict[f][tn].assign_attrs(
+                            units=new_unit_str
                         )
-                        for i, v in enumerate(subset_dict[f].time.values):
-                            subset_dict[f].coords['time'].values[i] = v + 365*(current-start) + 1
+                        
+                        # convert current unit if it is not the same as the earliest reference
+                        if current_unit != start_unit:
+                             factor = seconds_in[current_unit]/seconds_in[start_unit]
+                        else:
+                            factor = 1.0
+                        
+                        # change the values in the dataset
+                        for i, v in enumerate(subset_dict[f][tn].values):
+                            subset_dict[f].coords[tn].values[i] = factor*v + diff
             else:
                 raise AttributeError("Different units were found for time coord in each file. "
-                      "We were unable to normalize due to the units not being in 'days since ' format")
+                      "We were unable to normalize due to the units not being in '{unit} since ' format")
+        
         return subset_dict
 
     def query_catalog(self,
@@ -1151,7 +1201,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 # tl;dr hic sunt dracones
                 var_xr = []
                 if not var.is_static:
-                    cat_subset_dict = self.normalize_time_units(cat_subset_dict)
+                    cat_subset_dict = self.normalize_time_units(cat_subset_dict, var.T)
                     time_sort_dict = {f: cat_subset_dict[f].time.values[0]
                                       for f in list(cat_subset_dict)}
                     time_sort_dict = dict(sorted(time_sort_dict.items(), key=lambda item: item[1]))

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -934,8 +934,8 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             new_xr_ds = xr_ds.sel({time_coord.name: slice(ds_start, date_range_cf_end)})
         # dataset contains all of requested date range
         elif date_range_cf_start>=ds_start and date_range_cf_end<=ds_end:
-            new_xr_ds = xr_ds.sel({time_coord.name: slice(date_range_cf_start, date_range_cf_end)}
-)
+            new_xr_ds = xr_ds.sel({time_coord.name: slice(date_range_cf_start, date_range_cf_end)})
+
         return new_xr_ds
 
     def check_group_daterange(self, df: pd.DataFrame, date_range: util.DateRange,


### PR DESCRIPTION
**Description**
@nishsilva found an issue (#730) where his data couldn't get through crop_date_range. This was caused by the fact that the calendar attribute was hidden in the encoding of the time coord. After this, a new function had to be made to allow files that have differing time_units to pass through the preprocessor.

Associated issue #730  

**How Has This Been Tested?**
Tested with ECMWF-LR output on my workstation to launch Nish's POD. I also tested the seaice_suite and Wheeler_Kiladis.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
