### PR TITLE
Integrate MAR notebooks

### DIFF
--- a/data/fieldlist_GFDL.jsonc
+++ b/data/fieldlist_GFDL.jsonc
@@ -135,6 +135,12 @@
       "units": "N m-2",
       "ndim": 3
     },
+    "tos": {
+      "standard_name": "sea_surface_temperature",
+      "realm": "ocean",
+      "units": "degC",
+      "ndim": 3
+    },
     "alb_sfc": {
       "standard_name": "",
       "long_name":"surface albedo",

--- a/diagnostics/mar/SST_bias_NOAA_OISSTv2/SST_bias_NOAA_OISSTv2.html
+++ b/diagnostics/mar/SST_bias_NOAA_OISSTv2/SST_bias_NOAA_OISSTv2.html
@@ -1,25 +1,16 @@
-<title>MDTF example-multicase diagnostic</title>
+<title>Sea Surface Temperature Bias - NOAA OISSTv2</title>
 <img src="../mdtf_diag_banner.png">
-<h3>Multi-Case Example Diagnostic: zonal-average near-surface temperature anomaly</h3>
+<h3>MAR Diagnostic notebook: Sea Surface Temperature Bias - NOAA OISSTv2</h3>
 <p>
-    This POD illustrates how multiple cases (experiments) can be analyzed together.
-    The MDTF-diagnostics framework initializes and processes each case, writes the environment variables for the cases
-    to a yaml file (case_info.yml), and exports an ESM Intake catalog with information about the post-processed
-    data for each ease to the working directory (WORK_DIR). The example_multicase POD driver script reads
-    environment information from case_info.yml into a dictionary that it references to read data from the
-    post-processed files in the data catalog.
-</p>
-<p>
-    The example_multicase POD reads near-surface air temperature (TAS) from netcdf output files for multiple cases.
-    The POD time averages the TAS data and calculates the anomaly relative to the global mean.
-    The anomalies are zonally-averaged and the results from all cases are shown on a single plot.
+    This notebook plots the SST bias of a model simulation vs. climataology derived from NOAA OISSTv2    
+    Authors: Xinru Li and John Krasting
 </p>
 <TABLE>
     <TR>
         <TH align=left style="color:navy;">Time averages
         <TH align=left>Model Results
     <TR>
-        <TH align=left>Zonal-mean near-surface temperature anomalies (K)
+        <TH align=left>SST bias
 </TABLE>
 <!-- update the name of the template to [your_pod_name]_ipynb.html -->
 <TH align=center><A href=SST_bias_NOAA_OISSTv2_ipynb.html>notebook</A>

--- a/diagnostics/mar/SST_bias_NOAA_OISSTv2/SST_bias_NOAA_OISSTv2.html
+++ b/diagnostics/mar/SST_bias_NOAA_OISSTv2/SST_bias_NOAA_OISSTv2.html
@@ -1,0 +1,25 @@
+<title>MDTF example-multicase diagnostic</title>
+<img src="../mdtf_diag_banner.png">
+<h3>Multi-Case Example Diagnostic: zonal-average near-surface temperature anomaly</h3>
+<p>
+    This POD illustrates how multiple cases (experiments) can be analyzed together.
+    The MDTF-diagnostics framework initializes and processes each case, writes the environment variables for the cases
+    to a yaml file (case_info.yml), and exports an ESM Intake catalog with information about the post-processed
+    data for each ease to the working directory (WORK_DIR). The example_multicase POD driver script reads
+    environment information from case_info.yml into a dictionary that it references to read data from the
+    post-processed files in the data catalog.
+</p>
+<p>
+    The example_multicase POD reads near-surface air temperature (TAS) from netcdf output files for multiple cases.
+    The POD time averages the TAS data and calculates the anomaly relative to the global mean.
+    The anomalies are zonally-averaged and the results from all cases are shown on a single plot.
+</p>
+<TABLE>
+    <TR>
+        <TH align=left style="color:navy;">Time averages
+        <TH align=left>Model Results
+    <TR>
+        <TH align=left>Zonal-mean near-surface temperature anomalies (K)
+</TABLE>
+<!-- update the name of the template to [your_pod_name]_ipynb.html -->
+<TH align=center><A href=SST_bias_NOAA_OISSTv2_ipynb.html>notebook</A>

--- a/diagnostics/mar/SST_bias_NOAA_OISSTv2/SST_bias_NOAA_OISSTv2.ipynb
+++ b/diagnostics/mar/SST_bias_NOAA_OISSTv2/SST_bias_NOAA_OISSTv2.ipynb
@@ -252,7 +252,7 @@
    "metadata": {},
    "source": [
     "ds = momgrid.Gridset(filelist, force_symmetric=True, return_corners=True)\n",
-    "model_type = ds.model\n",
+    "model_type = tos_subset.df['source_id'][0] #this will need to be worked through with MAR team\n",
     "ds = ds.data.sel(time=slice(f\"{str(start).zfill(4)}-01-01\",f\"{str(end).zfill(4)}-12-31\"))"
    ],
    "outputs": [],
@@ -289,7 +289,7 @@
    "id": "3f322d2e-1c88-479f-86c7-5910d71cf3f9",
    "metadata": {},
    "source": [
-    "model_type = 'om5'\n",
+    "\n",
     "if \"om4\" in model_type:\n",
     "    dsobs = xr.open_dataset(\"/archive/John.Krasting/NOAA_OISST_v2_annual_mean_1993-2017_OM4.nc\", use_cftime=True)\n",
     "elif \"om5\" in model_type:\n",

--- a/diagnostics/mar/SST_bias_NOAA_OISSTv2/SST_bias_NOAA_OISSTv2.ipynb
+++ b/diagnostics/mar/SST_bias_NOAA_OISSTv2/SST_bias_NOAA_OISSTv2.ipynb
@@ -1,0 +1,1121 @@
+{
+ "cells": [
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "# Sea Surface Temperature Bias - NOAA OISSTv2\n",
+    "\n",
+    "* This notebook plots the SST bias of a model simulation vs. climataology derived from NOAA OISSTv2\n",
+    "* Authors: Xinru Li and John Krasting"
+   ],
+   "id": "8bfb94a9-e573-406d-b140-86af797d9523"
+  },
+  {
+   "cell_type": "code",
+   "id": "50093a3b-2193-4041-8409-de3dc594cf7d",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "# For testing and development purposes, enter a start year, end year, and\n",
+    "# an dora id number to analyze. The value of dora_id can also be a direct\n",
+    "# path to a /pp directory.\n",
+    "\n",
+    "config = {\n",
+    "    \"startyr\": None,\n",
+    "    \"endyr\": None,\n",
+    "    \"dora_id\": \"odiv-413\",\n",
+    "}"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "# Make sure this cell is active so that the workflow and Dora can update\n",
+    "# the config dictionary at runtime.\n",
+    "\n",
+    "#from gfdlnb.tools.update_notebook_config import update_notebook_config\n",
+    "#config = update_notebook_config(config)"
+   ],
+   "id": "9b94e2fadf0ab2c6",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "id": "cae4343a-ced9-41be-9fa6-3a6b42188886",
+   "metadata": {},
+   "source": [
+    "print(str(config))"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74366b78-6b75-4210-9ed3-24cef6af4550",
+   "metadata": {},
+   "source": [
+    "### Import Python Modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "dfcdc828-ad45-4ef0-92bc-05df9c036270",
+   "metadata": {},
+   "source": [
+    "import doralite\n",
+    "import glob\n",
+    "import momlevel\n",
+    "import subprocess\n",
+    "import os\n",
+    "import datetime\n",
+    "\n",
+    "import intake\n",
+    "import numpy as np\n",
+    "import xarray as xr\n",
+    "import matplotlib\n",
+    "import matplotlib.pyplot as plt\n",
+    "matplotlib.use('Agg')  # non-X windows backend\n",
+    "import cartopy.crs as ccrs\n",
+    "\n",
+    "from matplotlib.colors import ListedColormap, BoundaryNorm"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "id": "806241bd-ebea-4640-ab69-cea6edba62de",
+   "metadata": {},
+   "source": [
+    "# momgrid will use a directory of pre-computed weights that is used for calculating basic area-weighted statistics later\n",
+    "import momgrid\n",
+    "os.environ[\"MOMGRID_WEIGHTS_DIR\"] = \"/nbhome/John.Krasting/grid_weights\""
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3ddbddd-eed1-4ac4-9123-6c7df5fcab03",
+   "metadata": {},
+   "source": [
+    "### Definie Local Parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "04229c22-3781-400f-a390-8c5eaaef5189",
+   "metadata": {},
+   "source": [
+    "# Define some local variables. These are taken from the doralite object\n",
+    "# or they can be defined locally\n",
+    "\n",
+    "if config[\"dora_id\"] is not None:\n",
+    "    experiment =  doralite.dora_metadata(config[\"dora_id\"])\n",
+    "    pathPP = experiment[\"pathPP\"]\n",
+    "    expName = experiment[\"expName\"]\n",
+    "else:\n",
+    "    raise ValueError(\"Experiment must be defined\")\n",
+    "\n",
+    "# Define start and end years\n",
+    "try: \n",
+    "    start = os.environ[\"startdate\"]\n",
+    "except KeyError:\n",
+    "    start = config[\"startyr\"]\n",
+    "start = int(start) if start is not None else 1\n",
+    "try:\n",
+    "    end = os.environ[\"enddate\"]\n",
+    "except KeyError:\n",
+    "    end = config[\"endyr\"]\n",
+    "end = int(end) if end is not None else 9999"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8642873-93e4-4e1f-9486-435d6070fc43",
+   "metadata": {},
+   "source": [
+    "### Determine What Files to Load"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "382835f3-a3d7-419f-a92f-e65808230c59",
+   "metadata": {
+    "jupyter": {
+     "is_executing": true
+    }
+   },
+   "source": [
+    "# Determine what files are needed (leave this up to the developer for flexibility)\n",
+    "# This is an example of what someone might do:\n",
+    "frequency = 'mon'\n",
+    "\n",
+    "try:\n",
+    "    #  ^..^\n",
+    "    # /o  o\\   \n",
+    "    # oo--oo~~~\n",
+    "    cat = intake.open_esm_datastore(os.environ['CATALOG_FILE'])\n",
+    "except KeyError:\n",
+    "    print(f\"ERROR: Could not load catalog file {os.environ['CATALOG_FILE']}\")\n",
+    "\n",
+    "tos_subset = cat.search(variable_id='tos', frequency=frequency)\n",
+    "filelist = sorted([path for path in tos_subset.df['path']])\n",
+    "areacello_subset = cat.search(variable_id='areacello', frequency=frequency)\n",
+    "staticfile = sorted([path for path in tos_subset.df['path']])\n",
+    "staticfile = staticfile[0] if staticfile else None\n",
+    "\n",
+    "\n",
+    "# WARNING: LEGACY WAY OF GRABBING FILES\n",
+    "#component = \"ocean_monthly\"\n",
+    "#static = f\"{component}/{component}.static.nc\"\n",
+    "#varname = \"tos\"\n",
+    "\n",
+    "#chunk = \"5yr\"\n",
+    "#filelist = sorted(glob.glob(f\"{pathPP}{component}/ts/**/{chunk}/{component}.*.{varname}.nc\", recursive=True))\n",
+    "\n",
+    "#def is_in_range(file,start,end):\n",
+    "#    start = 1 if start is None else start\n",
+    "#    end = 9999 if end is None else end\n",
+    "#    target = set(list(range(start,end+1)))\n",
+    "#    fname = os.path.basename(file)\n",
+    "#    times = fname.split(\".\")[1]\n",
+    "#    times = times.split(\"-\")\n",
+    "#    times = [int(x[0:4]) for x in times]\n",
+    "#    candidate = set(list(range(times[0],times[1]+1)))\n",
+    "#    return len(candidate.intersection(target)) > 0\n",
+    "\n",
+    "#filelist = [x for x in filelist if is_in_range(x,start,end)]\n",
+    "#staticfile = f\"{pathPP}/{static}\"\n",
+    "\n",
+    "#_ = [print(x) for x in filelist]"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4bfd8545-cb3b-43ee-b1fb-e71a99fe3262",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "stop_here"
+    ]
+   },
+   "source": [
+    "### DMgetting Files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "736dbdaa-f8ed-4ad8-a641-eee616041458",
+   "metadata": {},
+   "source": [
+    "Dora cannot issue calls to dmget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "7096dc5b-559b-4221-a189-0836d77afd12",
+   "metadata": {},
+   "source": [
+    "if not \"DORA_EXECUTE\" in os.environ.keys():\n",
+    "    print(\"Calling dmget on files ...\")\n",
+    "    cmd = [\"dmget\"]+filelist+[staticfile]\n",
+    "    _ = subprocess.check_output(cmd)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b32a4d6d-e5a7-4477-af8f-9e5468e3babc",
+   "metadata": {},
+   "source": [
+    "### Load model data and grid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "70b1b444-20e4-4e63-b8a6-4d076d977eb2",
+   "metadata": {},
+   "source": [
+    "ds = momgrid.Gridset(filelist, force_symmetric=True, return_corners=True)\n",
+    "model_type = ds.model\n",
+    "ds = ds.data.sel(time=slice(f\"{str(start).zfill(4)}-01-01\",f\"{str(end).zfill(4)}-12-31\"))"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "id": "676c8308-6c0b-4448-9335-be668cb99e82",
+   "metadata": {},
+   "source": [
+    "ds"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3281e9a1-7d5d-4b51-afd8-867b973e2e10",
+   "metadata": {},
+   "source": [
+    "### Load observational data (if needed)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1cd28781-a0f9-44b5-9ef7-fc8251601eca",
+   "metadata": {},
+   "source": [
+    "Note that Dora only mounts `/archive`, `/nbhome`, and `/home`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "3f322d2e-1c88-479f-86c7-5910d71cf3f9",
+   "metadata": {},
+   "source": [
+    "model_type = 'om5'\n",
+    "if \"om4\" in model_type:\n",
+    "    dsobs = xr.open_dataset(\"/archive/John.Krasting/NOAA_OISST_v2_annual_mean_1993-2017_OM4.nc\", use_cftime=True)\n",
+    "elif \"om5\" in model_type:\n",
+    "    dsobs = xr.open_dataset(\"/archive/John.Krasting/NOAA_OISST_v2_annual_mean_1993-2017_OM5.nc\", use_cftime=True)\n",
+    "else:\n",
+    "    raise ValueError(f\"Unable to load obs for model type: {model_type}\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20efeacb-e03c-4ddb-8f12-1cb67dee8a4e",
+   "metadata": {},
+   "source": [
+    "### Define some helper function for the plots"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "c4fa45cd-e682-4aac-a98c-a0af350de2a3",
+   "metadata": {},
+   "source": [
+    "def gen_levs_and_cmap(start,end,delta,cmap=\"RdBu_r\"):\n",
+    "    \"\"\"Generates a difference colormap centered on white\"\"\"\n",
+    "    boundaries = np.arange(start,end,delta)\n",
+    "    levels = (boundaries[0:-1] + boundaries[1:]) / 2.\n",
+    "    base_cmap = plt.get_cmap(cmap)\n",
+    "    colors = base_cmap(np.linspace(0, 1, len(levels)))\n",
+    "    colors[[int(len(colors) / 2) - 1]] = [1, 1, 1, 1]\n",
+    "    colors[[int(len(colors) / 2)]] = [1, 1, 1, 1]\n",
+    "    cmap = ListedColormap(colors)\n",
+    "    norm = BoundaryNorm(boundaries, cmap.N, clip=True)\n",
+    "    return (cmap, norm, boundaries)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "id": "294f6a30-47b8-4938-8fa4-f6390e841234",
+   "metadata": {},
+   "source": [
+    "def set_annotaions(ax):\n",
+    "    _ = ax.set_xticks([])\n",
+    "    _ = ax.set_yticks([])\n",
+    "    _ = ax.text(0.0,1.06, \"SST Bias Relative to NOAA OISSTv2 (1993-2017)\", weight=\"bold\", fontsize=12, transform=ax.transAxes)\n",
+    "    _ = ax.text(0.0,1.02, expName, style=\"italic\", fontsize=10, transform=ax.transAxes)\n",
+    "    _ = ax.text(1.0,1.05, str(starttime.values), ha=\"right\", fontsize=8, transform=ax.transAxes)\n",
+    "    _ = ax.text(1.0,1.02, str(endtime.values), ha=\"right\", fontsize=8, transform=ax.transAxes)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "id": "574269bd-afb5-437f-ad30-703b70489d85",
+   "metadata": {},
+   "source": [
+    "def add_stats_box(ax, stats_str, x=0.015, y=0.8):\n",
+    "        # Adding the text box annotation\n",
+    "    props = dict(\n",
+    "        boxstyle=\"round,pad=0.3\", edgecolor=\"black\", linewidth=1.5, facecolor=\"white\"\n",
+    "    )\n",
+    "    ax.text(\n",
+    "        x,\n",
+    "        y,\n",
+    "        stats_str,\n",
+    "        transform=ax.transAxes,\n",
+    "        fontsize=8,\n",
+    "        verticalalignment=\"top\",\n",
+    "        bbox=props,\n",
+    "    )"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "id": "80be5109-0e21-450c-827f-2bed52263b00",
+   "metadata": {},
+   "source": [
+    "def calculate_stats(model,obs,areacello):\n",
+    "    diff = model - obs\n",
+    "    stats = {}\n",
+    "    stats[\"min\"] = float(diff.min())\n",
+    "    stats[\"max\"] = float(diff.max())\n",
+    "    stats = {**stats, **momgrid.xr_stats.xr_stats_2d(model,obs,ds.areacello,fmt=\"dict\")}\n",
+    "    # Limit to 4 significant digits\n",
+    "    stats = {k:f\"{v:.4g}\" for k,v in stats.items()}\n",
+    "    # Stats string\n",
+    "    stats_str = str(\"\\n\").join([f\"{k} = {v}\" for k,v in stats.items()])\n",
+    "    return (stats, stats_str)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "id": "aadf7139-8861-4a4a-8a2a-1a6c6244cc37",
+   "metadata": {},
+   "source": [
+    "def add_colorbar(fig, cb, boundaries):\n",
+    "    cbar_ax = fig.add_axes([0.16, 0.06, 0.7, 0.03])\n",
+    "    fig.colorbar(\n",
+    "        cb, cax=cbar_ax, orientation=\"horizontal\", extend=\"both\", ticks=boundaries[::4]\n",
+    "    )"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "id": "64a9c87a-dc17-4c3c-ba71-db76f86dad3e",
+   "metadata": {},
+   "source": [
+    "momlevel.util.annual_average(ds)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9fb9c99-0918-484c-9bf8-3d32d7afc082",
+   "metadata": {},
+   "source": [
+    "### Perform some calculations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "0f1309d7-1411-47ce-9aa0-440c4ece8724",
+   "metadata": {},
+   "source": [
+    "# Time-average the model data\n",
+    "model = ds.tos\n",
+    "starttime = model.time[0]\n",
+    "endtime = model.time[-1]\n",
+    "model = momlevel.util.annual_average(model).mean(\"time\", keep_attrs=True).load()\n",
+    "\n",
+    "# Obs data is already a climatology\n",
+    "obs = dsobs.tos"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6bd979de-61bb-449e-b447-9e959e640406",
+   "metadata": {},
+   "source": [
+    "### Establish a Dictionary to Store Scalar Metrics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "c885c9d6-b164-47b8-a473-f9f6851795db",
+   "metadata": {},
+   "source": [
+    "stats_dict = {}\n",
+    "stats_dict[\"metadata\"] = {\n",
+    "    \"expName\": str(expName),\n",
+    "    \"created\": datetime.datetime.now().isoformat(),\n",
+    "    \"starttime\": str(starttime.values),\n",
+    "    \"endtime\": str(endtime.values),\n",
+    "}\n",
+    "stats_dict[\"results\"] = {}\n",
+    "stats_dict"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "id": "77df75fe-0b2a-4659-aff8-f23708e1003d",
+   "metadata": {},
+   "source": [
+    "%matplotlib inline\n",
+    "# Setup plot\n",
+    "fig = plt.figure(figsize=(10,6))\n",
+    "ax = plt.subplot(1,1,1, facecolor=\"lightgray\")\n",
+    "\n",
+    "# Definie geolon and geolat for plotting (use corners!)\n",
+    "x = ds.geolon_c\n",
+    "y = ds.geolat_c\n",
+    "\n",
+    "# Get colormap\n",
+    "cmap, norm, boundaries = gen_levs_and_cmap(-4.5,4.75,0.25)\n",
+    "\n",
+    "# Run pcolormesh\n",
+    "cb = plt.pcolormesh(x,y,model-obs, cmap=cmap, norm=norm)\n",
+    "\n",
+    "# Clean up figure and add labels\n",
+    "set_annotaions(ax)\n",
+    "\n",
+    "# Add statistics\n",
+    "stats, stats_str = calculate_stats(model, obs, ds.areacello)\n",
+    "add_stats_box(ax, stats_str)\n",
+    "\n",
+    "# Add colorbar\n",
+    "add_colorbar(fig, cb, boundaries)\n",
+    "\n",
+    "plt.show()\n",
+    "\n",
+    "# Save stats\n",
+    "stats_dict[\"results\"][\"global\"] = stats"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e066754-54b0-4613-be89-364bc4421788",
+   "metadata": {},
+   "source": [
+    "### Arctic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "814e39fe-6b31-4051-9aae-9b44862c89fa",
+   "metadata": {},
+   "source": [
+    "xrange = (-298,61)\n",
+    "yrange = (60.,91.)\n",
+    "\n",
+    "_model = momgrid.geoslice.geoslice(model,x=xrange,y=yrange)\n",
+    "_obs = momgrid.geoslice.geoslice(obs,x=xrange,y=yrange)\n",
+    "\n",
+    "xq = list((_model.xh.values - 0.5).astype(int))\n",
+    "yq = list((_model.yh.values - 0.5).astype(int))\n",
+    "\n",
+    "xq = xq + [xq[-1] + 1]\n",
+    "yq = yq + [yq[-1] + 1]\n",
+    "\n",
+    "x = ds.geolon_c.values[yq,:][:,xq]\n",
+    "y = ds.geolat_c.values[yq,:][:,xq]\n",
+    "\n",
+    "# Get colormap\n",
+    "cmap, norm, boundaries = gen_levs_and_cmap(-2.0,2.125,0.125)\n",
+    "\n",
+    "fig = plt.figure(figsize=(6,6))\n",
+    "ax = plt.subplot(1,1,1, facecolor=\"lightgray\", projection=ccrs.NorthPolarStereo())\n",
+    "cb = ax.pcolormesh(x,y,_model-_obs,transform=ccrs.PlateCarree(), cmap=cmap, norm=norm)\n",
+    "ax.coastlines()\n",
+    "\n",
+    "# Clean up figure and add labels\n",
+    "set_annotaions(ax)\n",
+    "\n",
+    "# Add statistics\n",
+    "stats, stats_str = calculate_stats(_model, _obs, _model.areacello)\n",
+    "add_stats_box(ax, stats_str, x=0.05, y=0.95)\n",
+    "\n",
+    "# Add colorbar\n",
+    "add_colorbar(fig, cb, boundaries)\n",
+    "\n",
+    "# Save stats\n",
+    "stats_dict[\"results\"][\"Arctic\"] = stats"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f2efece-1333-4c0c-be5e-25ce18b8b67b",
+   "metadata": {},
+   "source": [
+    "### Southern Ocean"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "469f1fe1-d810-49e9-8e55-32fcabe11ff6",
+   "metadata": {},
+   "source": [
+    "xrange = (-300,60)\n",
+    "yrange = (-60.,-91.)\n",
+    "\n",
+    "_model = momgrid.geoslice.geoslice(model,x=xrange,y=yrange)\n",
+    "_obs = momgrid.geoslice.geoslice(obs,x=xrange,y=yrange)\n",
+    "\n",
+    "xq = list((_model.xh.values - 0.5).astype(int))\n",
+    "yq = list((_model.yh.values - 0.5).astype(int))\n",
+    "\n",
+    "xq = xq + [xq[-1] + 1]\n",
+    "yq = yq + [yq[-1] + 1]\n",
+    "\n",
+    "x = ds.geolon_c.values[yq,:][:,xq]\n",
+    "y = ds.geolat_c.values[yq,:][:,xq]\n",
+    "\n",
+    "# Get colormap\n",
+    "cmap, norm, boundaries = gen_levs_and_cmap(-2.0,2.125,0.125)\n",
+    "\n",
+    "fig = plt.figure(figsize=(6,6))\n",
+    "ax = plt.subplot(1,1,1, facecolor=\"lightgray\", projection=ccrs.SouthPolarStereo())\n",
+    "cb = ax.pcolormesh(x,y,_model-_obs,transform=ccrs.PlateCarree(), cmap=cmap, norm=norm)\n",
+    "ax.coastlines()\n",
+    "\n",
+    "# Clean up figure and add labels\n",
+    "set_annotaions(ax)\n",
+    "\n",
+    "# Add statistics\n",
+    "stats, stats_str = calculate_stats(_model, _obs, _model.areacello)\n",
+    "add_stats_box(ax, stats_str, x=0.5, y=0.7)\n",
+    "\n",
+    "# Add colorbar\n",
+    "add_colorbar(fig, cb, boundaries)\n",
+    "\n",
+    "# Save stats\n",
+    "stats_dict[\"results\"][\"southern_ocean\"] = stats"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee350a69-9515-4eb9-a3f3-d1c4461457e2",
+   "metadata": {},
+   "source": [
+    "### Northwest Pacific"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "02cbd719-18c5-4f3e-a16c-46ac751d9c5f",
+   "metadata": {},
+   "source": [
+    "xrange = (-250.,-150.)\n",
+    "yrange = (25.,60.)\n",
+    "\n",
+    "_model = momgrid.geoslice.geoslice(model,x=xrange,y=yrange)\n",
+    "_obs = momgrid.geoslice.geoslice(obs,x=xrange,y=yrange)\n",
+    "\n",
+    "xq = list((_model.xh.values - 0.5).astype(int))\n",
+    "yq = list((_model.yh.values - 0.5).astype(int))\n",
+    "\n",
+    "xq = xq + [xq[-1] + 1]\n",
+    "yq = yq + [yq[-1] + 1]\n",
+    "\n",
+    "x = ds.geolon_c.values[yq,:][:,xq]\n",
+    "y = ds.geolat_c.values[yq,:][:,xq]\n",
+    "\n",
+    "# Get colormap\n",
+    "cmap, norm, boundaries = gen_levs_and_cmap(-4.5,4.75,0.25)\n",
+    "\n",
+    "fig = plt.figure(figsize=(10,4))\n",
+    "ax = plt.subplot(1,1,1, facecolor=\"lightgray\", projection=ccrs.Miller(central_longitude=-200))\n",
+    "cb = ax.pcolormesh(x,y,_model-_obs,transform=ccrs.PlateCarree(), cmap=cmap, norm=norm)\n",
+    "ax.coastlines()\n",
+    "\n",
+    "# Clean up figure and add labels\n",
+    "set_annotaions(ax)\n",
+    "\n",
+    "# Add statistics\n",
+    "stats, stats_str = calculate_stats(_model, _obs, _model.areacello)\n",
+    "add_stats_box(ax, stats_str)\n",
+    "\n",
+    "# Add colorbar\n",
+    "add_colorbar(fig, cb, boundaries)\n",
+    "\n",
+    "# Save stats\n",
+    "stats_dict[\"results\"][\"Northest_Pacific\"] = stats"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79f0ad60-e903-461b-9f05-02a1bf0ebb74",
+   "metadata": {},
+   "source": [
+    "### Tropical and Subtropical Indo-Pacific"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "a8e06a2f-51af-4145-a473-c7e8e5820e2d",
+   "metadata": {},
+   "source": [
+    "xrange = (-280.,-80.)\n",
+    "yrange = (-23.,23.)\n",
+    "\n",
+    "_model = momgrid.geoslice.geoslice(model,x=xrange,y=yrange)\n",
+    "_obs = momgrid.geoslice.geoslice(obs,x=xrange,y=yrange)\n",
+    "\n",
+    "xq = list((_model.xh.values - 0.5).astype(int))\n",
+    "yq = list((_model.yh.values - 0.5).astype(int))\n",
+    "\n",
+    "xq = xq + [xq[-1] + 1]\n",
+    "yq = yq + [yq[-1] + 1]\n",
+    "\n",
+    "x = ds.geolon_c.values[yq,:][:,xq]\n",
+    "y = ds.geolat_c.values[yq,:][:,xq]\n",
+    "\n",
+    "# Get colormap\n",
+    "cmap, norm, boundaries = gen_levs_and_cmap(-4.5,4.75,0.25)\n",
+    "\n",
+    "fig = plt.figure(figsize=(10,4))\n",
+    "ax = plt.subplot(1,1,1, facecolor=\"lightgray\", projection=ccrs.Miller(central_longitude=-180))\n",
+    "cb = ax.pcolormesh(x,y,_model-_obs,transform=ccrs.PlateCarree(), cmap=cmap, norm=norm)\n",
+    "ax.coastlines()\n",
+    "\n",
+    "# Clean up figure and add labels\n",
+    "set_annotaions(ax)\n",
+    "\n",
+    "# Add statistics\n",
+    "stats, stats_str = calculate_stats(_model, _obs, _model.areacello)\n",
+    "add_stats_box(ax, stats_str, x=0.005, y=0.98)\n",
+    "\n",
+    "# Add colorbar\n",
+    "add_colorbar(fig, cb, boundaries)\n",
+    "\n",
+    "# Save stats\n",
+    "stats_dict[\"results\"][\"TropicalSubtropical_IndoPacific\"] = stats"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df86db64-3d9e-4464-a1f5-c3723b7ce570",
+   "metadata": {},
+   "source": [
+    "### South Indo-Pacific"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "750e8a23-a0c6-48bf-b769-812577a966b9",
+   "metadata": {},
+   "source": [
+    "xrange = (-300.,-170.)\n",
+    "yrange = (-25.,-60.)\n",
+    "\n",
+    "_model = momgrid.geoslice.geoslice(model,x=xrange,y=yrange)\n",
+    "_obs = momgrid.geoslice.geoslice(obs,x=xrange,y=yrange)\n",
+    "\n",
+    "xq = list((_model.xh.values - 0.5).astype(int))\n",
+    "yq = list((_model.yh.values - 0.5).astype(int))\n",
+    "\n",
+    "xq = xq + [xq[-1] + 1]\n",
+    "yq = yq + [yq[-1] + 1]\n",
+    "\n",
+    "x = ds.geolon_c.values[yq,:][:,xq]\n",
+    "y = ds.geolat_c.values[yq,:][:,xq]\n",
+    "\n",
+    "# Get colormap\n",
+    "cmap, norm, boundaries = gen_levs_and_cmap(-4.5,4.75,0.25)\n",
+    "\n",
+    "fig = plt.figure(figsize=(10,4))\n",
+    "ax = plt.subplot(1,1,1, facecolor=\"lightgray\", projection=ccrs.Miller(central_longitude=-180))\n",
+    "cb = ax.pcolormesh(x,y,_model-_obs,transform=ccrs.PlateCarree(), cmap=cmap, norm=norm)\n",
+    "ax.coastlines()\n",
+    "\n",
+    "# Clean up figure and add labels\n",
+    "set_annotaions(ax)\n",
+    "\n",
+    "# Add statistics\n",
+    "stats, stats_str = calculate_stats(_model, _obs, _model.areacello)\n",
+    "add_stats_box(ax, stats_str, x=0.005, y=0.98)\n",
+    "\n",
+    "# Add colorbar\n",
+    "add_colorbar(fig, cb, boundaries)\n",
+    "\n",
+    "# Save stats\n",
+    "stats_dict[\"results\"][\"south_indo_pacific\"] = stats"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "daf93db4-09ad-4ba2-84e5-2197005ac7b9",
+   "metadata": {},
+   "source": [
+    "### North Atlantic "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "6ce86514-5edc-4ff8-b8e6-c99420ff82ce",
+   "metadata": {},
+   "source": [
+    "xrange = (-80.,-0.)\n",
+    "yrange = (30.,60.)\n",
+    "\n",
+    "_model = momgrid.geoslice.geoslice(model,x=xrange,y=yrange)\n",
+    "_obs = momgrid.geoslice.geoslice(obs,x=xrange,y=yrange)\n",
+    "\n",
+    "xq = list((_model.xh.values - 0.5).astype(int))\n",
+    "yq = list((_model.yh.values - 0.5).astype(int))\n",
+    "\n",
+    "xq = xq + [xq[-1] + 1]\n",
+    "yq = yq + [yq[-1] + 1]\n",
+    "\n",
+    "x = ds.geolon_c.values[yq,:][:,xq]\n",
+    "y = ds.geolat_c.values[yq,:][:,xq]\n",
+    "\n",
+    "# Get colormap\n",
+    "cmap, norm, boundaries = gen_levs_and_cmap(-4.5,4.75,0.25)\n",
+    "\n",
+    "fig = plt.figure(figsize=(10,4))\n",
+    "ax = plt.subplot(1,1,1, facecolor=\"lightgray\", projection=ccrs.Miller(central_longitude=-60))\n",
+    "cb = ax.pcolormesh(x,y,_model-_obs,transform=ccrs.PlateCarree(), cmap=cmap, norm=norm)\n",
+    "ax.coastlines()\n",
+    "\n",
+    "# Clean up figure and add labels\n",
+    "set_annotaions(ax)\n",
+    "\n",
+    "# Add statistics\n",
+    "stats, stats_str = calculate_stats(_model, _obs, _model.areacello)\n",
+    "add_stats_box(ax, stats_str, x=0.05, y=0.9)\n",
+    "\n",
+    "# Add colorbar\n",
+    "add_colorbar(fig, cb, boundaries)\n",
+    "\n",
+    "# Save stats\n",
+    "stats_dict[\"results\"][\"North_Atlantic\"] = stats"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3fbb3b4c-f204-4c95-98e1-3e64104d20ff",
+   "metadata": {},
+   "source": [
+    "### South Atlantic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "8f9c0386-8f20-4911-931f-db8a14e0ad84",
+   "metadata": {},
+   "source": [
+    "xrange = (-75.,25.)\n",
+    "yrange = (-20.,-60.)\n",
+    "\n",
+    "_model = momgrid.geoslice.geoslice(model,x=xrange,y=yrange)\n",
+    "_obs = momgrid.geoslice.geoslice(obs,x=xrange,y=yrange)\n",
+    "\n",
+    "xq = list((_model.xh.values - 0.5).astype(int))\n",
+    "yq = list((_model.yh.values - 0.5).astype(int))\n",
+    "\n",
+    "xq = xq + [xq[-1] + 1]\n",
+    "yq = yq + [yq[-1] + 1]\n",
+    "\n",
+    "x = ds.geolon_c.values[yq,:][:,xq]\n",
+    "y = ds.geolat_c.values[yq,:][:,xq]\n",
+    "\n",
+    "# Get colormap\n",
+    "cmap, norm, boundaries = gen_levs_and_cmap(-4.5,4.75,0.25)\n",
+    "\n",
+    "fig = plt.figure(figsize=(10,4))\n",
+    "ax = plt.subplot(1,1,1, facecolor=\"lightgray\", projection=ccrs.Miller(central_longitude=-25))\n",
+    "cb = ax.pcolormesh(x,y,_model-_obs,transform=ccrs.PlateCarree(), cmap=cmap, norm=norm)\n",
+    "ax.coastlines()\n",
+    "\n",
+    "# Clean up figure and add labels\n",
+    "set_annotaions(ax)\n",
+    "\n",
+    "# Add statistics\n",
+    "stats, stats_str = calculate_stats(_model, _obs, _model.areacello)\n",
+    "add_stats_box(ax, stats_str, x=0.05, y=0.98)\n",
+    "\n",
+    "# Add colorbar\n",
+    "add_colorbar(fig, cb, boundaries)\n",
+    "\n",
+    "# Save stats\n",
+    "stats_dict[\"results\"][\"South_Atlantic\"] = stats"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3501515f-15c5-4b03-9590-b099ca7b95da",
+   "metadata": {},
+   "source": [
+    "### California Current"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "4aad3d3e-c52b-4d56-ace7-76c85ce9d608",
+   "metadata": {},
+   "source": [
+    "xrange = (-130.,-100.)\n",
+    "yrange = (18.,46.)\n",
+    "\n",
+    "_model = momgrid.geoslice.geoslice(model,x=xrange,y=yrange)\n",
+    "_obs = momgrid.geoslice.geoslice(obs,x=xrange,y=yrange)\n",
+    "\n",
+    "xq = list((_model.xh.values - 0.5).astype(int))\n",
+    "yq = list((_model.yh.values - 0.5).astype(int))\n",
+    "\n",
+    "xq = xq + [xq[-1] + 1]\n",
+    "yq = yq + [yq[-1] + 1]\n",
+    "\n",
+    "x = ds.geolon_c.values[yq,:][:,xq]\n",
+    "y = ds.geolat_c.values[yq,:][:,xq]\n",
+    "\n",
+    "# Get colormap\n",
+    "cmap, norm, boundaries = gen_levs_and_cmap(-4.5,4.75,0.25)\n",
+    "\n",
+    "fig = plt.figure(figsize=(10,4))\n",
+    "ax = plt.subplot(1,1,1, facecolor=\"lightgray\", projection=ccrs.Miller(central_longitude=-115))\n",
+    "cb = ax.pcolormesh(x,y,_model-_obs,transform=ccrs.PlateCarree(), cmap=cmap, norm=norm)\n",
+    "ax.coastlines()\n",
+    "\n",
+    "# Clean up figure and add labels\n",
+    "set_annotaions(ax)\n",
+    "\n",
+    "# Add statistics\n",
+    "stats, stats_str = calculate_stats(_model, _obs, _model.areacello)\n",
+    "add_stats_box(ax, stats_str, x=0.5, y=0.9)\n",
+    "\n",
+    "# Add colorbar\n",
+    "add_colorbar(fig, cb, boundaries)\n",
+    "\n",
+    "# Save stats\n",
+    "stats_dict[\"results\"][\"California_Current\"] = stats"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1c98a01-4071-4f0a-92b8-fee62ca566ea",
+   "metadata": {},
+   "source": [
+    "### Bengula Current"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "3a601a43-f29e-4e1e-8f4f-6e688c4b8422",
+   "metadata": {},
+   "source": [
+    "xrange = (-10.,20.)\n",
+    "yrange = (35.,-30.)\n",
+    "\n",
+    "_model = momgrid.geoslice.geoslice(model,x=xrange,y=yrange)\n",
+    "_obs = momgrid.geoslice.geoslice(obs,x=xrange,y=yrange)\n",
+    "\n",
+    "xq = list((_model.xh.values - 0.5).astype(int))\n",
+    "yq = list((_model.yh.values - 0.5).astype(int))\n",
+    "\n",
+    "xq = xq + [xq[-1] + 1]\n",
+    "yq = yq + [yq[-1] + 1]\n",
+    "\n",
+    "x = ds.geolon_c.values[yq,:][:,xq]\n",
+    "y = ds.geolat_c.values[yq,:][:,xq]\n",
+    "\n",
+    "# Get colormap\n",
+    "cmap, norm, boundaries = gen_levs_and_cmap(-4.5,4.75,0.25)\n",
+    "\n",
+    "fig = plt.figure(figsize=(10,4))\n",
+    "ax = plt.subplot(1,1,1, facecolor=\"lightgray\", projection=ccrs.Miller(central_longitude=5))\n",
+    "cb = ax.pcolormesh(x,y,_model-_obs,transform=ccrs.PlateCarree(), cmap=cmap, norm=norm)\n",
+    "ax.coastlines()\n",
+    "\n",
+    "# Clean up figure and add labels\n",
+    "set_annotaions(ax)\n",
+    "\n",
+    "# Add statistics\n",
+    "stats, stats_str = calculate_stats(_model, _obs, _model.areacello)\n",
+    "add_stats_box(ax, stats_str, x=0.2, y=0.9)\n",
+    "\n",
+    "# Add colorbar\n",
+    "add_colorbar(fig, cb, boundaries)\n",
+    "\n",
+    "# Save stats\n",
+    "stats_dict[\"results\"][\"Bengula_Current\"] = stats"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88e12bf1-ae52-44ea-9292-991223e32be6",
+   "metadata": {},
+   "source": [
+    "### Off the west coast of South America"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "210068ed-75a7-45c0-8125-f891d77a23f7",
+   "metadata": {},
+   "source": [
+    "xrange = (-110.,-60.)\n",
+    "yrange = (0.,-40.)\n",
+    "\n",
+    "_model = momgrid.geoslice.geoslice(model,x=xrange,y=yrange)\n",
+    "_obs = momgrid.geoslice.geoslice(obs,x=xrange,y=yrange)\n",
+    "\n",
+    "xq = list((_model.xh.values - 0.5).astype(int))\n",
+    "yq = list((_model.yh.values - 0.5).astype(int))\n",
+    "\n",
+    "xq = xq + [xq[-1] + 1]\n",
+    "yq = yq + [yq[-1] + 1]\n",
+    "\n",
+    "x = ds.geolon_c.values[yq,:][:,xq]\n",
+    "y = ds.geolat_c.values[yq,:][:,xq]\n",
+    "\n",
+    "# Get colormap\n",
+    "cmap, norm, boundaries = gen_levs_and_cmap(-4.5,4.75,0.25)\n",
+    "\n",
+    "fig = plt.figure(figsize=(10,4))\n",
+    "ax = plt.subplot(1,1,1, facecolor=\"lightgray\", projection=ccrs.Miller(central_longitude=-85))\n",
+    "cb = ax.pcolormesh(x,y,_model-_obs,transform=ccrs.PlateCarree(), cmap=cmap, norm=norm)\n",
+    "ax.coastlines()\n",
+    "\n",
+    "# Clean up figure and add labels\n",
+    "set_annotaions(ax)\n",
+    "\n",
+    "# Add statistics\n",
+    "stats, stats_str = calculate_stats(_model, _obs, _model.areacello)\n",
+    "add_stats_box(ax, stats_str, x=0.7, y=0.98)\n",
+    "\n",
+    "# Add colorbar\n",
+    "add_colorbar(fig, cb, boundaries)\n",
+    "\n",
+    "# Save stats\n",
+    "stats_dict[\"results\"][\"offthe_WestCoastSouthAmerica\"] = stats"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bcbf6a10-8c18-42e9-9e36-fbd8f8b63828",
+   "metadata": {},
+   "source": [
+    "### Carribbean region"
+   ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "xrange = (-90.,-60.)\n",
+    "yrange = (5.,30.)\n",
+    "\n",
+    "_model = momgrid.geoslice.geoslice(model,x=xrange,y=yrange)\n",
+    "_obs = momgrid.geoslice.geoslice(obs,x=xrange,y=yrange)\n",
+    "\n",
+    "xq = list((_model.xh.values - 0.5).astype(int))\n",
+    "yq = list((_model.yh.values - 0.5).astype(int))\n",
+    "\n",
+    "xq = xq + [xq[-1] + 1]\n",
+    "yq = yq + [yq[-1] + 1]\n",
+    "\n",
+    "x = ds.geolon_c.values[yq,:][:,xq]\n",
+    "y = ds.geolat_c.values[yq,:][:,xq]\n",
+    "\n",
+    "# Get colormap\n",
+    "cmap, norm, boundaries = gen_levs_and_cmap(-4.5,4.75,0.25)\n",
+    "\n",
+    "fig = plt.figure(figsize=(10,4))\n",
+    "ax = plt.subplot(1,1,1, facecolor=\"lightgray\", projection=ccrs.Miller(central_longitude=-60))\n",
+    "cb = ax.pcolormesh(x,y,_model-_obs,transform=ccrs.PlateCarree(), cmap=cmap, norm=norm)\n",
+    "ax.coastlines()\n",
+    "\n",
+    "# Clean up figure and add labels\n",
+    "set_annotaions(ax)\n",
+    "\n",
+    "# Add statistics\n",
+    "stats, stats_str = calculate_stats(_model, _obs, _model.areacello)\n",
+    "add_stats_box(ax, stats_str, x=0.65, y=0.21)\n",
+    "\n",
+    "# Add colorbar\n",
+    "add_colorbar(fig, cb, boundaries)\n",
+    "\n",
+    "# Save stats\n",
+    "stats_dict[\"results\"][\"Carribbean\"] = stats"
+   ],
+   "id": "4ace0276-687d-45af-9dea-bc266f31f0a8",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6d78292-72df-488d-a638-0628000cc7d3",
+   "metadata": {},
+   "source": [
+    "### Write Stats to a File"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "53578224-09ad-4f27-b203-e2464682ff4f",
+   "metadata": {},
+   "source": [
+    "if not \"DORA_EXECUTE\" in os.environ.keys():\n",
+    "    import yaml\n",
+    "    yml = yaml.dump(stats_dict)\n",
+    "    with open('oisst_stats.yaml', 'w') as file:\n",
+    "        file.write(yml)\n",
+    "    file.close()\n",
+    "    print(yml)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/diagnostics/mar/SST_bias_NOAA_OISSTv2/settings.jsonc
+++ b/diagnostics/mar/SST_bias_NOAA_OISSTv2/settings.jsonc
@@ -1,10 +1,10 @@
 {
   "settings" : {
     "driver" : "SST_bias_NOAA_OISSTv2.ipynb",
-    "long_name" : "Example diagnostic",
+    "long_name" : "Sea Surface Temperature Bias - NOAA OISSTv2",
     "convention": "gfdl",
     "mar": true,
-    "description" : "Example diagnostic",
+    "description" : "This notebook plots the SST bias of a model simulation vs. climataology derived from NOAA OISSTv2",
     "runtime_requirements": {
         "python3": ["matplotlib", "xarray", "netCDF4"]
     }

--- a/diagnostics/mar/SST_bias_NOAA_OISSTv2/settings.jsonc
+++ b/diagnostics/mar/SST_bias_NOAA_OISSTv2/settings.jsonc
@@ -1,0 +1,43 @@
+{
+  "settings" : {
+    "driver" : "SST_bias_NOAA_OISSTv2.ipynb",
+    "long_name" : "Example diagnostic",
+    "convention": "gfdl",
+    "mar": true,
+    "description" : "Example diagnostic",
+    "runtime_requirements": {
+        "python3": ["matplotlib", "xarray", "netCDF4"]
+    }
+  },
+
+  "dimensions": {
+     "yh": {
+             "standard_name": "latitude",
+             "units": "degrees_north",
+             "axis": "Y"
+           },
+    "xh": {
+             "standard_name": "longitude",
+             "units": "degrees_east",
+             "axis": "X"
+           },
+    "time": {"standard_name": "time"}
+  },
+
+  "varlist" : {
+    "tos": {
+      "standard_name" : "sea_surface_temperature",
+      "realm": "ocean",
+      "units": "degC",
+      "frequency" : "mon",
+      "dimensions": ["time", "yh", "xh"]
+    },
+    "areacello": {
+      "standard_name": "cell_area",
+      "dimensions": ["yh", "xh"],
+      "realm": "ocean",
+      "units": "m2",
+      "requirement": "optional"
+    }
+  }
+}

--- a/src/data_sources.py
+++ b/src/data_sources.py
@@ -70,17 +70,16 @@ class DataSourceBase(util.MDTFObjectBase, util.CaseLoggerMixin):
         self.date_range = util.DateRange(start=startdate, end=enddate)
 
     def set_query(self, var: varlist_util.VarlistEntry, path_regex: str):
-        if self.query['frequency'] == '':
-            if var.is_static:
-                freq = "fx"
-            else:
-                freq = var.T.frequency
+        if var.is_static:
+            freq = "fx"
+        else:
+            freq = var.T.frequency
 
-            if not isinstance(freq, str):
-                freq = freq.format_local()
-            if freq == 'hr':
-                freq = '1hr'
-            self.query['frequency'] = freq
+        if not isinstance(freq, str):
+            freq = freq.format_local()
+        if freq == 'hr':
+            freq = '1hr'
+        self.query['frequency'] = freq
 
         var_id = var.name
         standard_name = var.standard_name
@@ -160,6 +159,10 @@ class GFDLDataSource(DataSourceBase):
 
     def set_query(self, var: varlist_util.VarlistEntry, path_regex: str):
         super().set_query(var, path_regex)
+        # this might need updating; currently, static files have the variable_id 'fixed' for GFDL catalogs
+        if var.is_static:
+            self.query['variable_id'] = 'fixed'
+            self.query.pop('standard_name')
         # this is hacky, but prevents the framework from grabbing from ice_1x1deg
         if self.query['realm'] == 'seaIce*':
             self.query['realm'] = 'ice'

--- a/src/environment_manager.py
+++ b/src/environment_manager.py
@@ -361,6 +361,7 @@ class SubprocessRuntimePODWrapper:
         self.pod.pod_env_vars["case_env_file"] = out_file
         case_info = dict()
         case_info['CATALOG_FILE'] = catalog_file
+        self.pod.pod_env_vars['CATALOG_FILE'] = catalog_file
         case_info['CASE_LIST'] = dict()
         assert os.path.isfile(case_info['CATALOG_FILE']), 'CATALOG_FILE json not found in WORK_DIR'
         for case_name, case in case_list.items():
@@ -553,7 +554,7 @@ class SubprocessRuntimeManager(AbstractRuntimeManager):
         return subprocess.Popen(
             commands,
             shell=True, executable=self.bash_exec,
-            env=env_vars, cwd=p.pod.paths.POD_WORK_DIR,
+            env=env_vars.copy(), cwd=p.pod.paths.POD_WORK_DIR,
             stdout=p.pod.log_file, stderr=p.pod.log_file,
             universal_newlines=True, bufsize=1
         )

--- a/src/environment_manager.py
+++ b/src/environment_manager.py
@@ -12,6 +12,7 @@ import typing
 import subprocess
 from src import util
 import yaml
+import shutil
 
 import logging
 _log = logging.getLogger(__name__)
@@ -405,10 +406,14 @@ class SubprocessRuntimePODWrapper:
     def run_commands(self):
         """Produces the shell command(s) to run the POD.
         """
-        output_name = self.pod.driver.rstrip(".ipynb") + "_ipynb"
         if self.pod.program == 'jupyter':
+            output_name = os.path.basename(self.pod.driver).rstrip(".ipynb")+"_ipynb"
+            # I am really not a fan of this, but nbconvert does not have good output functions.
+            # This means that I need to copy over the notebook and run it from the wkdir
+            driver_copy = os.path.join(self.pod.pod_env_vars['WORK_DIR'], os.path.basename(self.pod.driver))
+            shutil.copy(self.pod.driver, driver_copy)
             return [f"/usr/bin/env {self.pod.program} nbconvert --to html" +\
-                    f" --output-dir='{self.pod.pod_env_vars['WORK_DIR']}' --output {output_name} --execute {self.pod.driver}"]
+                    f" --output-dir {self.pod.pod_env_vars['WORK_DIR']} --output {output_name} --execute {driver_copy}"]
         else:
             return [f"/usr/bin/env {self.pod.program} {self.pod.driver}"]
 

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -1158,6 +1158,7 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                              data_catalog,
                              var.name,
                              case_name)
+                print(case_d.query)
                 cat_subset = cat.search(**case_d.query)
                 if cat_subset.df.empty:
                     # check whether there is an alternate variable to substitute
@@ -1269,6 +1270,16 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                         else:
                             var_xr = xr.concat([var_xr, cat_subset_dict.values[cat_index]], var.N.name)
                 var_xr = self.drop_attributes(var_xr)
+                # grab only the requested static variable
+                if var.is_static:
+                    del_list = []
+                    for vname in var_xr.variables:
+                        if vname != var.name:
+                            del_list.append(vname)
+                    for del_name in del_list:
+                        del var_xr[del_name]
+                            
+                print(var_xr)
                 # add standard_name to the variable xarray dataset if it is not defined
                 for vname in var_xr.variables:
                     if (not isinstance(var_xr.variables[vname], xr.IndexVariable)

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -1158,7 +1158,6 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                              data_catalog,
                              var.name,
                              case_name)
-                print(case_d.query)
                 cat_subset = cat.search(**case_d.query)
                 if cat_subset.df.empty:
                     # check whether there is an alternate variable to substitute
@@ -1278,8 +1277,6 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                             del_list.append(vname)
                     for del_name in del_list:
                         del var_xr[del_name]
-                            
-                print(var_xr)
                 # add standard_name to the variable xarray dataset if it is not defined
                 for vname in var_xr.variables:
                     if (not isinstance(var_xr.variables[vname], xr.IndexVariable)

--- a/src/util/path_utils.py
+++ b/src/util/path_utils.py
@@ -101,8 +101,11 @@ class PodPathManager(PathManagerBase):
                  new_work_dir: bool = True):
 
         super().__init__(config, env, unittest, new_work_dir)
-
+        
         self.POD_CODE_DIR = os.path.join(self.CODE_ROOT, 'diagnostics', pod_name)
+        if not os.path.exists(self.POD_CODE_DIR):
+            self.POD_CODE_DIR = os.path.join(self.CODE_ROOT, 'diagnostics', 'mar',  pod_name)
+            
         self.POD_WORK_DIR = os.path.join(self.WORK_DIR, pod_name)
         self.POD_OUTPUT_DIR = os.path.join(self.OUTPUT_DIR, pod_name)
         if any(self.OBS_DATA_ROOT):


### PR DESCRIPTION
### **Description**
This PR contains multiple changes to the framework to allow MAR notebooks to be integrated into the framework. This also includes instruction as to how to integrate a MAR notebook for future reference.

**How To MARxMDTF**
This is very similar to the normal way of integrating PODs. The first thing to note is the new dir structure introduced.
Making a tree from the code_root dir for the implementation of the SST_bias_NOAA_OISSTv2 MAR notebook:
```
mdtf/
└── MDTF-diagnostics/
    └── diagnostics/
        └── mar/
            └── SST_bias_NOAA_OISSTv2/
                ├── settings.jsonc
                ├── SST_bias_NOAA_OISSTv2.html
                └── SST_bias_NOAA_OISSTv2.ipynb
```
As you can see, this is all very standard practice for the MDTF. The only main difference is that the actual 'pod' is found inside of a further directory: `mar`. A directory named `mar` has been made inside of the `diagnostics` directory. This was done in order to help isolate the mar notebooks and make it easier for them to be synced with what is found in the [MAR github repo](https://github.com/jkrasting/mar/tree/main). Syncing the notebooks will eventually be handled by a script found in the `mar` dir much like how we handle the CMIP CVs. It is important to note that the directory name that houses the notebook must be the same as the notebook minus `.ipynb`. This will allow for the syncing to work in the future. Onto the files within, the easiest one is the notebook itself `SST_bias_NOAA_OISSTv2.ipynb`. Not much trouble putting that into the dir! Now in order for the framework to launch the notebook, one must supply a settings.jsonc file.

In this file, it is important to note the field: `"driver" : "SST_bias_NOAA_OISSTv2.ipynb",`. This key and value pair are important as it tells the framework what notebook will actually need to be launched. It is case sensitive! We most also let the framework know that this is a MAR notebook. This can be done with `"mar": true,`.  Since MAR is made at the GFDL, it is also a good idea to supply `"convention": "gfdl",` as well. This is also where the variables that are used are defined. An example of an item in `varlist` can be seen as:
```
"tos": {
      "standard_name" : "sea_surface_temperature",
      "realm": "ocean",
      "units": "degC",
      "frequency" : "mon",
      "dimensions": ["time", "yh", "xh"]
},
```
Now, we need to make sure that this variable can actually be found in the MDTF fieldlist. This was done by adding the `tos` var into the [GFDL fieldlist](https://github.com/NOAA-GFDL/MDTF-diagnostics/blob/main/data/fieldlist_GFDL.jsonc) with the addition: 
```
"tos": {
  "standard_name": "sea_surface_temperature",
  "realm": "ocean",
  "units": "degC",
  "ndim": 3
},
```
The last thing that is required is to supply the output html template. For this case, I copied over the [example_notebook output template](https://github.com/NOAA-GFDL/MDTF-diagnostics/blob/main/diagnostics/example_notebook/example_notebook.html). The only edit required to grab the notebook is changing:
`<TH align=center><A href=example_notebook_ipynb.html>notebook</A>`
to:
`<TH align=center><A href=SST_bias_NOAA_OISSTv2_ipynb.html>notebook</A>`
But in order to actually merge into the MDTF, we would prefer a real description!

Now, we should look internally into the notebook to get a sense of what information is passed on from the framework to the subprocess (the notebook). The most important change was the implementation of the catalog. The MDTF does some processing on the datasets to make sure it fits a standardized format. After these edits are completed, new .nc files are created and listed in a catalog. This catalog can be found in the `MDTF_output.v#` folder with the name `MDTF_postprocessed_data.json`. In order to prevent the onus of pathing to the catalog from being on the POD dev, we supply the absolute path as an environment variable. It can be accessed with `os.environment["CATALOG_FILE"]`. As I understand it, catalogs are yet to be introduced into MAR. That being said, now could be a great opportunity to standardize this practice between both the MDTF and MAR! Here is the block of code that utilizes this env var:
```
# This is an example of what someone might do:
frequency = 'mon'

try:
    #  ^..^
    # /o  o\   
    # oo--oo~~~
    cat = intake.open_esm_datastore(os.environ['CATALOG_FILE'])
except KeyError:
    print(f"ERROR: Could not load catalog file {os.environ['CATALOG_FILE']}")

tos_subset = cat.search(variable_id='tos', frequency=frequency)
filelist = sorted([path for path in tos_subset.df['path']])
areacello_subset = cat.search(variable_id='areacello', frequency=frequency)
staticfile = sorted([path for path in tos_subset.df['path']])
staticfile = staticfile[0] if staticfile else None

```
This is a very simple implementation and would likely not fit your exact situation, but I hope it serves as a good starting point! Instead of just grabbing the path, it is generally seen as best practice to instead do this (as grabbed from [example_notebook](https://github.com/NOAA-GFDL/MDTF-diagnostics/blob/main/diagnostics/example_notebook/example_notebook.ipynb)):
```
# open the csv file using information provided by the catalog definition file
cat = intake.open_esm_datastore(cat_def_file)
tas_subset = cat.search(variable_id=tas_var, frequency="day")
# convert tas_subset catalog to an xarray dataset dict
tas_dict = tas_subset.to_dataset_dict(
    progressbar=False,
    aggregate=False,
    xarray_open_kwargs={"decode_times": True, "use_cftime": True}
)
```
 Some other env_vars that were found to be needed were `os.environ["startdate"]` and `os.environ["enddate"]`.

Congrats! You should now be the proud owner of a MAR notebook that the MDTF can launch! 

As this may be one of the last PRs that I write for this project, I just wanted to extend great wishes to everyone involved with the MDTF. I wish only the best for this group and future members! This has been an amazing experience for me being able to contribute to a great collaboration and mission! Thank you to all involved. I would also love to give a shout out to @wrongkindofdoctor for having to deal with my PRs for the past year!

Associated issue #778 

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
