### PR TITLE
define frequency using var.T instead of var.T.unit in set_query

### DIFF
--- a/src/data_sources.py
+++ b/src/data_sources.py
@@ -73,7 +73,7 @@ class DataSourceBase(util.MDTFObjectBase, util.CaseLoggerMixin):
         if var.is_static:
             freq = "fx"
         else:
-            freq = var.T.frequency.unit
+            freq = var.T.frequency
 
         if not isinstance(freq, str):
             freq = freq.format_local()


### PR DESCRIPTION
Using var.T.units will yield the wrong expected values in the catalog. The units are set in the date_range methods, and values such as 'mo' will not yield results when the frequency is queried, as the expected value would 'mon'
Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
