### PR TITLE
Prevent pip from installing numpy>2.0

### DIFF
--- a/src/conda/env_python3_base.yml
+++ b/src/conda/env_python3_base.yml
@@ -7,7 +7,6 @@ dependencies:
 # see https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/pkg-specs.
 
 - python=3.12
-- numpy=1.26.4
 - scipy=1.14.0
 - netCDF4=1.6.5
 - cftime=1.6.2
@@ -42,6 +41,7 @@ dependencies:
 - momlevel=1.0.1
 - pip=23.3.1
 - pip:
+    - numpy==1.26.4
     - falwa==2.0.0
     - cmocean
     - regionmask


### PR DESCRIPTION
**Description**
The install of the _MDTF_python3_base environment is grabbing numpy>2.0 due to requirements in the pip dependencies. This overwrites the numpy=1.26.4 setting in env_python3_base.yml. This causes the framework to crash because other packages are compiled against numpy 1.X, and this is incompatible with version 2.X. Moving the numpy=1.26.4 requirement in env_python3_base.yml to the pip section prevents pip from installing numpy>2. This fix shouldn't create any package versioning issues because it just makes sure the intended numpy version gets installed.

Associated issue # N/A

**How Has This Been Tested?**
This can be tested by running a fresh install of MDTF with no conda environments. Run the src/conda/conda_env_setup.sh install script. Then, configure templates/runtime_config.jsonc to run the example_multicase diagnostic. Before this fix, example_multicase will fail due to the mismatched numpy versions. With this fix, only numpy=1.26.4 should be installed, and the diagnostic will run without issue.

**Checklist:**
- [X] My branch is up-to-date with the NOAA-GFDL main branch, and all merge conflicts are resolved
- [N/A] The scripts are written in Python 3.12 or above (preferred; required if funded by a CPO grant), NCL, or R
- [N/A] All of my scripts are in the diagnostics/[POD short name] subdirectory, and include a main_driver script, template html, and settings.jsonc file
- [N/A] I have made corresponding changes to the documentation in the POD's doc/ subdirectory
- [N/A] I have requested that the framework developers add packages required by my POD to the python3, NCL, or R environment yaml file if necessary, and my environment builds with `conda_env_setup.sh` 
- [N/A] I have added any necessary data to input_data/obs_data/[pod short name] and/or input_data/model/[pod short name]
- [X] My code is portable; it uses [MDTF environment variables](https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx/ref_envvars.html), and does not contain hard-coded file or directory paths
- [N/A] I have provided the code to generate digested data files from raw data files
- [N/A] Each digested data file generated by the script contains numerical data (no figures), and is 3 GB or less in size
- [N/A] I have included copies of the figures generated by the POD in the pull request
- [X] The repository contains no extra test scripts or data files
