### PR TITLE
fix variable_id definition in postprocessor catalog

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -842,9 +842,9 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
     def drop_attributes(self, xr_ds: xr.Dataset) -> xr.Dataset:
         """ Drop attributes that cause conflicts with xarray dataset merge"""
         drop_atts = ['average_T2',
-                     'time_bnds',
-                     'lat_bnds',
-                     'lon_bnds',
+                     #'time_bnds',
+                     #'lat_bnds',
+                     #'lon_bnds',
                      'average_DT',
                      'average_T1',
                      'height',
@@ -853,10 +853,10 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         for att in drop_atts:
             if xr_ds.get(att, None) is not None:
                 xr_ds = xr_ds.drop_vars(att)
-                for coord in xr_ds.coords:
-                    if 'bounds' in xr_ds[coord].attrs:
-                        if xr_ds[coord].attrs['bounds'] == att:
-                            del xr_ds[coord].attrs['bounds']
+                #for coord in xr_ds.coords:
+                #    if 'bounds' in xr_ds[coord].attrs:
+                #        if xr_ds[coord].attrs['bounds'] == att:
+                #            del xr_ds[coord].attrs['bounds']
         return xr_ds
 
     def check_multichunk(self, group_df: pd.DataFrame, case_dr, log) -> pd.DataFrame:
@@ -1638,6 +1638,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 d.update({'time_range': f'{util.cftime_to_str(ds_match.time.values[0]).replace('-',':')}-'
                                         f'{util.cftime_to_str(ds_match.time.values[-1]).replace('-',':')}'})
                 d.update({'standard_name': ds_match[var.name].attrs['standard_name']})
+                d.update({'variable_id': var_name})
                 cat_entries.append(d)
 
         # create a Pandas dataframe from the catalog entries

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -842,9 +842,9 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
     def drop_attributes(self, xr_ds: xr.Dataset) -> xr.Dataset:
         """ Drop attributes that cause conflicts with xarray dataset merge"""
         drop_atts = ['average_T2',
-                     #'time_bnds',
-                     #'lat_bnds',
-                     #'lon_bnds',
+                     'time_bnds',
+                     'lat_bnds',
+                     'lon_bnds',
                      'average_DT',
                      'average_T1',
                      'height',
@@ -853,10 +853,10 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         for att in drop_atts:
             if xr_ds.get(att, None) is not None:
                 xr_ds = xr_ds.drop_vars(att)
-                #for coord in xr_ds.coords:
-                #    if 'bounds' in xr_ds[coord].attrs:
-                #        if xr_ds[coord].attrs['bounds'] == att:
-                #            del xr_ds[coord].attrs['bounds']
+                for coord in xr_ds.coords:
+                    if 'bounds' in xr_ds[coord].attrs:
+                        if xr_ds[coord].attrs['bounds'] == att:
+                            del xr_ds[coord].attrs['bounds']
         return xr_ds
 
     def check_multichunk(self, group_df: pd.DataFrame, case_dr, log) -> pd.DataFrame:


### PR DESCRIPTION
**Description**
variable_id was being populated with the name of the last variable read into xarray using the catalog_attrs attribute. This fix uses the correct variable id from the translation attribute

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
