### PR TITLE
Debug xr parser

### DIFF
--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -1546,10 +1546,10 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
 
         # assign lat/lon coordinate standard_name if not defined or incorrect
         for v in var_ds.variables:
-            if 'lat' in v.lower() and 'lat' not in var_ds[v].standard_name.lower():
-                var_ds[v]['standard_name'] = var.Y.standard_name
-            elif 'lon' in v.lower() and 'lon' not in var_ds[v].standard_name.lower():
-                var_ds[v]['standard_name'] = var.X.standard_name
+            if 'lat' in v.lower() and 'lat' not in var_ds[v].attrs['standard_name'].lower():
+                var_ds[v].attrs['standard_name'] = var.Y.standard_name
+            elif 'lon' in v.lower() and 'lon' not in var_ds[v].attrs['standard_name'].lower():
+                var_ds[v].attrs['standard_name'] = var.X.standard_name
 
         # The following block is retained for time comparison with dask delayed write procedure
         # var_ds.to_netcdf(

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -1544,6 +1544,12 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
                         v_dataset = ds[v].to_dataset()
                         var_ds = xr.merge([var_ds, v_dataset])
 
+        # assign lat/lon coordinate standard_name if not defined or incorrect
+        for v in var_ds.variables:
+            if 'lat' in v.lower() and 'lat' not in var_ds[v].standard_name.lower():
+                var_ds[v]['standard_name'] = var.Y.standard_name
+            elif 'lon' in v.lower() and 'lon' not in var_ds[v].standard_name.lower():
+                var_ds[v]['standard_name'] = var.X.standard_name
 
         # The following block is retained for time comparison with dask delayed write procedure
         # var_ds.to_netcdf(

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -891,7 +891,6 @@ class MDTFPreprocessorBase(metaclass=util.MDTFABCMeta):
         return pd.DataFrame.from_dict(group_df).reset_index()
 
     def crop_date_range(self, case_date_range: util.DateRange, xr_ds, time_coord) -> xr.Dataset:
-        xr_ds = self.drop_attributes(xr_ds)
         xr_ds = xr.decode_cf(xr_ds,
                              decode_coords=True,  # parse coords attr
                              decode_times=True,

--- a/src/units.py
+++ b/src/units.py
@@ -205,24 +205,10 @@ def convert_dataarray(ds, da_name: str, src_unit=None, dest_unit=None, log=_log)
                         da = dset
                         da_name = var
                         break
-    # try to find approximate matches to input name in standard_name and long_name attributes
     if da is None:
-        da_name_words = re.split('[-, _:;]', da_name)
-        for var in merged:
-            dset = ds.get(var)
-            for attr in search_attrs:
-                att_value = dset.attrs.get(attr, None)
-                if isinstance(att_value, str):
-                    att_words = re.split('[-, _:;]', att_value)
-                    name_matches = list(set(da_name_words) & set(att_words))
-                    if len(name_matches) >= min(len(da_name_words), len(att_words)):
-                        log.info("Found approximate match for %s in dataset %s attribute %s",
-                                 da_name, attr, att_value)
-                        da = dset
-                        da_name = var
-                        break
-    if da is None:
-        raise ValueError(f"convert_dataarray: '{da_name}' not found in dataset.")
+        log.warning(f"units.convert_dataarray: standard_name attribute '{da_name}' not found in dataset. "
+                    f"Skipping the unit conversion for the variable/coordinate associated with {da_name}")
+        return ds
     if src_unit is None:
         try:
             src_unit = da.attrs['units']

--- a/src/xr_parser.py
+++ b/src/xr_parser.py
@@ -630,7 +630,7 @@ class DefaultDatasetParser:
 
     def restore_vars_backup(self, ds, drop_vars: list):
         for var in drop_vars:
-            ds[var] = self.vars_backup.get(var, dict())
+            ds[var] = self.vars_backup.get(var, list())
     def normalize_standard_name(self, new_attr_d, attr_d):
         """Method for munging standard_name attribute prior to parsing.
         """


### PR DESCRIPTION
**Description**
Include a summary of the change, and link the associated issue (if applicable).  
List any dependencies that are required for this change, including libraries and variables,  
and their metadata (units, frequencies, etc...). Be sure to separate PRs and issues for new PODs and PODs currently under development.

Associated issue # (replace this phrase and parentheses with the issue number)  
#753 
**How Has This Been Tested?**
Please describe the tests that you ran to verify your changes in enough detail that  
someone can reproduce them. Include any relevant details for your test configuration  
such as the Python version, package versions, expected POD wallclock time, and the   
operating system(s) you ran your tests on.

**Checklist:**
- [x] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [x] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [ ] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [ ] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [ ] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [ ] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [ ] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [ ] I have provided the code to generate digested data files from raw data files
- [ ] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [ ] I have included copies of the figures generated by the POD in the pull request
- [x] The repository contains no extra test scripts or data files
