### PR TITLE
fix implementation of overwrite flag in src/output_manager.py

### DIFF
--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -534,13 +534,35 @@ class HTMLOutputManager(AbstractOutputManager,
                            self.WORK_DIR, self.OUT_DIR)
         try:
             if os.path.exists(self.OUT_DIR):
-                if not self.overwrite:
+                if self.overwrite:
+                    # if overwrite flag is true, replace OUT_DIR contents with WORK_DIR
                     self.obj.log.error("%s: '%s' exists, overwriting.",
                                        self.obj.full_name, self.OUT_DIR)
-                shutil.rmtree(self.OUT_DIR)
+                    shutil.rmtree(self.OUT_DIR)
+                    shutil.move(self.WORK_DIR, self.OUT_DIR)
+                    return
+                elif not self.overwrite:
+                    # if ovewrite flag is false, find the next suitable 'MDTF_output.v#' dir to write to
+                    if not os.path.exists(os.path.join(self.OUT_DIR, 'index.html')):
+                        # this will catch the majority of cases
+                        shutil.rmtree(self.OUT_DIR)
+                        shutil.move(self.WORK_DIR, self.OUT_DIR)
+                        return
+                    # the rest of this if statement is not strictly necessary, but may be useful for fringe edge cases
+                    # if some reason a index.html already exists in self.OUT_DIR, it will move to the next .v#
+                    out_main_dir = os.path.abspath(os.path.join(self.OUT_DIR, ".."))
+                    v_dirs = [d for d in os.listdir(out_main_dir) if 'MDTF_output.v' in d]
+                    if not v_dirs:
+                        NEW_BASE = 'MDTF_output.v1'
+                    v_nums = sorted([int(''.join(filter(str.isdigit, d))) for d in v_dirs], reverse=True)
+                    NEW_BASE = f'MDTF_output.v{v_nums[0]+1}'
+                    self.OUT_DIR = os.path.join(out_main_dir, NEW_BASE)
+                    if os.path.isdir(self.OUT_DIR):
+                        shutil.rmtree(self.OUT_DIR)
+                    shutil.move(self.WORK_DIR, self.OUT_DIR)
+                    return
         except Exception:
             raise
-        shutil.move(self.WORK_DIR, self.OUT_DIR)
 
     def verify_pod_links(self, pod):
         """Check for missing files linked to from POD's html page.

--- a/src/util/path_utils.py
+++ b/src/util/path_utils.py
@@ -60,8 +60,9 @@ class PathManagerBase:
                     self.OUTPUT_DIR = os.path.join(self._init_path('OUTPUT_DIR', config, env=env))
 
             if new_work_dir:
+                output_dir_main = os.path.abspath(os.path.join(self.OUTPUT_DIR, ".."))
                 self.WORK_DIR, ver = filesystem.bump_version(
-                    self.WORK_DIR, extra_dirs=[self.OUTPUT_DIR])
+                    self.WORK_DIR, extra_dirs=[output_dir_main])
                 self.OUTPUT_DIR, _ = filesystem.bump_version(self.OUTPUT_DIR, new_v=ver)
 
             # set root directory for TempDirManager


### PR DESCRIPTION
**Description**
When using a work dir that was not the same as the output dir, some weird behaviors were observed. This PR is more direct with happens in the output_manager to take care of these behaviors.

**How Has This Been Tested?**
Ran on workstation and GFDL analysis node

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
