### PR TITLE
change monthly units assigned by datelabel from 'mo' to 'mon'

### DIFF
--- a/src/util/datelabel.py
+++ b/src/util/datelabel.py
@@ -1178,7 +1178,7 @@ class DateFrequency(datetime.timedelta):
         elif s in ['seasonally', 'seasonal', 'seasons', 'season', 'se']:
             s = 'season'
         elif s in ['monthly', 'month', 'months', 'mon', 'mo']:
-            s = 'mo'
+            s = 'mon'
         elif s in ['weekly', 'weeks', 'week', 'wk', 'w']:
             s = 'wk'
         elif s in ['daily', 'day', 'days', 'dy', 'd', 'diurnal', 'diurnally']:
@@ -1203,7 +1203,7 @@ class DateFrequency(datetime.timedelta):
             return {'days': 365 * q}
         elif s == 'season':
             return {'days': 91 * q}
-        elif s == 'mo':
+        elif s == 'mon':
             return {'days': 30 * q}
         elif s == 'wk':
             return {'weeks': q}
@@ -1234,7 +1234,7 @@ class DateFrequency(datetime.timedelta):
         (defined in :meth:`src.data_manager.DataManager.dest_path`.)
         """
         if self.quantity == 1:
-            if self.unit == 'mo':
+            if self.unit == 'mon':
                 return 'mon'
             elif self.unit == 'day':
                 return 'day'


### PR DESCRIPTION
**Description**
Include a summary of the change, and link the associated issue (if applicable).  
List any dependencies that are required for this change, including libraries and variables,  
and their metadata (units, frequencies, etc...). Be sure to separate PRs and issues for new PODs and PODs currently under development.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [ ] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
