### PR TITLE
Fix bug where conda_env_root gets set to conda_root

### DIFF
--- a/src/environment_manager.py
+++ b/src/environment_manager.py
@@ -171,9 +171,6 @@ class CondaEnvironmentManager(AbstractEnvironmentManager):
             self.log.log.warning("Conda env directory '%s' not found; creating.",
                              self.conda_env_root)
             os.makedirs(self.conda_env_root)  # recursive mkdir if needed
-        else:
-            # only true in default anaconda install, may need to fix
-            self.conda_env_root = os.path.join(self.conda_root, 'envs')
 
     def create_environment(self, env_name):
         # check to see if conda env exists, and if not, try to create it


### PR DESCRIPTION
**Description**
Remove code that sets conda_env_root to conda_root. This causes issues when conda environments are not installed in the same root as conda. This prevented MDTF from finding the python environments when run on the PSL conda build.

Associated issue # N/A  

**How Has This Been Tested?**
This has been tested on two systems:
-Conda installed in /opt, but conda envs installed in /home/username. This fix prevents the /home/username path from getting overwritten. Launch MDTF framework with example_multicase diagnostic, and make sure the correct _MDTF_python3_base gets activated for the diagnostic.
-Conda installed in /home/username and envs installed in /home/username. No change, because conda_env_root was overwritten with the same path. Launch MDTF framework with example_multicase diagnostic, and make sure the correct _MDTF_python3_base gets activated for the diagnostic.


**Checklist:**
- [X] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [N/A] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [N/A] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [N/A] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [N/A] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [N/A] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [X] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [N/A] I have provided the code to generate digested data files from raw data files
- [N/A] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [N/A] I have included copies of the figures generated by the POD in the pull request
- [X] The repository contains no extra test scripts or data files
