### PR TITLE
i,j to lat lon

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -8,6 +8,8 @@ import dataclasses
 import datetime
 import importlib
 import pandas as pd
+from dask.bag.core import groupby_disk
+
 from src import util, varlist_util, translation, xr_parser, units
 from src.util import datelabel as dl
 import cftime
@@ -845,9 +847,6 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
     def drop_attributes(self, xr_ds: xr.Dataset) -> xr.Dataset:
         """ Drop attributes that cause conflicts with xarray dataset merge"""
         drop_atts = ['average_T2',
-                     'time_bnds',
-                     'lat_bnds',
-                     'lon_bnds',
                      'average_DT',
                      'average_T1',
                      'height',
@@ -1477,7 +1476,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         ds.attrs['history'] = hist
         return ds
 
-    def write_dataset(self, var, ds):
+    def write_dataset(self, var: varlist_util.VarlistEntry, ds: xr.Dataset):
         """Writes processed Dataset *ds* to location specified by the
         ``dest_path`` attribute of *var*, using xarray `to_netcdf()
         <https://xarray.pydata.org/en/stable/generated/xarray.Dataset.to_netcdf.html>`__.
@@ -1486,11 +1485,24 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         os.makedirs(os.path.dirname(var.dest_path), exist_ok=True)
         var_ds = ds[var.translation.name].to_dataset()
         var_ds = var_ds.rename_vars(name_dict={var.translation.name: var.name})
-        var.log.info("Writing '%s'.", var.dest_path, tags=util.ObjectLogTag.OUT_FILE)
         if var.is_static:
             unlimited_dims = []
         else:
             unlimited_dims = [var.T.name]
+        # append other grid types here as needed
+        irregular_grids = {'tripolar'}
+        if ds.attrs.get('grid', None) is not None:
+            # search for tripolar grid type
+            for g in irregular_grids:
+                grid_search = re.compile(g, re.IGNORECASE)
+                grid_regex_result = grid_search.search(ds.attrs.get('grid'))
+                if grid_regex_result is not None:
+                    # add variables not included in xarray dataset
+                    append_vars = list(set([v for v in ds.variables]).difference([v for v in var_ds.variables]))
+                    for v in append_vars:
+                        v_dataset = ds[v].to_dataset()
+                        var_ds = xr.merge([var_ds, v_dataset])
+
 
         # The following block is retained for time comparison with dask delayed write procedure
         # var_ds.to_netcdf(
@@ -1503,6 +1515,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
 
         # Uncomment the timing lines and log calls if desired
         # start_time = time.monotonic()
+        var.log.info("Writing '%s'.", var.dest_path, tags=util.ObjectLogTag.OUT_FILE)
         delayed_write = var_ds.to_netcdf(
             path=var.dest_path,
             mode='w',
@@ -1542,6 +1555,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 except Exception as exc:
                     raise util.chain_exc(exc, f"writing data for {var.full_name}.",
                                          util.DataPreprocessEvent)
+
 
             # del ds  # shouldn't be necessary
 
@@ -1648,7 +1662,6 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 elif not var.is_static:
                     d.update({'frequency': var.T.frequency.unit})
                 cat_entries.append(d)
-
         # create a Pandas dataframe from the catalog entries
 
         cat_df = pd.DataFrame(cat_entries)

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -1492,13 +1492,16 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         # append other grid types here as needed
         irregular_grids = {'tripolar'}
         if ds.attrs.get('grid', None) is not None:
-            # search for tripolar grid type
+            # search for irregular grid types
             for g in irregular_grids:
                 grid_search = re.compile(g, re.IGNORECASE)
                 grid_regex_result = grid_search.search(ds.attrs.get('grid'))
                 if grid_regex_result is not None:
-                    # add variables not included in xarray dataset
-                    append_vars = list(set([v for v in ds.variables]).difference([v for v in var_ds.variables]))
+                    # add variables not included in xarray dataset if dims correspond to vertices and bounds
+                    append_vars =\
+                        (list(set([v for v in ds.variables
+                                   if 'vertices' in ds[v].dims
+                                   or 'bnds' in ds[v].dims]).difference([v for v in var_ds.variables])))
                     for v in append_vars:
                         v_dataset = ds[v].to_dataset()
                         var_ds = xr.merge([var_ds, v_dataset])

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -8,8 +8,6 @@ import dataclasses
 import datetime
 import importlib
 import pandas as pd
-from dask.bag.core import groupby_disk
-
 from src import util, varlist_util, translation, xr_parser, units
 from src.util import datelabel as dl
 import cftime

--- a/src/xr_parser.py
+++ b/src/xr_parser.py
@@ -1133,7 +1133,7 @@ class DefaultDatasetParser:
         if our_axes_set == ds_axes_set:
             # check dimension coordinate names, std_names, units, bounds
             for coord in our_var.dim_axes.values():
-                # check for irregular grid coordinates
+                # check for irregular grid coordinates and skip them if found
                 coord_search = re.compile('[ij]')
                 coord_regex_result = coord_search.fullmatch(ds_axes[coord.axis])
                 if coord_regex_result is None:

--- a/src/xr_parser.py
+++ b/src/xr_parser.py
@@ -1133,14 +1133,20 @@ class DefaultDatasetParser:
         if our_axes_set == ds_axes_set:
             # check dimension coordinate names, std_names, units, bounds
             for coord in our_var.dim_axes.values():
-                ds_coord_name = ds_axes[coord.axis]
-                self.reconcile_names(coord, ds, ds_coord_name, overwrite_ours=True)
-                if coord.axis == 'T':
+                # check for irregular grid coordinates
+                coord_search = re.compile('[ij]')
+                coord_regex_result = coord_search.fullmatch(ds_axes[coord.axis])
+                if coord_regex_result is None:
+                    ds_coord_name = ds_axes[coord.axis]
+                    self.reconcile_names(coord, ds, ds_coord_name, overwrite_ours=True)
+                    if coord.axis == 'T':
                     # special case for time coordinate
-                    self.reconcile_time_units(coord, ds[ds_coord_name])
+                        self.reconcile_time_units(coord, ds[ds_coord_name])
+                    else:
+                        self.reconcile_units(coord, ds[ds_coord_name])
+                    self.reconcile_coord_bounds(coord, ds, ds_coord_name)
                 else:
-                    self.reconcile_units(coord, ds[ds_coord_name])
-                self.reconcile_coord_bounds(coord, ds, ds_coord_name)
+                    continue
         else:
             _log.warning(f"Variable {our_var.name} has unexpected dimensionality: "
                          f" expected axes {list(our_axes_set)}, got {list(ds_axes_set)}.")


### PR DESCRIPTION
**Description**
Add logic to bypass i,j coordinates if they are present in the coords attribute of a dataset during xr_parser name check. Irregular grids may map X, Y axes to i,j coordinates instead of longitude,latitude.
Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
