### PR TITLE
add alternate name for rsds in CMIP fieldlist

### DIFF
--- a/data/fieldlist_CMIP.jsonc
+++ b/data/fieldlist_CMIP.jsonc
@@ -274,6 +274,7 @@
       "standard_name": "surface_downwelling_shortwave_flux_in_air",
       "realm": "atmos",
       "units": "W m-2",
+      "alternate_standard_names": ["downwelling_shortwave_flux_in_sea_water"],
       "ndim": 3
     },
     "rsdt": {


### PR DESCRIPTION
**Description**
Catalogs generated from the GFDL builder will populate rsds the 'standard_name' with 'downwelling_shortwave_flux_in_sea_water'. This is a needed fix to allow the forcing_feedback POD to run with catalogs generated on CM5 data.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
