### PR TITLE
Fix pp time defs

### DIFF
--- a/src/data_sources.py
+++ b/src/data_sources.py
@@ -73,7 +73,12 @@ class DataSourceBase(util.MDTFObjectBase, util.CaseLoggerMixin):
         if var.is_static:
             freq = "fx"
         else:
-            freq = var.T.frequency
+            freq = var.T.frequency.unit
+
+        if not isinstance(freq, str):
+            freq = freq.format_local()
+        if freq == 'hr':
+            freq = '1hr'
 
         var_id = var.name
         standard_name = var.standard_name
@@ -84,11 +89,6 @@ class DataSourceBase(util.MDTFObjectBase, util.CaseLoggerMixin):
             standard_name = var.translation.standard_name
             if any(var.translation.alternate_standard_names):
                 standard_name = [var.translation.standard_name] + var.translation.alternate_standard_names
-
-        if not isinstance(freq, str):
-            freq = freq.format_local()
-        if freq == 'hr':
-            freq = '1hr'
 
         # define initial query dictionary with variable settings requirements that do not change if
         # the variable is translated

--- a/src/data_sources.py
+++ b/src/data_sources.py
@@ -54,7 +54,6 @@ class DataSourceBase(util.MDTFObjectBase, util.CaseLoggerMixin):
             if case_dict.get(att, None) is not None:
                 self.query[att] = case_dict[att]
 
-
     @property
     def _children(self):
         """Iterable of the multirun varlist that is associated with the data source object
@@ -64,29 +63,28 @@ class DataSourceBase(util.MDTFObjectBase, util.CaseLoggerMixin):
     def iter_vars_only(self, active=None):
         yield from self.varlist.iter_vars_only(active=active)
 
-    def read_varlist(self, parent, append_vars: bool=False):
+    def read_varlist(self, parent, append_vars: bool = False):
         self.varlist = varlist_util.Varlist.from_struct(parent, append_vars)
 
     def set_date_range(self, startdate: str, enddate: str):
         self.date_range = util.DateRange(start=startdate, end=enddate)
-    
+
     def set_query(self, var: varlist_util.VarlistEntry, path_regex: str):
-        date_range = var.T.range
+        if var.is_static:
+            freq = "fx"
+        else:
+            freq = var.T.frequency
+
         var_id = var.name
         standard_name = var.standard_name
         if self.query['realm'] == '':
             self.query['realm'] = var.realm
-        if var.translation.convention is not None:
+        if var.translation is not None:
             var_id = var.translation.name
             standard_name = var.translation.standard_name
             if any(var.translation.alternate_standard_names):
                 standard_name = [var.translation.standard_name] + var.translation.alternate_standard_names
-                date_range = var.translation.T.range
-        if var.is_static:
-            date_range = None
-            freq = "fx"
-        else:
-            freq = var.T.frequency
+
         if not isinstance(freq, str):
             freq = freq.format_local()
         if freq == 'hr':
@@ -98,7 +96,6 @@ class DataSourceBase(util.MDTFObjectBase, util.CaseLoggerMixin):
         self.query['path'] = path_regex
         self.query['standard_name'] = standard_name
         self.query['variable_id'] = var_id
-
 
     def translate_varlist(self,
                           var: varlist_util.VarlistEntry,
@@ -129,10 +126,11 @@ class CMIPDataSource(DataSourceBase):
     # col_spec = sampleLocalFileDataSource_col_spec
     # varlist = diagnostic.varlist
     convention: str = "CMIP"
-    
+
     def set_query(self, var: varlist_util.VarlistEntry, path_regex: str):
         super().set_query(var, path_regex)
         return
+
 
 @data_source.maker
 class CESMDataSource(DataSourceBase):
@@ -143,10 +141,11 @@ class CESMDataSource(DataSourceBase):
     # col_spec = sampleLocalFileDataSource_col_spec
     # varlist = diagnostic.varlist
     convention: str = "CESM"
-    
+
     def set_query(self, var: varlist_util.VarlistEntry, path_regex: str):
         super().set_query(var, path_regex)
         return
+
 
 @data_source.maker
 class GFDLDataSource(DataSourceBase):

--- a/src/environment_manager.py
+++ b/src/environment_manager.py
@@ -302,7 +302,7 @@ class SubprocessRuntimePODWrapper:
                 # define env vars for varlist entries without data. Name collisions
                 # are OK in this case.
                 try:
-                    self.pod_env_vars.update(var.env_vars)
+                    self.env_vars.update(var.env_vars)
                 except util.WormKeyError:
                     continue
 

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -1643,7 +1643,8 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                                         f'{util.cftime_to_str(ds_match.time.values[-1]).replace('-', ':')}'})
                 d.update({'standard_name': ds_match[var.name].attrs['standard_name']})
                 d.update({'variable_id': var_name})
-                d.update({'frequency': ds_match[var.name].attrs['frequency']})
+                if 'frequency' in ds_match[var.name].attrs:
+                    d.update({'frequency': ds_match[var.name].attrs['frequency']})
                 cat_entries.append(d)
 
         # create a Pandas dataframe from the catalog entries

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -1645,6 +1645,8 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 d.update({'variable_id': var_name})
                 if 'frequency' in ds_match[var.name].attrs:
                     d.update({'frequency': ds_match[var.name].attrs['frequency']})
+                elif not var.is_static:
+                    d.update({'frequency': var.T.frequency.unit})
                 cat_entries.append(d)
 
         # create a Pandas dataframe from the catalog entries

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -31,6 +31,7 @@ import logging
 _log = logging.getLogger(__name__)
 write_times = []
 
+
 def copy_as_alternate(old_v, **kwargs):
     """Wrapper for :py:func:`dataclasses.replace` that creates a copy of an
     existing variable (:class:`~src.varlist.VarlistEntry`) *old_v* and sets appropriate
@@ -67,6 +68,7 @@ class PreprocessorFunctionBase(abc.ABC):
       function is capable of converting into the format requested by the POD.
     - :meth:`process`, which actually implements the data format conversion.
     """
+
     def __init__(self, *args):
         """Called during Preprocessor's init."""
         pass
@@ -101,20 +103,20 @@ class PreprocessorFunctionBase(abc.ABC):
 class PercentConversionFunction(PreprocessorFunctionBase):
     """A PreprocessorFunction which convers the dependent variable's units and values,
     for the specific case of percentages. ``0-1`` are not defined in the UDUNITS-2
-    library. So, this function handles the case where we have to convert from 
+    library. So, this function handles the case where we have to convert from
     ``0-1`` to ``%``.
     """
-    
+
     _std_name_tuple = ('0-1', '%')
-    
+
     def execute(self, var, ds, **kwargs):
         var_unit = getattr(var, "units", "")
-        tv = var.translation #abbreviate
+        tv = var.translation  # abbreviate
         tv_unit = getattr(tv, "units", "")
         # 0-1 to %
         if str(tv_unit) == self._std_name_tuple[0] and str(var_unit) == self._std_name_tuple[1]:
             ds[tv.name].attrs['units'] = '%'
-            ds[tv.name].values = ds[tv.name].values*100
+            ds[tv.name].values = ds[tv.name].values * 100
             return ds
         # % to 0-1
         if str(tv_unit) == self._std_name_tuple[1] and str(var_unit) == self._std_name_tuple[0]:
@@ -123,10 +125,11 @@ class PercentConversionFunction(PreprocessorFunctionBase):
             if ds[tv.name].values[:, :, 3].max() < 1.5:
                 return ds
             else:
-                ds[tv.name].values = ds[tv.name].values/100
+                ds[tv.name].values = ds[tv.name].values / 100
                 return ds
 
         return ds
+
 
 class PrecipRateToFluxFunction(PreprocessorFunctionBase):
     """A PreprocessorFunction which converts the dependent variable's units, for
@@ -207,8 +210,8 @@ class PrecipRateToFluxFunction(PreprocessorFunctionBase):
                             v.full_name, exc, v_to_translate.standard_name)
                 return None
             v.alternates.append(v.translation)
-            #new_v = copy_as_alternate(v)
-            #new_v.translation = new_tv
+            # new_v = copy_as_alternate(v)
+            # new_v.translation = new_tv
             v.translation.name = new_tv.name
             v.translation.standard_name = new_tv.standard_name
             v.translation.units = new_tv.units
@@ -332,7 +335,7 @@ class RenameVariablesFunction(PreprocessorFunctionBase):
         tv = var.translation  # abbreviate
         rename_d = dict()
         # rename var
-        #if tv.name != var.name:
+        # if tv.name != var.name:
         #    var.log.debug("Rename '%s' variable in %s to '%s'.",
         #                  tv.name, var.full_name, var.name,
         #                  tags=util.ObjectLogTag.NC_HISTORY
@@ -890,7 +893,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                              decode_coords=True,  # parse coords attr
                              decode_times=True,
                              use_cftime=True  # use cftime instead of np.datetime6
-        )
+                             )
         cal = 'noleap'
         if 'calendar' in xr_ds[time_coord.name].attrs:
             cal = xr_ds[time_coord.name].attrs['calendar']
@@ -925,7 +928,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         date_range_cf_end = self.cast_to_cftime(case_date_range.end.lower, cal)
 
         if ds_start < date_range_cf_start and ds_end < date_range_cf_start or \
-           ds_end > date_range_cf_end and ds_start > date_range_cf_end:
+                ds_end > date_range_cf_end and ds_start > date_range_cf_end:
             new_xr_ds = None
         # dataset falls entirely within user-specified date range
         elif ds_start >= date_range_cf_start and ds_end <= date_range_cf_end:
@@ -938,7 +941,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         elif date_range_cf_start < ds_start <= date_range_cf_end <= ds_end:
             new_xr_ds = xr_ds.sel({time_coord.name: slice(ds_start, date_range_cf_end)})
         # dataset contains all of requested date range
-        elif date_range_cf_start>=ds_start and date_range_cf_end<=ds_end:
+        elif date_range_cf_start >= ds_start and date_range_cf_end <= ds_end:
             new_xr_ds = xr_ds.sel({time_coord.name: slice(date_range_cf_start, date_range_cf_end)})
 
         return new_xr_ds
@@ -960,8 +963,8 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             end_times = []
             for tr in df['time_range'].values:
                 tr = tr.replace(' ', '').replace('-', '').replace(':', '')
-                start_times.append(tr[0:len(tr)//2])
-                end_times.append(tr[len(tr)//2:])
+                start_times.append(tr[0:len(tr) // 2])
+                end_times.append(tr[len(tr) // 2:])
             df['start_time'] = pd.Series(start_times)
             df['end_time'] = pd.Series(end_times)
         else:
@@ -975,11 +978,11 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 # convert start_times to date_format for all files in query
                 df['start_time'] = start_time_vals
                 df['start_time'] = df['start_time'].apply(lambda x:
-                                                                      datetime.datetime.strptime(x, date_format))
+                                                          datetime.datetime.strptime(x, date_format))
                 # convert end_times to date_format for all files in query
                 df['end_time'] = end_time_vals
                 df['end_time'] = df['end_time'].apply(lambda x:
-                                                                datetime.datetime.strptime(x, date_format))
+                                                      datetime.datetime.strptime(x, date_format))
             # method throws ValueError if ranges aren't contiguous
             dates_df = df.loc[:, ['start_time', 'end_time']]
             date_range_vals = []
@@ -1005,10 +1008,10 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                     ds_st = cat_row['start_time']
                     ds_et = cat_row['end_time']
                 # date range includes entire or part of dataset
-                if ds_st>=date_range.start.lower and ds_et<date_range.end.upper or \
-                        ds_st<date_range.end.lower and ds_et>=date_range.start.lower or \
+                if ds_st >= date_range.start.lower and ds_et < date_range.end.upper or \
+                        ds_st < date_range.end.lower and ds_et >= date_range.start.lower or \
                         ds_st <= date_range.end.lower < ds_et:
-                        return_df.append(cat_row)
+                    return_df.append(cat_row)
 
             return pd.DataFrame.from_dict(return_df)
         except ValueError:
@@ -1022,7 +1025,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         return pd.DataFrame(columns=group_df.columns)
 
     def normalize_time_units(self, subset_dict: dict, time_coord, log=_log) -> dict:
-        """ 
+        """
         Some datasets will have the time units that are different in each individual file.
         This function updates each time unit to rely on the earliest year grabbed in the
         query stage.
@@ -1031,25 +1034,25 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         """
 
         time_units = np.sort([subset_dict[f].time.units for f in list(subset_dict)])
-        tn = time_coord.name #abbreviate        
+        tn = time_coord.name  # abbreviate
 
         # assumes each dataset has the same calendar
         cal = 'noleap'
         if 'calendar' in subset_dict[list(subset_dict)[0]][tn].attrs:
             cal = subset_dict[list(subset_dict)[0]][tn].attrs['calendar']
         elif 'calendar' in subset_dict[list(subset_dict)[0]][tn].encoding:
-            cal = subset_dict[list(subset_dict)[0]][tn].encoding['calendar'] 
- 
-        if len(set(time_units)) > 1: # check if each dataset has the different time coord units
+            cal = subset_dict[list(subset_dict)[0]][tn].encoding['calendar']
+
+        if len(set(time_units)) > 1:  # check if each dataset has the different time coord units
             # check if time coord units are in the form "{unit} since {date}"
             # they can be different units as this function converts to the earliest case
             if all(["since" in u for u in time_units]):
-                start_unit = time_units[0].split(" ")[0] 
+                start_unit = time_units[0].split(" ")[0]
                 start_str = " ".join(time_units[0].split(" ")[2:])
                 start_cft = dl.str_to_cftime(
-                                start_str.replace(" ","").replace(":", "").replace("-", ""),
-                                calendar=cal
-                            )
+                    start_str.replace(" ", "").replace(":", "").replace("-", ""),
+                    calendar=cal
+                )
                 new_unit_str = f"{start_unit} since {start_str}"
 
                 # dictionary of how many seconds are in each time unit
@@ -1058,43 +1061,42 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                     "minutes": 60.0,
                     "hours": 3600.0,
                     "days": 86400.0,
-                    "weeks": 604800.0, # these are rarer and vague cases (they could be problematic)
-                    "months": 2628000.0, # seconds in common year (365 days) / 12
-                    "years": 31536000.0 # common year (365 days)
+                    "weeks": 604800.0,  # these are rarer and vague cases (they could be problematic)
+                    "months": 2628000.0,  # seconds in common year (365 days) / 12
+                    "years": 31536000.0  # common year (365 days)
                 }
-
 
                 for f in list(subset_dict):
                     current_unit = subset_dict[f][time_coord.name].units.split(" ")[0].lower()
                     current_str = " ".join(subset_dict[f][tn].units.split(" ")[2:])
                     current_cft = dl.str_to_cftime(
-                                  current_str.replace(" ","").replace(":", "").replace("-", ""),
-                                  calendar=cal
-                                  )
+                        current_str.replace(" ", "").replace(":", "").replace("-", ""),
+                        calendar=cal
+                    )
 
-                    #TODO: add logic to add year values for different calendars
-        
+                    # TODO: add logic to add year values for different calendars
+
                     if current_cft > start_cft:
                         # get difference between current files unit reference point and earliest found
-                        diff = ((current_cft-start_cft).total_seconds())/seconds_in[start_unit] 
+                        diff = ((current_cft - start_cft).total_seconds()) / seconds_in[start_unit]
 
                         subset_dict[f].coords['time'] = subset_dict[f][tn].assign_attrs(
                             units=new_unit_str
                         )
-                        
+
                         # convert current unit if it is not the same as the earliest reference
                         if current_unit != start_unit:
-                             factor = seconds_in[current_unit]/seconds_in[start_unit]
+                            factor = seconds_in[current_unit] / seconds_in[start_unit]
                         else:
                             factor = 1.0
-                        
+
                         # change the values in the dataset
                         for i, v in enumerate(subset_dict[f][tn].values):
-                            subset_dict[f].coords[tn].values[i] = factor*v + diff
+                            subset_dict[f].coords[tn].values[i] = factor * v + diff
             else:
                 raise AttributeError("Different units were found for time coord in each file. "
-                      "We were unable to normalize due to the units not being in '{unit} since ' format")
-        
+                                     "We were unable to normalize due to the units not being in '{unit} since ' format")
+
         return subset_dict
 
     def query_catalog(self,
@@ -1127,8 +1129,9 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             path_regex = [re.compile(r'({})'.format(case_name))]
 
             for var in case_d.varlist.iter_vars():
-                date_range = var.T.range
-                
+                if not var.is_static:
+                    date_range = var.T.range
+
                 # define initial query dictionary with variable settings requirements that do not change if
                 # the variable is translated
                 case_d.set_query(var, path_regex)
@@ -1215,8 +1218,8 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
 
                     for k in list(time_sort_dict):
                         cat_subset_dict[k] = self.crop_date_range(date_range,
-                                             cat_subset_dict[k],
-                                             var.T)
+                                                                  cat_subset_dict[k],
+                                                                  var.T)
                         if cat_subset_dict[k] is None:
                             continue
                         else:
@@ -1243,7 +1246,8 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                             and var_xr[vname].attrs.get('standard_name', None) is None):
                         case_query_standard_name = case_d.query.get('standard_name')
                         if isinstance(case_query_standard_name, list):
-                            new_standard_name = [name for name in case_query_standard_name if name == var.translation.standard_name][0]
+                            new_standard_name = \
+                            [name for name in case_query_standard_name if name == var.translation.standard_name][0]
                         else:
                             new_standard_name = case_query_standard_name
                         var_xr[vname].attrs['standard_name'] = new_standard_name
@@ -1292,7 +1296,6 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                         xarray_ds = user_module.main(xarray_ds, v.name)
 
         return xarray_ds
-
 
     def setup(self, pod):
         """Method to do additional configuration immediately before :meth:`process`
@@ -1490,16 +1493,16 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
             unlimited_dims = [var.T.name]
 
         # The following block is retained for time comparison with dask delayed write procedure
-        #var_ds.to_netcdf(
+        # var_ds.to_netcdf(
         #    path=var.dest_path,
         #    mode='w',
         #    **self.save_dataset_kwargs,
         #    unlimited_dims=unlimited_dims
-        #)
-        #ds.close()
+        # )
+        # ds.close()
 
         # Uncomment the timing lines and log calls if desired
-        #start_time = time.monotonic()
+        # start_time = time.monotonic()
         delayed_write = var_ds.to_netcdf(
             path=var.dest_path,
             mode='w',
@@ -1509,11 +1512,11 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         )
         delayed_write.compute()
         delayed_write.close()
-        #end_time = time.monotonic()
-        #var.log.info(f'Time to write file {var.dest_path}: {str(datetime.timedelta(seconds=end_time - start_time))}')
-        #dt = datetime.timedelta(seconds=end_time - start_time)
-        #write_times.append(dt.total_seconds())
-        #var.log.info(f'Total write time: {str(sum(write_times))} s')
+        # end_time = time.monotonic()
+        # var.log.info(f'Time to write file {var.dest_path}: {str(datetime.timedelta(seconds=end_time - start_time))}')
+        # dt = datetime.timedelta(seconds=end_time - start_time)
+        # write_times.append(dt.total_seconds())
+        # var.log.info(f'Total write time: {str(sum(write_times))} s')
 
     def write_ds(self, case_list: dict,
                  catalog_subset: collections.OrderedDict,
@@ -1588,7 +1591,8 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 # todo: maybe skip this if no standard_name attribute for v in case_xr_dataset
                 v.log.info(f'Calling parse_ds for {v.name}')
                 var_xr_dataset = self.parse_ds(v, case_xr_dataset)
-                varlist_ex = [v_l.translation.name for v_l in case_list[case_name].varlist.iter_vars()]
+                varlist_ex = [v_l.translation.name for v_l in case_list[case_name].varlist.iter_vars()
+                              if v_l.translation is not None]
                 if tv_name in varlist_ex:
                     varlist_ex.remove(tv_name)
                 for v_d in var_xr_dataset.variables:
@@ -1635,10 +1639,11 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
 
                 d.update({'project_id': var.translation.convention})
                 d.update({'path': var.dest_path})
-                d.update({'time_range': f'{util.cftime_to_str(ds_match.time.values[0]).replace('-',':')}-'
-                                        f'{util.cftime_to_str(ds_match.time.values[-1]).replace('-',':')}'})
+                d.update({'time_range': f'{util.cftime_to_str(ds_match.time.values[0]).replace('-', ':')}-'
+                                        f'{util.cftime_to_str(ds_match.time.values[-1]).replace('-', ':')}'})
                 d.update({'standard_name': ds_match[var.name].attrs['standard_name']})
                 d.update({'variable_id': var_name})
+                d.update({'frequency': ds_match[var.name].attrs['frequency']})
                 cat_entries.append(d)
 
         # create a Pandas dataframe from the catalog entries

--- a/src/xr_parser.py
+++ b/src/xr_parser.py
@@ -1272,14 +1272,17 @@ class DefaultDatasetParser:
         else:
             ds_T_units = None
 
-        var_T_units = var.translation.T.units
+        if var.is_static:
+            var_T_units = None
+        else:
+            var_T_units = var.translation.T.units
 
-        if ds_T_units is not None:
+        if ds_T_units is not None and not var.is_static:
             if str(var_T_units) != str(ds_T_units):
                 var.translation.T.units = ds_T_units
                 self.log.info("Units for 'time' on var '%s' found in dataset; setting to '%s'.",
                               var.translation.name, ds_T_units)
-        else:
+        elif not var.is_static:
             var.translation.T.units = ""
             self.log.info("Units for 'time' on var '%s' not found in dataset; setting to ''.",
                           var.translation.name)


### PR DESCRIPTION
**Description**
* Fix logic in preprocessor, data_sources, and xr_parser to check variable time is_static attribute
* update frequency on a per-variable basis if the attribute is available when writing the post processed data catalog
* fix env_vars attribute reference in the subprocessPodwrapper
Associated issue #748 

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
