### PR TITLE
add new --freq flag in mdtf-test-data to docs and tests

### DIFF
--- a/.github/workflows/mdtf_tests.yml
+++ b/.github/workflows/mdtf_tests.yml
@@ -90,9 +90,9 @@ jobs:
         pip install mdtf-test-data
         mkdir mdtf_test_data ; cd mdtf_test_data
         # generate the data and run unit tests
-        mdtf_synthetic.py -c GFDL --startyear 1 --nyears 10 --unittest
+        mdtf_synthetic.py -c GFDL --startyear 1 --nyears 10 --freq day --unittest
         mdtf_synthetic.py -c NCAR --startyear 1975 --nyears 7
-        mdtf_synthetic.py -c CMIP --startyear 1990 --nyears 20
+        mdtf_synthetic.py -c CMIP --startyear 1990 --nyears 20 --freq day mon
         cd ../
         mkdir wkdir
         ## make input data directories

--- a/README.md
+++ b/README.md
@@ -224,8 +224,8 @@ mamba env create --force -q -f ./src/conda/_env_synthetic_data.yml
 conda activate _MDTF_synthetic_data
 pip install mdtf-test-data
 mkdir mdtf_test_data && cd mdtf_test_data
-mdtf_synthetic.py -c CMIP --startyear 1980 --nyears 5
-mdtf_synthetic.py -c CMIP --startyear 1985 --nyears 5
+mdtf_synthetic.py -c CMIP --startyear 1980 --nyears 5 --freq day
+mdtf_synthetic.py -c CMIP --startyear 1985 --nyears 5 --freq day
 ```
 Then, modify the ``path`` entries in diagnostic/example_multicase/esm_catalog_CMIP_synthetic_r1i1p1f1_gr1.csv, and
 the `"catalog_file":` path in diagnostic/example_multicase/esm_catalog_CMIP_synthetic_r1i1p1f1_gr1.json to include the

--- a/doc/sphinx/ref_container.rst
+++ b/doc/sphinx/ref_container.rst
@@ -58,8 +58,8 @@ We generate our synthetic data by running:
       micromamba activate _MDTF_synthetic_data
       pip install mdtf-test-data
       mkdir mdtf_test_data && cd mdtf_test_data
-      mdtf_synthetic.py -c CMIP --startyear 1980 --nyears 5
-      mdtf_synthetic.py -c CMIP --startyear 1985 --nyears 5
+      mdtf_synthetic.py -c CMIP --startyear 1980 --nyears 5 --freq day
+      mdtf_synthetic.py -c CMIP --startyear 1985 --nyears 5 --freq day
 
 Now would be a good time to generate a catalog for the synthetic data, but, in the sake
 of testing, we provide a catalog for the files needed to run the example POD.

--- a/doc/sphinx/start_install.rst
+++ b/doc/sphinx/start_install.rst
@@ -276,8 +276,8 @@ using the configuration in the
     % conda activate _MDTF_synthetic_data
     % pip install mdtf-test-data
     % mkdir mdtf_test_data && cd mdtf_test_data
-    % mdtf_synthetic.py -c CMIP --startyear 1980 --nyears 5
-    % mdtf_synthetic.py -c CMIP --startyear 1985 --nyears 5
+    % mdtf_synthetic.py -c CMIP --startyear 1980 --nyears 5 --freq day
+    % mdtf_synthetic.py -c CMIP --startyear 1985 --nyears 5 --freq day
 
 Obtaining supporting data for 3rd-generation and older single-run PODs
 -------------------------------------------------------------------------

--- a/templates/module_config.jsonc
+++ b/templates/module_config.jsonc
@@ -15,8 +15,8 @@
 // > pip install mdtf-test-data
 // > cd <root directory>/mdtf
 // > mkdir mdtf_test_data && cd mdtf_test_data
-// > mdtf_synthetic.py -c CMIP --startyear 1980 --nyears 5
-// > mdtf_synthetic.py -c CMIP --startyear 1985 --nyears 5
+// > mdtf_synthetic.py -c CMIP --startyear 1980 --nyears 5 --freq day
+// > mdtf_synthetic.py -c CMIP --startyear 1985 --nyears 5 --freq day
 // Note that MODEL_DATA_ROOT assumes that mdtf_test_data is one directory above MDTF-diagnostics
 // in this sample config file
 {

--- a/templates/runtime_config.jsonc
+++ b/templates/runtime_config.jsonc
@@ -15,8 +15,8 @@
 // > pip install mdtf-test-data
 // > cd <root directory>/mdtf
 // > mkdir mdtf_test_data && cd mdtf_test_data
-// > mdtf_synthetic.py -c CMIP --startyear 1980 --nyears 5
-// > mdtf_synthetic.py -c CMIP --startyear 1985 --nyears 5
+// > mdtf_synthetic.py -c CMIP --startyear 1980 --nyears 5 --freq day
+// > mdtf_synthetic.py -c CMIP --startyear 1985 --nyears 5 --freq day
 // Note that MODEL_DATA_ROOT assumes that mdtf_test_data is one directory above MDTF-diagnostics
 // in this sample config file
 {


### PR DESCRIPTION
**Description**
In the latest mdtf-test-data (1.0.9), the user is given a flag to set the frequency of the generated data. It also allows for the user to easily throw custom yml's into a direct install for more freq options for each data type. This PR adds the flag into the CI tests and documentation.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
