### PR TITLE
fix conditional when resolving cat_subset with multiple var_ids

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -1201,15 +1201,16 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                 # if multiple entries exist, refine with variable_id
                 # this will solve issues where standard_id is not enough to uniquely ID a variable
                 # e.g. for catalogs with variables defined at individual levels
-                if len(cat_subset.df.variable_id) > 1:
+                if len(set(cat_subset.df.variable_id)) > 1:
                     var.log.info(f"Query for case {case_name} variable {var.name} in {data_catalog} returned multiple"
                                  f"entries. Refining query using variable_id")
                     if var.translation is not None:
+                        print(var.translation.name)
                         case_d.query.update({'variable_id': var.translation.name})
                     else:
                         case_d.query.update({'variable_id': var.name})
                     cat_subset = cat.search(**case_d.query)
-                    if len(cat_subset.df.variable_id) > 1:
+                    if len(set(cat_subset.df.variable_id)) > 1:
                         raise util.DataRequestError(
                             f"Unable to find unique entry for {case_d.query['variable_id']}"
                             f" for case {case_name} in {data_catalog}")


### PR DESCRIPTION
**Description**
In a recent PR #764, a check was made to resolve cat_subsets with multiple var_ids for a single variable search. This check needed a set() in the conditional of the logic.

Associated issue # (replace this phrase and parentheses with the issue number)  

**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [ ] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [ ] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [ ] The repository contains no extra test scripts or data files
