### PR TITLE
del bounds attr from coord in drop_attributes()

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -852,6 +852,10 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         for att in drop_atts:
             if xr_ds.get(att, None) is not None:
                 xr_ds = xr_ds.drop_vars(att)
+                for coord in xr_ds.coords:
+                    if 'bounds' in xr_ds[coord].attrs:
+                        if xr_ds[coord].attrs['bounds'] == att:
+                            del xr_ds[coord].attrs['bounds']
         return xr_ds
 
     def check_multichunk(self, group_df: pd.DataFrame, case_dr, log) -> pd.DataFrame:

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -849,6 +849,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                      'average_T1',
                      'height',
                      'date']
+        # TODO: find a suitable answer to conflicts in xarray merging (i.e. nctoolkit)
         for att in drop_atts:
             if xr_ds.get(att, None) is not None:
                 xr_ds = xr_ds.drop_vars(att)

--- a/src/xr_parser.py
+++ b/src/xr_parser.py
@@ -1072,7 +1072,7 @@ class DefaultDatasetParser:
         expectations based on the model's convention (*our_var*), for the bounds
         on the dimension coordinate *our_coord*.
         """
-        if len(ds.cf.bounds) > 0:
+        if len(ds.cf.bounds.get(ds_coord_name, [])) > 0:
             bounds = ds.cf.get_bounds(ds_coord_name)
         elif hasattr(ds[ds_coord_name], 'attrs'):
             if ds[ds_coord_name].attrs.get('bounds', None):


### PR DESCRIPTION
**Description**
The bounds attr was still found in the time coord after the bounds data was dropped. This PR makes sure this attribute is deleted from the coord. It also changes the conditional of an If statement to make sure we are only reconciling the variable asked by the function call.

Associated issue #730  

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
