### PR TITLE
Update documentation with Globus links

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,16 +116,17 @@ for, the Windows Subsystem for Linux.
 
 ## 2. Download the sample data
 
-Supporting observational data and sample model data are available via anonymous FTP at [ftp://ftp.cgd.ucar.edu/archive/mdtf](ftp://ftp.cgd.ucar.edu/archive/mdtf).
-- Digested observational data: run ` wget ftp://ftp.cgd.ucar.edu/archive/mdtf/obs_data_latest/\*` or download the
-  collection "NCAR CGD Anon" from [Globus](https://www.globus.org/)
-- NCAR-CESM-CAM sample data (12.3 Gb): model.QBOi.EXP1.AMIP.001.tar 
-  (ftp://ftp.cgd.ucar.edu/archive/mdtf/model.QBOi.EXP1.AMIP.001.tar)
+Supporting observational data and sample model data are available via 
+Globus.
+-  [Digested observational data](https://app.globus.org/file-manager?origin_id=87726236-cbdd-4a91-a904-7cc1c47f8912)
 - NOAA-GFDL-CM4 sample data (4.8 Gb): model.GFDL.CM4.c96L32.am4g10r8.tar
   (ftp://ftp.cgd.ucar.edu/archive/mdtf/model.GFDL.CM4.c96L32.am4g10r8.tar)
+- [CESM2-CAM6 Coupled model timeslice data, individual files]
+  (https://app.globus.org/file-manager?origin_id=200c3a02-0c49-4e3c-ad24-4a24db9b1c2d&origin_path=%2F)
+- [CESM2-CAM4 Atmosphere timeslice data (QBOi case) tar or individual files] 
+  (https://app.globus.org/file-manager?origin_id=52f097f5-b6ba-4cbb-8c10-8e17fa2b9bf4&origin_path=%2F)
 
-Note that the above paths are symlinks to the most recent versions of the data and will be reported as zero bytes in an FTP client.
-
+For tar files tranfered over ftp, please note that the above paths are symlinks to the most recent versions of the data and will be reported as zero bytes in an FTP client.
 Running `tar -xvf [filename].tar` will extract the contents in the following hierarchy under the `mdtf` directory:
 
 ```

--- a/doc/sphinx/pod_requirements.rst
+++ b/doc/sphinx/pod_requirements.rst
@@ -111,8 +111,11 @@ Sample and supporting data submission
 -------------------------------------
 
 Data hosting for the MDTF framework is currently managed manually. The data
-is hosted via anonymous FTP on UCAR's servers. Download the sample data by
-running :bash:`wget ftp://ftp.cgd.ucar.edu/archive/mdtf/obs_data_latest/\*`
+is hosted via Globus on UCAR's machines. Download the sample data at 
+- `Digested observational data (Globus) <https://app.globus.org/file-manager?origin_id=87726236-cbdd-4a91-a904-7cc1c47f8912>`__.
+- NOAA-GFDL-CM4 sample data (FTP 4.8 Gb): `model.GFDL.CM4.c96L32.am4g10r8.tar <ftp://ftp.cgd.ucar.edu/archive/mdtf/model.GFDL.CM4.c96L32.am4g10r8.tar>`__.
+- `NCAR-CESM-CAM4 Atmosphere Model sample data MDTFv2 (Globus 12.6 Gb tar file, QBOi case) <https://app.globus.org/file-manager?origin_id=52f097f5-b6ba-4cbb-8c10-8e17fa2b9bf4&origin_path=%2F>`__.
+- `NCAR-CESM2-CAM6 Coupled Model sample data MDTFv3 (Globus, individual files) <https://app.globus.org/file-manager?origin_id=200c3a02-0c49-4e3c-ad24-4a24db9b1c2d&origin_path=%2F>`__.
 
 
 Digested observational or supporting data
@@ -154,13 +157,13 @@ code and data provided.
        MJO_suite/ERA.v200.EOF.summer-0.png
        MJO_suite/ERA.u200.EOF.summer-1.png
 
-After following the above instructions, please refer to 
-`the GitHub Discussion on transferring obs_data <https://github.com/NOAA-GFDL/MDTF-diagnostics/discussions/125>`__
-or email Dani Coleman at bundy at ucar dot edu or contact your liaison on the MDTF Leads Team.
+After following the above instructions, please use Globus to transfer a tar file of your data,
+with the name $pod_name.$tartail.tar
+`MDTF Share (for incoming data from POD developers) <https://app.globus.org/file-manager?origin_id=620e84f2-1f5b-46b7-addd-06e9ba44cfac&origin_path=%2F">`__.
+Then email Dani Coleman at bundy at ucar dot edu or contact your liaison on the MDTF Leads Team.
 
-Files will be posted for Guest/anonymous access :
-ftp://ftp.cgd.ucar.edu/archive/mdtf/obs_data_latest/{$pod_name}.latest.tar
-with 'latest' pointing to the date-or-version-tagged tar file
+Files will be posted on Globus
+- `Digested observational data (Globus) <https://app.globus.org/file-manager?origin_id=87726236-cbdd-4a91-a904-7cc1c47f8912>`__.
 
 Note that prior to version 3, obs_data from all PODs was consolidated in one
 tar file. To assist in usability as the number of PODs grow, they will now
@@ -170,8 +173,9 @@ files on the developer.
 Sample model data
 ^^^^^^^^^^^^^^^^^
 
-For PODs dealing with atmospheric phenomena, we recommend that you use sample data from the following sources,
+We recommend that you use sample data from the following sources,
 if applicable:
 
-- A timeslice run of `NCAR CAM5 <https://www.earthsystemgrid.org/dataset/ucar.cgd.ccsm4.NOAA-MDTF.html>`__ 
-- A timeslice run of `GFDL AM4 <http://data1.gfdl.noaa.gov/MDTF/>`__ (contact the leads for password).
+- NOAA-GFDL-CM4 sample data (FTP 4.8 Gb): `model.GFDL.CM4.c96L32.am4g10r8.tar <ftp://ftp.cgd.ucar.edu/archive/mdtf/model.GFDL.CM4.c96L32.am4g10r8.tar>`__.
+- `NCAR-CESM2-CAM4 Atmosphere Model sample data MDTFv2 (Globus 12.6 Gb tar file, QBOi case) <https://app.globus.org/file-manager?origin_id=52f097f5-b6ba-4cbb-8c10-8e17fa2b9bf4&origin_path=%2F>`__.
+- `NCAR-CESM2-CAM6 Coupled Model sample data MDTFv3 (Globus, individual files) <https://app.globus.org/file-manager?origin_id=200c3a02-0c49-4e3c-ad24-4a24db9b1c2d&origin_path=%2F>`__.

--- a/doc/sphinx/start_config.rst
+++ b/doc/sphinx/start_config.rst
@@ -28,7 +28,7 @@ the package. The currently recognized conventions are:
 * ``CESM``: Variable names and units used in the default output of models developed at the
   `National Center for Atmospheric Research <https://ncar.ucar.edu>`__, such as
   `CAM <https://www.cesm.ucar.edu/models/cesm2/atmosphere/>`__ (all versions) and
-  `CESM2 <https://www.cesm.ucar.edu/models/cesm2/>`__.
+  `CESM <https://www.cesm.ucar.edu/models/cesm2/>`__.
 
 * ``GFDL``: Variable names and units used in the default output of models developed at the
   `Geophysical Fluid Dynamics Laboratory <https://www.gfdl.noaa.gov/>`__, such as

--- a/doc/sphinx/start_install.rst
+++ b/doc/sphinx/start_install.rst
@@ -283,17 +283,18 @@ Obtaining supporting data for 3rd-generation and older single-run PODs
 -------------------------------------------------------------------------
 
 Supporting observational data and sample model data for second and third generation single-run PODs are available
-via anonymous FTP from ftp://ftp.cgd.ucar.edu/archive/mdtf. The observational data is required for the PODs’ operation,
+via globus. The observational data is required for the PODs’ operation,
 while the sample model data is optional and only needed for test and demonstration purposes. The files you will need
 to download are:
 
-- Digested observational data (159 Mb): `MDTF_v2.1.a.obs_data.tar <ftp://ftp.cgd.ucar.edu/archive/mdtf/MDTF_v2.1.a.obs_data.tar>`__.
-- NCAR-CESM-CAM sample data (12.3 Gb): `model.QBOi.EXP1.AMIP.001.tar <ftp://ftp.cgd.ucar.edu/archive/mdtf/model.QBOi.EXP1.AMIP.001.tar>`__.
-- NOAA-GFDL-CM4 sample data (4.8 Gb): `model.GFDL.CM4.c96L32.am4g10r8.tar <ftp://ftp.cgd.ucar.edu/archive/mdtf/model.GFDL.CM4.c96L32.am4g10r8.tar>`__.
+- `Digested observational data (Globus) <https://app.globus.org/file-manager?origin_id=87726236-cbdd-4a91-a904-7cc1c47f8912>`__.
+- NOAA-GFDL-CM4 sample data (FTP 4.8 Gb): `model.GFDL.CM4.c96L32.am4g10r8.tar <ftp://ftp.cgd.ucar.edu/archive/mdtf/model.GFDL.CM4.c96L32.am4g10r8.tar>`__.
+- `NCAR-CESM2-CAM4 Atmosphere Model sample data MDTFv2 (Globus 12.6 Gb tar file, QBOi case) <https://app.globus.org/file-manager?origin_id=52f097f5-b6ba-4cbb-8c10-8e17fa2b9bf4&origin_path=%2F>`__.
+- `NCAR-CESM2-CAM6 Coupled Model sample data MDTFv3 (Globus, individual files) <https://app.globus.org/file-manager?origin_id=200c3a02-0c49-4e3c-ad24-4a24db9b1c2d&origin_path=%2F>`__.
 
-The default single-run test case uses the ``QBOi.EXP1.AMIP.001`` sample dataset, and the ``GFDL.CM4.c96L32.am4g10r8``
+The default single-run test case uses the ``QBOi`` sample dataset, and the ``GFDL.CM4.c96L32.am4g10r8``
 sample dataset is only for testing the `MJO Propagation and Amplitude POD <../sphinx_pods/MJO_prop_amp.html>`__.
-Note that the above paths are symlinks to the most recent versions of the data, and will be reported as having
+Note that the above FTP paths are symlinks to the most recent versions of the data, and will be reported as having
 a size of zero bytes in an FTP client.
 
 Download these files and extract the contents in the following directory hierarchy under the ``mdtf`` directory:


### PR DESCRIPTION
**Description**
Updated documentation with Globus links for input (digested) obs_data, sample CESM data and incoming share directory for POD developers.
        modified:   README.md
        modified:   doc/sphinx/pod_requirements.rst
        modified:   doc/sphinx/start_config.rst
        modified:   doc/sphinx/start_install.rst

[Obs_data (digested, distributed to users)](https://app.globus.org/file-manager?origin_id=87726236-cbdd-4a91-a904-7cc1c47f8912&origin_path=%2F")
[Share (for incoming data from POD developers)](https://app.globus.org/file-manager?origin_id=620e84f2-1f5b-46b7-addd-06e9ba44cfac&origin_path=%2F")
[Timeslice CESM Data MDTFv3](https://app.globus.org/file-manager?origin_id=200c3a02-0c49-4e3c-ad24-4a24db9b1c2d&origin_path=%2F) 
[Timeslice CESM Data MDTFv1 (QBOi case)](https://app.globus.org/file-manager?origin_id=52f097f5-b6ba-4cbb-8c10-8e17fa2b9bf4&origin_path=%2F")


**How Has This Been Tested?**
I don't see how to test the sphinx documentation because the link from the code base in GH looks to contain the old files. Let me know if there is something I can run to generate a test version, because the links definitely should be checked!

**Checklist:**
- [GH says mergable ] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
