### PR TITLE
Bump intake esm version

### DIFF
--- a/src/conda/_env_synthetic_data.yml
+++ b/src/conda/_env_synthetic_data.yml
@@ -7,7 +7,7 @@ dependencies:
 - numpy=1.26.4
 - netCDF4=1.6.4
 - cftime=1.6.2
-- xarray=2024.1.1
+- xarray=2025.1.2
 - setuptools=68.1.2
 - esmf=8.4.2
 - esmpy=8.4.2

--- a/src/conda/conda_env_setup.sh
+++ b/src/conda/conda_env_setup.sh
@@ -174,7 +174,7 @@ if [ "$make_envs" = "true" ]; then
 		echo "... previous env ${env_name} removed."
 	fi
         echo "Creating conda env ${env_name} in ${conda_prefix}..."
-        "$_INSTALL_EXE" env create -q -p "$conda_prefix" -f "$env_file" 
+        "$_INSTALL_EXE" env create -qy -p "$conda_prefix" -f "$env_file"
         echo "... conda env ${env_name} created."
     done
     "$_INSTALL_EXE" clean -aqy

--- a/src/conda/env_base.yml
+++ b/src/conda/env_base.yml
@@ -10,7 +10,7 @@ dependencies:
 - numpy=1.26.4
 - netCDF4=1.6.4
 - cftime=1.6.2
-- xarray=2024.1.1
+- xarray=2025.1.2
 # Note: newer versions of cf_xarray are causing issues with missing
 # xarray dataset attributes. There seem to be modifications where
 # ds.cf attributes are defined later in the process, and this clashes
@@ -19,11 +19,11 @@ dependencies:
 - matplotlib=3.8.2
 - pandas=2.2.2
 - pint=0.24.3
-- dask=2024.7.1
+- dask=2025.2.0
 - ecgtools=2024.7.31
 - cfunits=3.3.6
-- intake=0.7.0
-- intake-esm=2024.2.6
+- intake=2.0.8
+- intake-esm=2025.2.3
 - subprocess32=3.5.4
 - pyyaml=6.0.1
 - click=8.1.7

--- a/src/conda/env_base_micromamba.yml
+++ b/src/conda/env_base_micromamba.yml
@@ -12,7 +12,7 @@ dependencies:
 - numpy=1.26.4
 - netCDF4=1.6.4
 - cftime=1.6.2
-- xarray=2024.1.1
+- xarray=2025.1.2
 # Note: newer versions of cf_xarray are causing issues with missing
 # xarray dataset attributes. There seem to be modifications where
 # ds.cf attributes are defined later in the process, and this clashes
@@ -21,11 +21,11 @@ dependencies:
 - matplotlib=3.8.2
 - pandas=2.2.0
 - pint=0.24.3
-- dask=2024.1.1
+- dask=2025.2.0
 - ecgtools=2024.7.31
 - cfunits=3.3.6
-- intake=0.7.0
-- intake-esm=2024.2.6
+- intake=2.0.8
+- intake-esm=2025.2.3
 - subprocess32=3.5.4
 - pyyaml=6.0.1
 - click=8.1.7

--- a/src/conda/env_dev.yml
+++ b/src/conda/env_dev.yml
@@ -13,7 +13,7 @@ dependencies:
 - xesmf=0.8.1
 - esmf=8.4.2
 - esmpy=8.4.2
-- xarray=2024.1.1
+- xarray=2025.1.2
 - matplotlib=3.8.2
 - cartopy=0.22.0
 - cython=3.0.2
@@ -22,11 +22,11 @@ dependencies:
 - gsw=3.6.17
 - h5py=3.9.0
 - nc-time-axis=1.4.1
-- dask=2024.7.1
+- dask=2025.2.0
 - pyyaml=6.0.1
 - cfunits=3.3.6
-- intake=0.7.0
-- intake-esm=2024.2.6
+- intake=2.0.8
+- intake-esm=2025.2.3
 - kerchunk=0.2.7
 - intake-esgf=2024.12.7
 - cf_xarray=0.8.4

--- a/src/conda/env_python3_base.yml
+++ b/src/conda/env_python3_base.yml
@@ -11,13 +11,13 @@ dependencies:
 - scipy=1.14.0
 - netCDF4=1.6.5
 - cftime=1.6.2
-- xarray=2024.1.1
+- xarray=2025.1.2
 - matplotlib=3.8.2
 - pandas=2.2.2
 - cartopy=0.22.0
 - cython=3.0.2
 - pint=0.24.3
-- dask=2024.1.1
+- dask=2025.2.0
 - numba=0.60.0
 - scikit-learn=1.4.2
 - xesmf=0.8.7
@@ -28,9 +28,9 @@ dependencies:
 #- enso_metrics=3.1.1 Required by pcmdi_metrics, but no support for python>3.10
 #- pcmdi_metrics=3.0.2 Not used by current PODs-implement later
 - h5py=3.9.0
-- intake=0.7.0
+- intake=2.0.8
 - intake-xarray=0.7.0
-- intake-esm=2024.2.6
+- intake-esm=2025.2.3
 - nc-time-axis=1.4.1
 - pyyaml=6.0.1
 - networkx=3.1

--- a/src/conda/env_python3_base_micromamba.yml
+++ b/src/conda/env_python3_base_micromamba.yml
@@ -11,13 +11,13 @@ dependencies:
 - scipy=1.14.0
 - netCDF4=1.6.5
 - cftime=1.6.2
-- xarray=2024.1.1
+- xarray=2025.1.2
 - matplotlib=3.8.2
 - pandas=2.2.2
 - cartopy=0.22.0
 - cython=3.0.2
 - pint=0.24.3
-- dask=2024.1.1
+- dask=2025.2.0
 - numba=0.60.0
 - scikit-learn=1.4.2
 - xesmf=0.8.1
@@ -29,8 +29,8 @@ dependencies:
 #- pcmdi_metrics=3.0.2 Not used by current PODs-implement later
 - h5py=3.9.0
 - intake=0.7.0
-- intake-xarray=0.7.0
-- intake-esm=2024.2.6
+- intake-xarray=2.0.8
+- intake-esm=2025.2.3
 - nc-time-axis=1.4.1
 - pyyaml=6.0.1
 - networkx=3.1

--- a/src/conda/env_python3_base_micromamba.yml
+++ b/src/conda/env_python3_base_micromamba.yml
@@ -28,8 +28,8 @@ dependencies:
 #- enso_metrics=3.1.1 Required by pcmdi_metrics, but no support for python>3.10
 #- pcmdi_metrics=3.0.2 Not used by current PODs-implement later
 - h5py=3.9.0
-- intake=0.7.0
-- intake-xarray=2.0.8
+- intake=2.0.8
+- intake-xarray=0.7.0
 - intake-esm=2025.2.3
 - nc-time-axis=1.4.1
 - pyyaml=6.0.1


### PR DESCRIPTION
**Description**
Bump intake-esm and dependencies to latest versions in conda env files
Add -y flag to conda env create call in conda_env_setup.sh
Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [x] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
